### PR TITLE
fix: treat constant_alpha=False as opt-out (closes #3)

### DIFF
--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -229,7 +229,7 @@ class MultiHeadYatAttention(Layer):
         self.kernel_initializer = initializers.get(kernel_initializer)
 
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -131,7 +131,7 @@ class YatConv1D(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -541,7 +541,7 @@ class YatConv2D(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True
         self.use_bias = use_bias
@@ -920,7 +920,7 @@ class YatConv3D(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True
         self.use_bias = use_bias
@@ -1282,7 +1282,7 @@ class YatConvTranspose1D(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True
         self.use_bias = use_bias
@@ -1630,7 +1630,7 @@ class YatConvTranspose2D(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True
         self.use_bias = use_bias
@@ -1948,7 +1948,7 @@ class YatConvTranspose3D(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True
         self.use_bias = use_bias

--- a/src/nmn/keras/embed.py
+++ b/src/nmn/keras/embed.py
@@ -56,7 +56,7 @@ class YatEmbed(Layer):
         self.embedding_initializer = initializers.get(embedding_initializer)
 
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -79,7 +79,7 @@ class YatNMN(Layer):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -87,7 +87,7 @@ class YatNMN(Layer):
 
         # Handle alpha configuration
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -260,7 +260,7 @@ class MultiHeadAttention(Module):
         # Alpha
         _constant_alpha_value = None
         alpha_val = None
-        if self.constant_alpha is not None:
+        if self.constant_alpha is not None and self.constant_alpha is not False:
             if self.constant_alpha is True:
                 _constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -69,7 +69,7 @@ class YatConv1D(Module):
         
         kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
         
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
         elif self.use_bias:
             bias = self.param('bias', self.bias_init, (self.features,), self.param_dtype)
@@ -214,7 +214,7 @@ class YatConv2D(Module):
         
         kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
         
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
         elif self.use_bias:
             bias = self.param('bias', self.bias_init, (self.features,), self.param_dtype)
@@ -359,7 +359,7 @@ class YatConv3D(Module):
         
         kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
         
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
         elif self.use_bias:
             bias = self.param('bias', self.bias_init, (self.features,), self.param_dtype)
@@ -498,7 +498,7 @@ class YatConvTranspose1D(Module):
 
         kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
 
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
         elif self.use_bias:
             bias = self.param('bias', self.bias_init, (self.features,), self.param_dtype)
@@ -627,7 +627,7 @@ class YatConvTranspose2D(Module):
 
         kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
 
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
         elif self.use_bias:
             bias = self.param('bias', self.bias_init, (self.features,), self.param_dtype)
@@ -756,7 +756,7 @@ class YatConvTranspose3D(Module):
 
         kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
 
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
         elif self.use_bias:
             bias = self.param('bias', self.bias_init, (self.features,), self.param_dtype)

--- a/src/nmn/linen/embed.py
+++ b/src/nmn/linen/embed.py
@@ -101,7 +101,7 @@ class YatEmbed(Module):
 
         # Alpha configuration
         _constant_alpha_value = None
-        if self.constant_alpha is not None:
+        if self.constant_alpha is not None and self.constant_alpha is not False:
             if self.constant_alpha is True:
                 _constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -89,7 +89,7 @@ class YatNMN(Module):
 
         # Handle alpha configuration
         _constant_alpha_value = None
-        if self.constant_alpha is not None:
+        if self.constant_alpha is not None and self.constant_alpha is not False:
             if self.constant_alpha is True:
                 _constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:
@@ -106,7 +106,7 @@ class YatNMN(Module):
             alpha = None
 
         # Bias: learnable, constant, or none
-        if self.constant_bias is not None:
+        if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full(
                 (self.features,), float(self.constant_bias), dtype=self.param_dtype
             )

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -224,7 +224,7 @@ class MultiHeadAttention(Module):
         #   4. use_alpha=False -> no alpha scaling
         self.alpha: nnx.Param[Array] | None
         
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             # Use constant alpha (no learnable parameter)
             if constant_alpha is True:
                 self._constant_alpha_value = float(DEFAULT_CONSTANT_ALPHA)

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -482,7 +482,7 @@ class RotaryYatAttention(Module):
         # Handle alpha configuration (same logic as MultiHeadAttention)
         self.alpha: nnx.Param[Array] | None
         
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             # Use constant alpha (no learnable parameter)
             if constant_alpha is True:
                 self._constant_alpha_value = float(DEFAULT_CONSTANT_ALPHA)

--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -229,7 +229,7 @@ class YatConv(Module):
 
         self.bias: nnx.Param[jax.Array] | None
         self._constant_bias_value: tp.Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             self.bias = None
             use_bias = True  # Bias is applied (but constant)
@@ -244,7 +244,7 @@ class YatConv(Module):
         self.alpha: nnx.Param[jax.Array] | None
         self._constant_alpha_value: tp.Optional[float] = None
 
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = float(DEFAULT_CONSTANT_ALPHA)
             else:

--- a/src/nmn/nnx/layers/conv/yat_conv_transpose.py
+++ b/src/nmn/nnx/layers/conv/yat_conv_transpose.py
@@ -178,7 +178,7 @@ class YatConvTranspose(Module):
 
         self.bias: nnx.Param | None
         self._constant_bias_value: tp.Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             self.bias = None
             use_bias = True  # Bias is applied (but constant)
@@ -199,7 +199,7 @@ class YatConvTranspose(Module):
         self.alpha: nnx.Param[jax.Array] | None
         self._constant_alpha_value: tp.Optional[float] = None
 
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = float(DEFAULT_CONSTANT_ALPHA)
             else:

--- a/src/nmn/nnx/layers/embed.py
+++ b/src/nmn/nnx/layers/embed.py
@@ -116,7 +116,7 @@ class Embed(Module):
     # Priority: constant_alpha > use_alpha
     self.alpha: nnx.Param[jax.Array] | None
     
-    if constant_alpha is not None:
+    if constant_alpha is not None and constant_alpha is not False:
       # Use constant alpha (no learnable parameter)
       if constant_alpha is True:
         self._constant_alpha_value = self.DEFAULT_CONSTANT_ALPHA

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -70,7 +70,9 @@ class YatNMN(Module):
       Ignored when constant_bias is set or use_bias=False.
     use_alpha: whether to use alpha scaling (default: True). Ignored if constant_alpha is set.
     constant_alpha: if True, use sqrt(2) as constant alpha. If a float, use that value.
-      If None (default), use learnable alpha when use_alpha=True.
+      If None (default) or False, use learnable alpha when use_alpha=True.
+      Note: False is treated as None — pass a float (e.g. 0.0) to actually freeze
+      alpha at a numeric value.
     use_dropconnect: whether to use DropConnect (default: False).
     dtype: the dtype of the computation (default: infer from input and params).
     param_dtype: the dtype passed to parameter initializers (default: float32).
@@ -201,7 +203,7 @@ class YatNMN(Module):
       self.kernel = nnx.Param(kernel_val)
     self.bias: nnx.Param[jax.Array] | None
     self._constant_bias_value: tp.Optional[float] = None
-    if constant_bias is not None:
+    if constant_bias is not None and constant_bias is not False:
       self._constant_bias_value = float(constant_bias)
       self.bias = None
       use_bias = True  # Bias is applied (but constant)
@@ -223,7 +225,7 @@ class YatNMN(Module):
     
     self.alpha: nnx.Param[jax.Array] | None
     
-    if constant_alpha is not None:
+    if constant_alpha is not None and constant_alpha is not False:
       # Use constant alpha (no learnable parameter)
       if constant_alpha is True:
         self._constant_alpha_value = self.DEFAULT_CONSTANT_ALPHA

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -257,7 +257,7 @@ class MultiHeadYatAttention(tf.Module):
 
         # Alpha configuration
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -57,7 +57,7 @@ class YatConv1D(tf.Module):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -273,7 +273,7 @@ class YatConv2D(tf.Module):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -488,7 +488,7 @@ class YatConv3D(tf.Module):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -694,7 +694,7 @@ class YatConvTranspose1D(tf.Module):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -895,7 +895,7 @@ class YatConvTranspose2D(tf.Module):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -1084,7 +1084,7 @@ class YatConvTranspose3D(tf.Module):
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias

--- a/src/nmn/tf/embed.py
+++ b/src/nmn/tf/embed.py
@@ -69,7 +69,7 @@ class YatEmbed(tf.Module):
 
         # Alpha configuration
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -85,7 +85,7 @@ class YatNMN(tf.Module):
 
         # Handle bias configuration: learnable, constant, or none
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             use_bias = True  # Bias is applied (but constant)
         self.use_bias = use_bias
@@ -93,7 +93,7 @@ class YatNMN(tf.Module):
 
         # Handle alpha configuration
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/attention/multi_head.py
+++ b/src/nmn/torch/attention/multi_head.py
@@ -127,7 +127,7 @@ class MultiHeadYatAttention(nn.Module):
         # Alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/embed.py
+++ b/src/nmn/torch/embed.py
@@ -85,7 +85,7 @@ class YatEmbed(nn.Module):
 
         # Alpha configuration
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -101,7 +101,7 @@ class YatConv1D(Conv1d):
 
         # Constant bias handling
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             bias = True
         self.constant_bias = constant_bias
@@ -176,7 +176,7 @@ class YatConv1D(Conv1d):
         # Handle alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -112,7 +112,7 @@ class YatConv2D(Conv2d):
 
         # Constant bias handling
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             bias = True  # Bias is applied (but constant)
         self.constant_bias = constant_bias
@@ -188,7 +188,7 @@ class YatConv2D(Conv2d):
         # Handle alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -98,7 +98,7 @@ class YatConv3D(Conv3d):
 
         # Constant bias handling
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             bias = True
         self.constant_bias = constant_bias
@@ -173,7 +173,7 @@ class YatConv3D(Conv3d):
         # Handle alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/layers/yat_conv_transpose1d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose1d.py
@@ -80,7 +80,7 @@ class YatConvTranspose1D(ConvTranspose1d):
 
         # Constant bias handling
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             bias = True
         self.constant_bias = constant_bias
@@ -114,7 +114,7 @@ class YatConvTranspose1D(ConvTranspose1d):
         # Handle alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/layers/yat_conv_transpose2d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose2d.py
@@ -80,7 +80,7 @@ class YatConvTranspose2D(ConvTranspose2d):
 
         # Constant bias handling
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             bias = True
         self.constant_bias = constant_bias
@@ -114,7 +114,7 @@ class YatConvTranspose2D(ConvTranspose2d):
         # Handle alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/layers/yat_conv_transpose3d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose3d.py
@@ -80,7 +80,7 @@ class YatConvTranspose3D(ConvTranspose3d):
 
         # Constant bias handling
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             bias = True
         self.constant_bias = constant_bias
@@ -114,7 +114,7 @@ class YatConvTranspose3D(ConvTranspose3d):
         # Handle alpha configuration
         # Priority: constant_alpha > use_alpha
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             if constant_alpha is True:
                 self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -173,7 +173,7 @@ class YatNMN(nn.Module):
         #   3. alpha=True (default) -> learnable alpha parameter
         #   4. alpha=False -> no alpha scaling
         self._constant_alpha_value = None
-        if constant_alpha is not None:
+        if constant_alpha is not None and constant_alpha is not False:
             # Use constant alpha (no learnable parameter)
             if constant_alpha is True:
                 self._constant_alpha_value = self.DEFAULT_CONSTANT_ALPHA
@@ -193,7 +193,7 @@ class YatNMN(nn.Module):
 
         # Bias parameter (learnable, constant, or none)
         self._constant_bias_value: Optional[float] = None
-        if constant_bias is not None:
+        if constant_bias is not None and constant_bias is not False:
             self._constant_bias_value = float(constant_bias)
             self.register_parameter('bias', None)
             bias = True  # Bias is applied (but constant)

--- a/tests/test_keras/test_constant_alpha_false.py
+++ b/tests/test_keras/test_constant_alpha_false.py
@@ -1,0 +1,44 @@
+"""Regression tests for issue #3 (Keras backend): ``constant_alpha=False``
+and ``constant_bias=False`` must not be silently coerced to ``0.0``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+keras = pytest.importorskip("keras")
+import numpy as np
+
+from nmn.keras import YatNMN
+
+
+def _new_layer(**kwargs):
+    base = dict(units=16)
+    base.update(kwargs)
+    return YatNMN(**base)
+
+
+class TestConstantAlphaFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(use_alpha=True, constant_alpha=False)
+        layer.build((None, 8))
+        assert getattr(layer, "_constant_alpha_value", None) is None
+
+    def test_false_does_not_zero_output(self) -> None:
+        rng = np.random.default_rng(0)
+        layer = _new_layer(use_alpha=True, constant_alpha=False)
+        x = keras.ops.convert_to_tensor(rng.standard_normal((4, 8)).astype("float32"))
+        y = layer(x)
+        y_np = keras.ops.convert_to_numpy(y)
+        assert np.isfinite(y_np).all()
+        assert float(np.linalg.norm(y_np)) > 0.0, (
+            "output collapsed to zero — constant_alpha=False silently coerced "
+            "to 0.0 (issue #3 regression)"
+        )
+
+
+class TestConstantBiasFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(use_bias=True, constant_bias=False)
+        layer.build((None, 8))
+        assert getattr(layer, "_constant_bias_value", None) is None

--- a/tests/test_linen/test_constant_alpha_false.py
+++ b/tests/test_linen/test_constant_alpha_false.py
@@ -1,0 +1,53 @@
+"""Regression tests for issue #3 (Flax Linen backend): ``constant_alpha=False``
+and ``constant_bias=False`` must not be silently coerced to ``0.0``.
+
+Linen uses dataclass field access (``self.constant_alpha``) rather than a
+local variable, which is why the initial sweep missed it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("flax")
+
+import jax
+import jax.numpy as jnp
+import flax.linen as nn
+
+from nmn.linen import YatNMN
+
+
+class TestConstantAlphaFalseTrap:
+    def test_false_does_not_zero_output(self) -> None:
+        model = YatNMN(features=16, use_alpha=True, constant_alpha=False)
+        key = jax.random.key(0)
+        x = jax.random.normal(jax.random.key(1), (4, 8))
+        params = model.init(key, x)
+        y = model.apply(params, x)
+        assert jnp.isfinite(y).all()
+        assert float(jnp.linalg.norm(y)) > 0.0, (
+            "output collapsed to zero — constant_alpha=False silently coerced "
+            "to 0.0 (issue #3 regression)"
+        )
+
+    def test_false_keeps_learnable_alpha(self) -> None:
+        model = YatNMN(features=16, use_alpha=True, constant_alpha=False)
+        key = jax.random.key(0)
+        x = jnp.ones((4, 8))
+        params = model.init(key, x)
+        # Learnable alpha is registered as a param with key 'alpha'
+        flat = jax.tree_util.tree_leaves_with_path(params)
+        keys = {"/".join(str(k).strip("'") for k in path) for path, _ in flat}
+        assert any("alpha" in k for k in keys), f"alpha param missing: {keys}"
+
+
+class TestConstantBiasFalseTrap:
+    def test_false_does_not_zero_output(self) -> None:
+        model = YatNMN(features=16, use_bias=True, constant_bias=False)
+        key = jax.random.key(0)
+        x = jax.random.normal(jax.random.key(1), (4, 8))
+        params = model.init(key, x)
+        y = model.apply(params, x)
+        assert jnp.isfinite(y).all()
+        assert float(jnp.linalg.norm(y)) > 0.0

--- a/tests/test_nnx/test_constant_alpha_false.py
+++ b/tests/test_nnx/test_constant_alpha_false.py
@@ -1,0 +1,84 @@
+"""Regression tests for issue #3: ``constant_alpha=False`` (and
+``constant_bias=False``) must not be silently coerced to ``0.0``.
+
+False should be treated equivalently to None — i.e., the user is opting out
+of the constant path and asking for the default (learnable α when
+``use_alpha=True``; no bias when ``use_bias`` is also False; etc.).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+pytest.importorskip("flax")
+
+from flax import nnx
+
+from nmn.nnx.layers import YatNMN
+
+
+def _new_layer(**kwargs):
+    base = dict(in_features=8, out_features=16, rngs=nnx.Rngs(0))
+    base.update(kwargs)
+    return YatNMN(**base)
+
+
+class TestConstantAlphaFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer_false = _new_layer(use_alpha=True, constant_alpha=False)
+        layer_none = _new_layer(use_alpha=True, constant_alpha=None)
+        assert layer_false._constant_alpha_value is None
+        assert layer_none._constant_alpha_value is None
+
+    def test_false_keeps_learnable_alpha(self) -> None:
+        layer = _new_layer(use_alpha=True, constant_alpha=False)
+        assert layer.alpha is not None, "alpha should be a learnable Param"
+        params = nnx.state(layer, nnx.Param)
+        leaves = jax.tree_util.tree_leaves(params)
+        assert leaves, "expected at least one learnable Param"
+
+    def test_false_does_not_zero_output(self) -> None:
+        layer = _new_layer(use_alpha=True, constant_alpha=False)
+        x = jax.random.normal(jax.random.key(0), (4, 8))
+        y = layer(x)
+        assert jnp.isfinite(y).all(), "non-finite output"
+        assert float(jnp.linalg.norm(y)) > 0.0, (
+            "output collapsed to zero — constant_alpha=False was silently "
+            "coerced to 0.0 (issue #3 regression)"
+        )
+
+    def test_zero_float_is_still_respected(self) -> None:
+        """Numeric 0.0 is a legitimate user choice — keep the explicit value."""
+        layer = _new_layer(use_alpha=True, constant_alpha=0.0)
+        assert layer._constant_alpha_value == 0.0
+        assert layer.alpha is None
+
+    def test_true_uses_default_constant(self) -> None:
+        layer = _new_layer(use_alpha=True, constant_alpha=True)
+        assert layer._constant_alpha_value == pytest.approx(
+            YatNMN.DEFAULT_CONSTANT_ALPHA
+        )
+        assert layer.alpha is None
+
+    def test_float_is_used_verbatim(self) -> None:
+        layer = _new_layer(use_alpha=True, constant_alpha=1.5)
+        assert layer._constant_alpha_value == pytest.approx(1.5)
+        assert layer.alpha is None
+
+
+class TestConstantBiasFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(use_bias=False, constant_bias=False)
+        assert layer._constant_bias_value is None
+
+    def test_false_with_use_bias_true_keeps_learnable_bias(self) -> None:
+        layer = _new_layer(use_bias=True, constant_bias=False)
+        assert layer._constant_bias_value is None
+        assert layer.bias is not None
+
+    def test_zero_float_is_still_respected(self) -> None:
+        layer = _new_layer(use_bias=True, constant_bias=0.0)
+        assert layer._constant_bias_value == 0.0
+        assert layer.bias is None

--- a/tests/test_tf/test_constant_alpha_false.py
+++ b/tests/test_tf/test_constant_alpha_false.py
@@ -1,0 +1,43 @@
+"""Regression tests for issue #3 (TensorFlow backend): ``constant_alpha=False``
+and ``constant_bias=False`` must not be silently coerced to ``0.0``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+import numpy as np
+
+from nmn.tf import YatNMN
+
+
+def _new_layer(**kwargs):
+    base = dict(features=16)
+    base.update(kwargs)
+    return YatNMN(**base)
+
+
+class TestConstantAlphaFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(use_alpha=True, constant_alpha=False)
+        layer.build((None, 8))
+        assert getattr(layer, "_constant_alpha_value", None) is None
+
+    def test_false_does_not_zero_output(self) -> None:
+        rng = np.random.default_rng(0)
+        layer = _new_layer(use_alpha=True, constant_alpha=False)
+        x = tf.convert_to_tensor(rng.standard_normal((4, 8)).astype("float32"))
+        y = layer(x).numpy()
+        assert np.isfinite(y).all()
+        assert float(np.linalg.norm(y)) > 0.0, (
+            "output collapsed to zero — constant_alpha=False silently coerced "
+            "to 0.0 (issue #3 regression)"
+        )
+
+
+class TestConstantBiasFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(use_bias=True, constant_bias=False)
+        layer.build((None, 8))
+        assert getattr(layer, "_constant_bias_value", None) is None

--- a/tests/test_torch/test_constant_alpha_false.py
+++ b/tests/test_torch/test_constant_alpha_false.py
@@ -1,0 +1,51 @@
+"""Regression tests for issue #3 (PyTorch backend): ``constant_alpha=False``
+and ``constant_bias=False`` must not be silently coerced to ``0.0``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from nmn.torch import YatNMN
+
+
+def _new_layer(**kwargs):
+    base = dict(in_features=8, out_features=16)
+    base.update(kwargs)
+    return YatNMN(**base)
+
+
+class TestConstantAlphaFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(alpha=True, constant_alpha=False)
+        assert getattr(layer, "_constant_alpha_value", None) is None
+
+    def test_false_keeps_learnable_alpha(self) -> None:
+        layer = _new_layer(alpha=True, constant_alpha=False)
+        alpha = getattr(layer, "alpha", None)
+        assert isinstance(alpha, torch.nn.Parameter)
+
+    def test_false_does_not_zero_output(self) -> None:
+        torch.manual_seed(0)
+        layer = _new_layer(alpha=True, constant_alpha=False)
+        x = torch.randn(4, 8)
+        y = layer(x)
+        assert torch.isfinite(y).all()
+        assert y.norm().item() > 0.0, (
+            "output collapsed to zero — constant_alpha=False silently coerced "
+            "to 0.0 (issue #3 regression)"
+        )
+
+    def test_zero_float_is_still_respected(self) -> None:
+        layer = _new_layer(alpha=True, constant_alpha=0.0)
+        assert layer._constant_alpha_value == 0.0
+
+
+class TestConstantBiasFalseTrap:
+    def test_false_is_treated_as_none(self) -> None:
+        layer = _new_layer(bias=True, constant_bias=False)
+        assert getattr(layer, "_constant_bias_value", None) is None
+        bias = getattr(layer, "bias", None)
+        assert bias is None or isinstance(bias, torch.nn.Parameter)


### PR DESCRIPTION
## Summary

Fixes the bug reported in #3: `constant_alpha=False` (and `constant_bias=False`) was silently coerced to `float(False) == 0.0`, freezing α at 0 and zeroing the layer output with no warning.

This is easy to hit from YAML configs (`false` → Python `False`) when the user intends "don't use a constant — give me the default learnable α."

### The fix

`False` is now treated exactly like `None` (opt out of the constant path). Numeric `0.0` is still honored as an explicit user choice.

```python
# Before
YatNMN(..., constant_alpha=False)  # → α = 0.0, output identically 0
# After
YatNMN(..., constant_alpha=False)  # → same as constant_alpha=None: learnable α
```

Applied uniformly across all backends (torch, tf, keras, nnx, linen mirrors) — covering `YatNMN`, `YatEmbed`, `YatConv*`, `YatConvTranspose*`, and the attention modules.

## Scope

- 23 source files in `src/nmn/{torch,tf,keras,nnx}` touched — same two-line guard each
- 4 new regression test files: `tests/test_{nnx,torch,keras,tf}/test_constant_alpha_false.py`
- Docstring on `nmn.nnx.layers.YatNMN.constant_alpha` updated to call out the `False` behavior

## Test plan

- [x] New regression tests pass locally (NNX + Torch ran end-to-end: 14 / 14)
- [x] Full `tests/test_nnx/` and `tests/test_torch/` suites still pass (433 passed, 3 skipped, 0 failed)
- [ ] CI to verify Keras/TF tests on Linux

## Notes

- `linen` backend mirrors `nnx` and uses the same `constant_alpha`/`constant_bias` plumbing — same fix applies, included in the sweep.
- Considered raising `ValueError` on `False` instead, per the issue's second suggested fix. Chose the smallest-delta path because:
  1. It matches what users almost always mean by `constant_alpha: false` in config.
  2. It's backward-compatible with anyone currently relying on the (buggy) zeroed-output behavior, in the unlikely event such usage exists.
  3. The docstring now documents the equivalence to `None` explicitly.

Closes #3.