### PR TITLE
feat: add MLX (Apple Silicon) as the sixth NMN backend

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -12,6 +12,7 @@ Comprehensive examples for using Neural Matter Networks across all supported fra
   - [TensorFlow](#tensorflow)
   - [Flax NNX](#flax-nnx)
   - [Flax Linen](#flax-linen)
+  - [MLX](#mlx)
 - [Architecture Examples](#architecture-examples)
   - [Vision: CNN with Yat Layers](#vision-cnn-with-yat-layers)
   - [NLP: Transformer Block](#nlp-transformer-block-with-yat-attention)
@@ -291,6 +292,46 @@ model = YatMLP()
 params = model.init(key, jnp.zeros((1, 128)))
 output = model.apply(params, jnp.zeros((32, 128)))  # (32, 10)
 ```
+
+### MLX
+
+```python
+import mlx.core as mx
+import mlx.nn as nn
+from nmn.mlx import YatNMN, YatConv2D
+
+# ═══════════════════════════════════════════════════════════════
+# Dense Layer
+# ═══════════════════════════════════════════════════════════════
+dense = YatNMN(features=64, constant_alpha=True)
+x = mx.random.normal(shape=(32, 128))
+y = dense(x)  # (32, 64)
+
+# ═══════════════════════════════════════════════════════════════
+# 2D Convolution — channels-last (N, H, W, C)
+# ═══════════════════════════════════════════════════════════════
+conv = YatConv2D(filters=32, kernel_size=3, padding="same")
+images = mx.random.normal(shape=(8, 32, 32, 3))
+features = conv(images)  # (8, 32, 32, 32)
+
+# ═══════════════════════════════════════════════════════════════
+# A small Sequential-style MLP
+# ═══════════════════════════════════════════════════════════════
+class YatMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = YatNMN(features=128)
+        self.fc2 = YatNMN(features=10)
+        # Build lazy params eagerly so value_and_grad sees them.
+        _ = self.fc2(self.fc1(mx.zeros((1, 28 * 28))))
+
+    def __call__(self, x):
+        x = x.reshape((x.shape[0], -1))
+        return self.fc2(self.fc1(x))
+```
+
+> MLX wheels are Apple-Silicon-only — install via `pip install "nmn[mlx]"`
+> on macOS arm64.
 
 ---
 
@@ -699,8 +740,11 @@ src/nmn/
 ├── tf/examples/
 │   └── mnist.py                     # Native TensorFlow MNIST MLP
 │
-└── keras/examples/
-    └── mnist.py                     # Keras 3 (backend-agnostic) MNIST MLP
+├── keras/examples/
+│   └── mnist.py                     # Keras 3 (backend-agnostic) MNIST MLP
+│
+└── mlx/examples/
+    └── mnist.py                     # MLX MNIST MLP (Apple Silicon — GPU or CPU)
 ```
 
 ### Running Examples
@@ -710,6 +754,9 @@ src/nmn/
 PYTHONPATH=src python -m nmn.torch.examples.vision.mnist --report .context/torch_mnist.json
 PYTHONPATH=src python -m nmn.nnx.examples.vision.mnist   --report .context/nnx_mnist.json
 PYTHONPATH=src python -m nmn.linen.examples.mnist        --report .context/linen_mnist.json
+
+# MLX (Apple Silicon, Metal GPU by default)
+PYTHONPATH=src python -m nmn.mlx.examples.mnist --device gpu --report .context/mlx_mnist.json
 
 # TensorFlow / Keras (need separate framework installs)
 PYTHONPATH=src python -m nmn.tf.examples.mnist                          --report .context/tf_mnist.json
@@ -795,6 +842,22 @@ from nmn.linen.nmn import YatNMN
 
 # Convolutions
 from nmn.linen.conv import YatConv1D, YatConv2D, YatConv3D
+
+# ═══════════════════════════════════════════════════════════════
+# MLX (Apple Silicon)
+# ═══════════════════════════════════════════════════════════════
+from nmn.mlx import YatNMN
+
+# Convolutions
+from nmn.mlx import YatConv1D, YatConv2D, YatConv3D
+from nmn.mlx import YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D
+
+# Attention + embedding
+from nmn.mlx import MultiHeadYatAttention, YatEmbed
+from nmn.mlx import yat_attention, yat_attention_weights, normalize_qk
+
+# Squashers
+from nmn.mlx import softermax, softer_sigmoid, soft_tanh
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="center">
   <em>Activation-free neural layers that learn non-linearity through geometric operations.</em>
   <br>
-  <strong>One library. Five frameworks. Numerically equivalent.</strong>
+  <strong>One library. Six frameworks. Numerically equivalent.</strong>
 </p>
 
 <p align="center">
@@ -21,6 +21,7 @@
   <a href="docs/guides/flax-nnx.md"><strong>⚡ JAX/Flax</strong></a> ·
   <a href="docs/guides/keras.md"><strong>🟨 Keras</strong></a> ·
   <a href="docs/guides/tensorflow.md"><strong>🟧 TF</strong></a> ·
+  <a href="docs/guides/mlx.md"><strong>🍎 MLX</strong></a> ·
   <a href="docs/architecture.md"><strong>🧮 Theory</strong></a> ·
   <a href="docs/migration.md"><strong>🔄 Migrate</strong></a> ·
   <a href="https://azettaai.github.io/nmn/paper/"><strong>📄 Paper</strong></a>
@@ -65,7 +66,7 @@ y = YatNMN(in_features=128, out_features=64)(x)   # geometric, intrinsically non
 | Requires an external activation for non-linearity      | Non-linearity is intrinsic                                              |
 | Fires for distant-but-aligned vectors (spurious)       | Penalizes distance → cleaner, prototype-like features                   |
 
-NMN ships across **PyTorch, Flax NNX, Flax Linen, Keras 3, and TensorFlow** with numerically equivalent outputs (< 1e-6 max-abs error in fp32). Pick the framework you like; switch later without retraining math.
+NMN ships across **PyTorch, Flax NNX, Flax Linen, Keras 3, TensorFlow, and MLX** (Apple Silicon) with numerically equivalent outputs (< 1e-6 max-abs error in fp32, verified by an integration parity matrix). Pick the framework you like; switch later without retraining math.
 
 ---
 
@@ -78,7 +79,8 @@ pip install "nmn[nnx]"            # + Flax NNX (JAX)
 pip install "nmn[linen]"          # + Flax Linen (JAX)
 pip install "nmn[keras]"          # + Keras 3 / TensorFlow
 pip install "nmn[tf]"             # + TensorFlow
-pip install "nmn[all]"            # everything
+pip install "nmn[mlx]"            # + MLX (Apple Silicon only)
+pip install "nmn[all]"            # everything except MLX (Linux/Windows safe)
 ```
 
 **Requirements:** Python ≥ 3.10 (≥ 3.11 if you want JAX/Flax).

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Each guide is self-contained: install → hello world → MNIST → CNN → atte
 - [⚡ **Flax Linen**](guides/flax-linen.md)
 - [🟨 **Keras 3**](guides/keras.md) (multi-backend)
 - [🟧 **TensorFlow**](guides/tensorflow.md)
+- [🍎 **MLX**](guides/mlx.md) (Apple Silicon)
 
 ---
 
@@ -39,23 +40,24 @@ Each guide is self-contained: install → hello world → MNIST → CNN → atte
 | **Flax Linen** | You're maintaining a legacy Linen codebase.                                                |
 | **Keras 3**    | You want a high-level API that runs on JAX, TF, *or* PyTorch backends.                     |
 | **TensorFlow** | You need TF-specific deployment (TFLite, Serving) or `tf.Module`-level control.            |
+| **MLX**        | You're on Apple Silicon and want the best perf-per-watt + native Metal GPU acceleration.   |
 
-All five **produce numerically equivalent outputs** (max abs error < 1e-6 in fp32). You can prototype in one and serve from another.
+All six **produce numerically equivalent outputs** (max abs error < 1e-6 in fp32). You can prototype in one and serve from another.
 
 ---
 
 ## Layer support matrix
 
-All layers are available across **all 5 frameworks**.
+All layers are available across **all 6 frameworks**.
 
-| Layer                                      | PyTorch                | TF                     | Keras                  | NNX                                       | Linen                  |
-| ------------------------------------------ | :--------------------: | :--------------------: | :--------------------: | :---------------------------------------: | :--------------------: |
-| Dense                                       | `YatNMN`               | `YatNMN`               | `YatNMN`               | `YatNMN`                                  | `YatNMN`               |
-| Conv 1D / 2D / 3D                          | `YatConv{1,2,3}D`      | `YatConv{1,2,3}D`      | `YatConv{1,2,3}D`      | `YatConv`                                 | `YatConv{1,2,3}D`      |
-| ConvTranspose 1D / 2D / 3D                 | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` | `YatConvTranspose`                        | `YatConvTranspose{1,2,3}D` |
-| Multi-Head Attention                       | `MultiHeadYatAttention`| `MultiHeadYatAttention`| `MultiHeadYatAttention`| `MultiHeadAttention`                      | `MultiHeadAttention`   |
-| Embedding                                  | `YatEmbed`             | `YatEmbed`             | `YatEmbed`             | `Embed`                                   | `YatEmbed`             |
-| Squashers (`softermax`, `softer_sigmoid`, `soft_tanh`) | ✅       | ✅                     | ✅                     | ✅                                        | ✅                     |
+| Layer                                      | PyTorch                | TF                     | Keras                  | NNX                                       | Linen                  | MLX                    |
+| ------------------------------------------ | :--------------------: | :--------------------: | :--------------------: | :---------------------------------------: | :--------------------: | :--------------------: |
+| Dense                                       | `YatNMN`               | `YatNMN`               | `YatNMN`               | `YatNMN`                                  | `YatNMN`               | `YatNMN`               |
+| Conv 1D / 2D / 3D                          | `YatConv{1,2,3}D`      | `YatConv{1,2,3}D`      | `YatConv{1,2,3}D`      | `YatConv`                                 | `YatConv{1,2,3}D`      | `YatConv{1,2,3}D`      |
+| ConvTranspose 1D / 2D / 3D                 | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` | `YatConvTranspose`                        | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` (groups=1) |
+| Multi-Head Attention                       | `MultiHeadYatAttention`| `MultiHeadYatAttention`| `MultiHeadYatAttention`| `MultiHeadAttention`                      | `MultiHeadAttention`   | `MultiHeadYatAttention`|
+| Embedding                                  | `YatEmbed`             | `YatEmbed`             | `YatEmbed`             | `Embed`                                   | `YatEmbed`             | `YatEmbed`             |
+| Squashers (`softermax`, `softer_sigmoid`, `soft_tanh`) | ✅       | ✅                     | ✅                     | ✅                                        | ✅                     | ✅                     |
 
 **NNX-only advanced variants:**
 
@@ -74,7 +76,8 @@ nmn/
 │   ├── nnx/        Flax NNX implementation + examples + Pallas kernels
 │   ├── linen/      Flax Linen implementation
 │   ├── keras/      Keras 3 implementation
-│   └── tf/         TensorFlow implementation
+│   ├── tf/         TensorFlow implementation
+│   └── mlx/        MLX implementation (Apple Silicon)
 ├── tests/
 │   ├── test_<framework>/   Per-framework unit tests
 │   ├── integration/         Cross-framework consistency

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -1,0 +1,258 @@
+# MLX Guide
+
+End-to-end walkthrough for using NMN with **MLX** — Apple's array
+framework for ML on Apple Silicon.
+
+- **Module path**: `nmn.mlx`
+- **Minimum versions**: Python 3.10+, [`mlx`](https://pypi.org/project/mlx/) ≥ 0.18
+- **Hardware**: Apple Silicon (`darwin-arm64`). MLX has no Linux/Windows
+  wheels at the time of writing.
+
+---
+
+## 1. Install
+
+```bash
+pip install "nmn[mlx]"
+```
+
+Verify:
+
+```python
+import mlx.core as mx
+import nmn
+from nmn.mlx import YatNMN
+
+print(nmn.__version__, mx.default_device())
+layer = YatNMN(features=64)
+y = layer(mx.zeros((32, 128)))
+print(y.shape)  # (32, 64)
+```
+
+MLX automatically uses the integrated Metal GPU on Apple Silicon. To run
+on CPU instead set the default device explicitly:
+
+```python
+import mlx.core as mx
+mx.set_default_device(mx.cpu)
+```
+
+---
+
+## 2. Hello world — replace one `Linear + ReLU`
+
+```python
+import mlx.core as mx
+from nmn.mlx import YatNMN
+
+# Before:
+# fc = nn.Sequential(nn.Linear(128, 64), nn.ReLU())
+
+# After:
+fc = YatNMN(features=64)
+
+x = mx.random.normal(shape=(32, 128))
+y = fc(x)
+print(y.shape)            # (32, 64)
+print(float(mx.min(y)))   # ≥ 0 (Yat output is a squared ratio)
+```
+
+No activation function — the non-linearity is baked into the layer.
+
+---
+
+## 3. MNIST end-to-end
+
+```python
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+from nmn.mlx import YatNMN
+
+class YatMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = YatNMN(features=256)
+        self.fc2 = YatNMN(features=128)
+        self.out = nn.Linear(128, 10)
+        # Eagerly build the lazy YatNMN parameters so value_and_grad
+        # captures the full parameter tree.
+        dummy = mx.zeros((1, 28 * 28))
+        _ = self.fc2(self.fc1(dummy))
+
+    def __call__(self, x):
+        x = x.reshape((x.shape[0], -1))
+        return self.out(self.fc2(self.fc1(x)))
+
+def loss_fn(model, x, y):
+    return mx.mean(nn.losses.cross_entropy(model(x), y))
+
+model = YatMLP()
+optimizer = optim.AdamW(learning_rate=3e-4)
+grad_fn = nn.value_and_grad(model, loss_fn)
+
+# ... your data loader → (x, y) batches ...
+for x, y in batches:
+    loss, grads = grad_fn(model, x, y)
+    optimizer.update(model, grads)
+    mx.eval(model.parameters(), optimizer.state)
+```
+
+A complete runnable version is at
+[`src/nmn/mlx/examples/mnist.py`](../../src/nmn/mlx/examples/mnist.py):
+
+```bash
+PYTHONPATH=src python -m nmn.mlx.examples.mnist \
+    --epochs 3 --device gpu --report .context/mlx_mnist.json
+```
+
+**Measured baseline** (Apple Silicon, Metal GPU, fp32, batch=128, lr=3e-4, seed=0):
+
+| Epoch | Train loss | Test loss | Test acc |
+| ----- | ---------- | --------- | -------- |
+| 0     | 0.4490     | 0.1923    | 93.89 %  |
+| 1     | 0.1630     | 0.1448    | 95.56 %  |
+| 2     | 0.1271     | 0.1220    | **96.28 %** |
+
+3 epochs ≈ 1.6 s wall time. `--device cpu` reproduces the **same**
+accuracies in ≈ 2.4 s. See the
+[cross-framework benchmark blog post](../../website/blog-pages/20-cross-framework-mnist.html)
+for a side-by-side with PyTorch / NNX / Linen.
+
+---
+
+## 4. CNN — replacing `Conv2d + ReLU`
+
+```python
+import mlx.core as mx
+import mlx.nn as nn
+from nmn.mlx import YatConv2D, YatNMN
+
+class YatCNN(nn.Module):
+    def __init__(self, num_classes=10):
+        super().__init__()
+        self.c1 = YatConv2D(filters=32, kernel_size=3, padding="same")
+        self.c2 = YatConv2D(filters=64, kernel_size=3, padding="same")
+        self.fc = YatNMN(features=num_classes)
+        # Warm up lazy params with a dummy CIFAR-shaped input.
+        _ = self.__call__(mx.zeros((1, 32, 32, 3)))
+
+    def __call__(self, x):
+        x = nn.MaxPool2d(2)(self.c1(x))
+        x = nn.MaxPool2d(2)(self.c2(x))
+        x = mx.mean(x, axis=(1, 2))   # global average pool
+        return self.fc(x)
+```
+
+Input layout is **channels-last** (`(N, H, W, C)`) — same as TF / Keras /
+JAX. Supported `padding`: `"valid"`, `"same"`, or an integer / tuple of
+integers for explicit symmetric padding.
+
+---
+
+## 5. Attention
+
+```python
+from nmn.mlx import MultiHeadYatAttention
+import mlx.core as mx
+
+attn = MultiHeadYatAttention(embed_dim=512, num_heads=8)
+x = mx.random.normal(shape=(4, 16, 512))
+y = attn(x)                # self-attention
+y = attn(x, ctx, ctx)      # cross-attention with ctx as keys/values
+```
+
+For causal LMs, build a triangular boolean mask of shape
+`(B, H, q_len, kv_len)` (`True = attend`) and pass it via `mask=`.
+
+---
+
+## 6. Embeddings with weight tying
+
+```python
+from nmn.mlx import YatEmbed
+import mlx.core as mx
+
+embed = YatEmbed(num_embeddings=10_000, features=128, constant_alpha=True)
+
+token_ids = mx.array([[1, 2, 3, 4, 5]], dtype=mx.int32)
+h = embed(token_ids)               # (1, 5, 128)
+scores = embed.attend(h[0, -1])    # (10_000,) — YAT retrieval scoring
+```
+
+Same `.attend(query)` API as the other backends — useful for tying
+input/output embeddings in language models.
+
+---
+
+## 7. Saving & loading
+
+MLX serialises parameters to `.safetensors`:
+
+```python
+import mlx.utils
+
+mlx.utils.tree_flatten(model.parameters())  # inspect
+model.save_weights("yat_mlp.safetensors")
+
+# Later:
+restored = YatMLP()
+restored.load_weights("yat_mlp.safetensors")
+```
+
+---
+
+## 8. Lazy build pattern — read this once
+
+`YatNMN`, `YatConv*`, `YatConvTranspose*`, and `MultiHeadYatAttention`
+**build their parameters on the first forward pass** (matching the TF /
+Keras backends' ergonomics). This means:
+
+1. `nn.value_and_grad(model, loss_fn)` captures the parameter tree at
+   *construction* time. If you wrap an unbuilt model, the captured
+   tree won't include the projection kernels — gradients will only
+   flow through the always-eager `alpha`.
+2. Same for `optimizer.update(model, grads)` — the optimizer state
+   shape is fixed at first call.
+
+**Fix**: run one forward pass with a dummy input *before* wrapping the
+model. The MNIST script above does this inside `__init__`; do the same
+for your custom modules.
+
+---
+
+## 9. Device & precision notes
+
+- **Default device is the Metal GPU** on Apple Silicon. The first kernel
+  launch incurs a small JIT cost; subsequent steps are fast.
+- **fp32 is the default**. fp16 / bf16 reduce memory and speed up
+  matmuls — bump `epsilon` to `1e-3` to stay numerically safe with
+  small inputs.
+- **CPU vs GPU output drift**: Metal matmul accumulates at lower
+  precision than CPU fp32 (≈ 1e-3 element-wise on a small matmul).
+  This is a property of the device, not the layer. The cross-framework
+  parity tests pin to `mx.cpu` for that reason; user training runs are
+  unaffected because optimization tolerates the noise.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom                                  | Likely cause                                      | Fix                                                                |
+| ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
+| Gradients only flow through `alpha`      | Lazy params not built before `value_and_grad`     | Call the model once with a dummy input first (§ 8)                  |
+| `NaN` loss in the first ~10 steps        | `epsilon` too small for the input/weight scale    | `YatNMN(features=..., epsilon=1e-3)`                                |
+| `ValueError: padding must have length …` | Mixed scalar/tuple padding spec                   | Use a single scalar or a tuple matching the conv ndim               |
+| Slow first step, fast after              | Metal kernel JIT                                  | Reuse the same Module across steps                                  |
+| 3-D conv slower than expected            | First call is uncached                            | Warm up with a dummy `(1, *spatial, C)` input before benchmarking   |
+| Tests assert tighter than ~1e-3 fail     | Comparing GPU output to CPU numpy reference       | Pin the run to `mx.cpu` for parity tests (see § 9)                  |
+
+---
+
+## 11. Next steps
+
+- [Architecture & theory](../architecture.md)
+- [Migration cheat sheet](../migration.md) — switching from PyTorch / NNX / TF
+- [Cross-framework MNIST benchmark](../../website/blog-pages/20-cross-framework-mnist.html)
+  — measured numbers for every backend
+- [EXAMPLES.md](../../EXAMPLES.md) — more MLX snippets

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -145,8 +145,18 @@ class YatCNN(nn.Module):
 ```
 
 Input layout is **channels-last** (`(N, H, W, C)`) — same as TF / Keras /
-JAX. Supported `padding`: `"valid"`, `"same"`, or an integer / tuple of
-integers for explicit symmetric padding.
+JAX. Supported `padding`:
+
+| Mode | Behaviour |
+| --- | --- |
+| `"valid"` | No padding (default). |
+| `"same"` | Symmetric padding so output spatial size = input / stride (rounded up). |
+| `"circular"` | Wrap-around (a.k.a. periodic). Pre-pads with `np.pad(..., 'wrap')` semantics. |
+| `"reflect"` | Mirror without repeating the edge. Pre-pads with `np.pad(..., 'reflect')`. |
+| `"causal"` | 1-D only: zero-pad on the left so output\[t\] only depends on input\[≤ t\]. |
+| `int` / `tuple[int]` | Explicit symmetric padding per spatial axis. |
+
+`circular` and `reflect` are implemented via `concatenate(slice + reverse-slice + slice)` since MLX's native `mx.pad` only supports `constant` and `edge` modes.
 
 ---
 

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -165,6 +165,35 @@ y = attn(x, ctx, ctx)      # cross-attention with ctx as keys/values
 For causal LMs, build a triangular boolean mask of shape
 `(B, H, q_len, kv_len)` (`True = attend`) and pass it via `mask=`.
 
+### Spherical-YAT-Performer — linear-complexity attention
+
+For long sequences, the standard ``O(n²)`` softmax YAT attention is
+replaced by an anchor-based feature decomposition that runs in
+``O(n)``:
+
+```python
+from nmn.mlx import create_yat_tp_projection, yat_tp_attention
+import mlx.core as mx
+
+# Precompute the random projections once.
+params = create_yat_tp_projection(
+    head_dim=64,
+    num_anchor_features=32,   # P
+    num_prf_features=8,       # M
+    num_quad_nodes=1,         # R
+    seed=0,
+)
+
+q = mx.random.normal(shape=(2, 4096, 8, 64))  # long sequence
+k = mx.random.normal(shape=(2, 4096, 8, 64))
+v = mx.random.normal(shape=(2, 4096, 8, 64))
+out = yat_tp_attention(q, k, v, params, causal=False)
+```
+
+Use ``causal=True`` for autoregressive decoding (prefix sums over the
+key dimension). The total feature count is ``F = R·P·M``; memory
+crosses below quadratic attention when ``seq_len > F``.
+
 ### Rotary Position Embeddings (RoPE)
 
 ```python

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -295,7 +295,41 @@ for your custom modules.
 
 ---
 
-## 9. DropConnect regularization
+## 9. Fused metal-kernel forward (Apple GPU only)
+
+`YatNMN` ships an opt-in fused forward that computes
+`α · (x · Wᵀ + b)² / (‖x − W‖² + ε)` in a single Metal kernel launch
+on the GPU, falling back to standard MLX ops on CPU.
+
+```python
+layer = YatNMN(features=1024, fused=True)
+y = layer(x)
+```
+
+Gradients flow through it via `mx.custom_function` — the VJP uses
+standard ops (not the kernel) and is checked against a centered
+finite-difference reference in `tests/test_mlx/test_fused.py`. The
+fused path **silently falls back to the eager forward** when an
+unsupported flag is on (`spherical`, `weight_normalized`,
+`return_weights`).
+
+The forward kernel is intentionally simple — one thread per `(batch,
+output)` element doing a manual inner product. On a 512→1024 layer
+with batch 64 this measures ~12 % faster than the eager forward on
+M-series GPUs. The win grows with `in_features × out_features`; for
+sub-1 ms layers, kernel-launch overhead dominates and you should
+leave `fused=False`.
+
+```python
+from nmn.mlx import fused_yat_score, is_gpu_available
+
+# Functional access — also benefits from the metal kernel on GPU.
+y = fused_yat_score(x, w, bias=b, alpha=mx.array([1.5]), epsilon=1e-5)
+```
+
+---
+
+## 10. DropConnect regularization
 
 `YatNMN`, `YatConv{1,2,3}D`, and `YatConvTranspose{1,2,3}D` all accept a
 weight-level DropConnect:
@@ -316,7 +350,7 @@ with DropConnect.
 
 ---
 
-## 10. Device & precision notes
+## 11. Device & precision notes
 
 - **Default device is the Metal GPU** on Apple Silicon. The first kernel
   launch incurs a small JIT cost; subsequent steps are fast.
@@ -331,7 +365,7 @@ with DropConnect.
 
 ---
 
-## 11. Troubleshooting
+## 12. Troubleshooting
 
 | Symptom                                  | Likely cause                                      | Fix                                                                |
 | ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
@@ -344,7 +378,7 @@ with DropConnect.
 
 ---
 
-## 12. Next steps
+## 13. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Migration cheat sheet](../migration.md) — switching from PyTorch / NNX / TF

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -221,6 +221,24 @@ pair. Free-form functional access through
 `precompute_freqs_cis`, `apply_rotary_emb`,
 `rotary_yat_attention_weights`, `rotary_yat_attention` for custom blocks.
 
+#### Autoregressive decoding with a KV cache
+
+```python
+attn.init_cache(batch_size=1, max_length=2048)
+out_first = attn(prompt_tokens, decode=True)          # may be many tokens
+for _ in range(generation_length):
+    next_token_embedding = ...                        # (1, 1, embed_dim)
+    out = attn(next_token_embedding, decode=True)
+attn.reset_cache()
+```
+
+`decode=True` appends new K / V to the cache, applies RoPE with the
+correct absolute positions, and uses an implicit causal mask within the
+chunk. The byte-by-byte equivalence test in
+`tests/test_mlx/test_kv_cache.py::test_decode_matches_causal_prefill_byte_identical`
+confirms full-causal-prefill and token-by-token decode produce
+identical outputs.
+
 ---
 
 ## 6. Embeddings with weight tying

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -165,6 +165,23 @@ y = attn(x, ctx, ctx)      # cross-attention with ctx as keys/values
 For causal LMs, build a triangular boolean mask of shape
 `(B, H, q_len, kv_len)` (`True = attend`) and pass it via `mask=`.
 
+### Rotary Position Embeddings (RoPE)
+
+```python
+from nmn.mlx import RotaryYatAttention
+import mlx.core as mx
+
+attn = RotaryYatAttention(embed_dim=512, num_heads=8, max_seq_len=2048)
+x = mx.random.normal(shape=(4, 16, 512))
+y = attn(x)                                  # adds rotary positional encoding
+y = attn(x, position_offset=128)             # caller-controlled offset
+```
+
+Composes with the standard YAT softmax over the same `(q', k')` rotation
+pair. Free-form functional access through
+`precompute_freqs_cis`, `apply_rotary_emb`,
+`rotary_yat_attention_weights`, `rotary_yat_attention` for custom blocks.
+
 ---
 
 ## 6. Embeddings with weight tying

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -221,7 +221,28 @@ for your custom modules.
 
 ---
 
-## 9. Device & precision notes
+## 9. DropConnect regularization
+
+`YatNMN`, `YatConv{1,2,3}D`, and `YatConvTranspose{1,2,3}D` all accept a
+weight-level DropConnect:
+
+```python
+layer = YatNMN(features=128, use_dropconnect=True, drop_rate=0.2)
+
+# Training mode — DropConnect is applied.
+y = layer(x, deterministic=False)
+
+# Inference / validation — pass deterministic=True (default).
+y = layer(x, deterministic=True)
+```
+
+The mask is resampled on every forward call. `weight_normalized=True`
+on conv layers skips the per-step `‖W‖²` recomputation and pairs cleanly
+with DropConnect.
+
+---
+
+## 10. Device & precision notes
 
 - **Default device is the Metal GPU** on Apple Silicon. The first kernel
   launch incurs a small JIT cost; subsequent steps are fast.
@@ -236,7 +257,7 @@ for your custom modules.
 
 ---
 
-## 10. Troubleshooting
+## 11. Troubleshooting
 
 | Symptom                                  | Likely cause                                      | Fix                                                                |
 | ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
@@ -249,7 +270,7 @@ for your custom modules.
 
 ---
 
-## 11. Next steps
+## 12. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Migration cheat sheet](../migration.md) — switching from PyTorch / NNX / TF

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -183,6 +183,51 @@ class MLP(nn.Module):
 
 ---
 
+## MLX (Apple Silicon)
+
+### Before
+
+```python
+import mlx.nn as nn
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(784, 256)
+        self.fc2 = nn.Linear(256, 128)
+        self.fc3 = nn.Linear(128, 10)
+    def __call__(self, x):
+        x = nn.relu(self.fc1(x))
+        x = nn.relu(self.fc2(x))
+        return self.fc3(x)
+```
+
+### After
+
+```python
+import mlx.core as mx
+import mlx.nn as nn
+from nmn.mlx import YatNMN
+
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = YatNMN(features=256)
+        self.fc2 = YatNMN(features=128)
+        self.fc3 = nn.Linear(128, 10)
+        # MLX YatNMN builds parameters lazily — warm up with a dummy
+        # input so nn.value_and_grad captures them.
+        _ = self.fc2(self.fc1(mx.zeros((1, 784))))
+
+    def __call__(self, x):
+        return self.fc3(self.fc2(self.fc1(x)))
+```
+
+The lazy-build pattern matches `nmn.tf` / `nmn.keras`; see
+[`docs/guides/mlx.md` § 8](guides/mlx.md) for the full reasoning.
+
+---
+
 ## Common patterns and gotchas
 
 ### Final classification layer
@@ -240,3 +285,4 @@ See [`architecture.md` § Numerical stability](architecture.md#3-numerical-stabi
 - [Keras step-by-step](guides/keras.md)
 - [TensorFlow step-by-step](guides/tensorflow.md)
 - [Flax Linen step-by-step](guides/flax-linen.md)
+- [MLX step-by-step](guides/mlx.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ torch = ["torch>=1.11.0", "torchvision>=0.12.0"]
 keras = ["tensorflow>=2.10.0"]
 tf = ["tensorflow>=2.10.0"]
 linen = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
+mlx = ["mlx>=0.18.0"]
 all = ["nmn[nnx,torch,keras,tf,linen]"]
 test = [
     "nmn[dev,all]",

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -20,6 +20,11 @@ from .rotary import (
     rotary_yat_attention,
     rotary_yat_attention_weights,
 )
+from .performer import (
+    create_yat_tp_projection,
+    yat_tp_features,
+    yat_tp_attention,
+)
 from .squashers import softermax, softer_sigmoid, soft_tanh
 
 try:
@@ -51,5 +56,8 @@ __all__ = [
     "apply_rotary_emb",
     "rotary_yat_attention",
     "rotary_yat_attention_weights",
+    "create_yat_tp_projection",
+    "yat_tp_features",
+    "yat_tp_attention",
     "softermax", "softer_sigmoid", "soft_tanh",
 ] + _conv_all

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -1,0 +1,16 @@
+"""MLX backend for Neural Matter Network (NMN).
+
+Apple-Silicon-native implementation of the YAT family of layers, mirroring
+the surface of ``nmn.tf`` / ``nmn.keras``. Requires ``mlx``.
+"""
+
+from .nmn import YatNMN, YatDense
+from .squashers import softermax, softer_sigmoid, soft_tanh
+
+__all__ = [
+    "YatNMN",
+    "YatDense",
+    "softermax",
+    "softer_sigmoid",
+    "soft_tanh",
+]

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -25,6 +25,7 @@ from .performer import (
     yat_tp_features,
     yat_tp_attention,
 )
+from .fused import fused_yat_score, is_gpu_available
 from .squashers import softermax, softer_sigmoid, soft_tanh
 
 try:
@@ -59,5 +60,7 @@ __all__ = [
     "create_yat_tp_projection",
     "yat_tp_features",
     "yat_tp_attention",
+    "fused_yat_score",
+    "is_gpu_available",
     "softermax", "softer_sigmoid", "soft_tanh",
 ] + _conv_all

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -5,6 +5,14 @@ the surface of ``nmn.tf`` / ``nmn.keras``. Requires ``mlx``.
 """
 
 from .nmn import YatNMN, YatDense
+from .embed import YatEmbed
+from .attention import (
+    MultiHeadYatAttention,
+    normalize_qk,
+    yat_attention,
+    yat_attention_weights,
+    yat_attention_normalized,
+)
 from .squashers import softermax, softer_sigmoid, soft_tanh
 
 try:
@@ -24,9 +32,12 @@ except ImportError:
     _conv_all = []
 
 __all__ = [
-    "YatNMN",
-    "YatDense",
-    "softermax",
-    "softer_sigmoid",
-    "soft_tanh",
+    "YatNMN", "YatDense",
+    "YatEmbed",
+    "MultiHeadYatAttention",
+    "normalize_qk",
+    "yat_attention",
+    "yat_attention_weights",
+    "yat_attention_normalized",
+    "softermax", "softer_sigmoid", "soft_tanh",
 ] + _conv_all

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -13,6 +13,13 @@ from .attention import (
     yat_attention_weights,
     yat_attention_normalized,
 )
+from .rotary import (
+    RotaryYatAttention,
+    precompute_freqs_cis,
+    apply_rotary_emb,
+    rotary_yat_attention,
+    rotary_yat_attention_weights,
+)
 from .squashers import softermax, softer_sigmoid, soft_tanh
 
 try:
@@ -39,5 +46,10 @@ __all__ = [
     "yat_attention",
     "yat_attention_weights",
     "yat_attention_normalized",
+    "RotaryYatAttention",
+    "precompute_freqs_cis",
+    "apply_rotary_emb",
+    "rotary_yat_attention",
+    "rotary_yat_attention_weights",
     "softermax", "softer_sigmoid", "soft_tanh",
 ] + _conv_all

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -7,10 +7,26 @@ the surface of ``nmn.tf`` / ``nmn.keras``. Requires ``mlx``.
 from .nmn import YatNMN, YatDense
 from .squashers import softermax, softer_sigmoid, soft_tanh
 
+try:
+    from .conv import (
+        YatConv1D, YatConv2D, YatConv3D,
+        YatConv1d, YatConv2d, YatConv3d,
+        YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
+        YatConvTranspose1d, YatConvTranspose2d, YatConvTranspose3d,
+    )
+    _conv_all = [
+        "YatConv1D", "YatConv2D", "YatConv3D",
+        "YatConv1d", "YatConv2d", "YatConv3d",
+        "YatConvTranspose1D", "YatConvTranspose2D", "YatConvTranspose3D",
+        "YatConvTranspose1d", "YatConvTranspose2d", "YatConvTranspose3d",
+    ]
+except ImportError:
+    _conv_all = []
+
 __all__ = [
     "YatNMN",
     "YatDense",
     "softermax",
     "softer_sigmoid",
     "soft_tanh",
-]
+] + _conv_all

--- a/src/nmn/mlx/_yat_core.py
+++ b/src/nmn/mlx/_yat_core.py
@@ -1,0 +1,67 @@
+"""Shared YAT formula helper for MLX conv / transpose-conv layers.
+
+Each ``YatConv*D`` and ``YatConvTranspose*D`` layer inlines roughly twenty
+lines of identical bias / epsilon / YAT-divide / alpha logic — this module
+holds the single source of truth, mirroring ``nmn.tf._yat_core``.
+
+The helper is duck-typed on the ``layer`` object; it reads the same
+instance attributes the conv classes already expose.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+__all__ = ["yat_score"]
+
+
+def yat_score(
+    layer,
+    dot_prod_map: mx.array,
+    distance_sq_map: mx.array,
+) -> mx.array:
+    """Apply bias / epsilon / YAT-divide / alpha to a raw conv output.
+
+    Returns ``(dot + bias) ** 2 / (||x − W||² + ε) · α``.
+
+    Required attributes on ``layer``:
+
+    * ``use_bias``, ``_constant_bias_value``, ``bias``, ``dtype`` — for the
+      bias resolution.
+    * ``learnable_epsilon``, ``epsilon_param``, ``epsilon`` — for the
+      effective epsilon (softplus-of-raw or constant).
+    * ``use_alpha``, ``alpha``, ``_constant_alpha_value`` — for the optional
+      alpha multiplier.
+    """
+    # Add bias inside the numerator square.
+    if layer.use_bias:
+        if layer._constant_bias_value is not None:
+            bias_const = mx.full(
+                (layer.filters,),
+                layer._constant_bias_value,
+                dtype=layer.dtype,
+            )
+            bias_shape = [1] * (dot_prod_map.ndim - 1) + [layer.filters]
+            dot_prod_map = dot_prod_map + mx.reshape(bias_const, bias_shape)
+        else:
+            bias_shape = [1] * (dot_prod_map.ndim - 1) + [layer.filters]
+            dot_prod_map = dot_prod_map + mx.reshape(layer.bias, bias_shape)
+
+    # Effective epsilon (softplus-of-raw learnable, or constant).
+    if layer.learnable_epsilon and getattr(layer, "epsilon_param", None) is not None:
+        eps = nn.softplus(layer.epsilon_param)
+    else:
+        eps = layer.epsilon
+
+    # YAT: (dot + bias)² / (||x − W||² + ε)
+    y = (dot_prod_map * dot_prod_map) / (distance_sq_map + eps)
+
+    # Optional alpha.
+    if layer._constant_alpha_value is not None:
+        y = y * mx.array(layer._constant_alpha_value, dtype=layer.dtype)
+    elif layer.use_alpha and getattr(layer, "alpha", None) is not None:
+        y = y * layer.alpha
+
+    return y

--- a/src/nmn/mlx/attention.py
+++ b/src/nmn/mlx/attention.py
@@ -1,0 +1,324 @@
+"""YAT attention for MLX.
+
+Implements:
+
+* Functional ``yat_attention_weights`` / ``yat_attention`` /
+  ``yat_attention_normalized`` — the score
+  ``(q·k)² / (‖q − k‖² + ε)`` plus softmax normalization.
+* ``MultiHeadYatAttention`` — a four-projection (Q, K, V, out) module
+  using YAT attention internally.
+
+Mirrors ``nmn.tf.attention``. The mask convention is ``True = attend,
+False = mask out`` (consistent with the other backends).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+__all__ = [
+    "normalize_qk",
+    "yat_attention_weights",
+    "yat_attention",
+    "yat_attention_normalized",
+    "MultiHeadYatAttention",
+]
+
+
+DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
+_MASK_FILL = -1e9
+
+
+def normalize_qk(
+    query: mx.array,
+    key: mx.array,
+    epsilon: float = 1e-6,
+) -> Tuple[mx.array, mx.array]:
+    """L2-normalize ``query`` and ``key`` along the last axis."""
+    q_norm = mx.sqrt(mx.sum(query * query, axis=-1, keepdims=True) + epsilon)
+    k_norm = mx.sqrt(mx.sum(key * key, axis=-1, keepdims=True) + epsilon)
+    return query / q_norm, key / k_norm
+
+
+def yat_attention_weights(
+    query: mx.array,
+    key: mx.array,
+    mask: Optional[mx.array] = None,
+    dropout_rate: float = 0.0,
+    training: bool = False,
+    epsilon: float = 1e-5,
+    alpha: Optional[mx.array] = None,
+    scale: Optional[float] = None,
+    spherical: bool = False,
+) -> mx.array:
+    """Softmax over the YAT score.
+
+    Inputs use the (batch, length, num_heads, head_dim) convention, the
+    output mask the (batch, heads, q_len, kv_len) convention.
+    """
+    head_dim = query.shape[-1]
+    dim_scale = math.sqrt(head_dim)
+
+    if spherical:
+        query, key = normalize_qk(query, key, epsilon)
+        dot_product = mx.einsum("bqhd,bkhd->bhqk", query, key)
+        squared_dot = dot_product * dot_product
+        distance_sq = mx.maximum(2.0 - 2.0 * dot_product, 0.0)
+        attn = squared_dot / ((distance_sq + epsilon) * dim_scale)
+    else:
+        dot_product = mx.einsum("bqhd,bkhd->bhqk", query, key)
+        squared_dot = dot_product * dot_product
+        q_sq = mx.sum(query * query, axis=-1)  # (B, Q, H)
+        k_sq = mx.sum(key * key, axis=-1)      # (B, K, H)
+        q_sq = mx.transpose(q_sq, (0, 2, 1))[..., :, None]  # (B, H, Q, 1)
+        k_sq = mx.transpose(k_sq, (0, 2, 1))[..., None, :]  # (B, H, 1, K)
+        dist_sq = mx.maximum(q_sq + k_sq - 2.0 * dot_product, 0.0)
+        attn = squared_dot / ((dist_sq + epsilon) * dim_scale)
+
+    if alpha is not None:
+        attn = attn * alpha
+    elif scale is not None:
+        attn = attn * scale
+
+    if mask is not None:
+        attn = mx.where(
+            mask,
+            attn,
+            mx.array(_MASK_FILL, dtype=attn.dtype),
+        )
+
+    attn = mx.softmax(attn, axis=-1)
+
+    if dropout_rate > 0.0 and training:
+        keep = 1.0 - dropout_rate
+        rnd = mx.random.uniform(shape=attn.shape)
+        mask_dropout = rnd < keep
+        attn = mx.where(mask_dropout, attn / keep, mx.zeros_like(attn))
+    return attn
+
+
+def yat_attention(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    mask: Optional[mx.array] = None,
+    dropout_rate: float = 0.0,
+    training: bool = False,
+    epsilon: float = 1e-5,
+    alpha: Optional[mx.array] = None,
+    scale: Optional[float] = None,
+    spherical: bool = False,
+) -> mx.array:
+    """Softmax(YAT score) @ V. See ``yat_attention_weights`` for conventions."""
+    weights = yat_attention_weights(
+        query, key,
+        mask=mask,
+        dropout_rate=dropout_rate,
+        training=training,
+        epsilon=epsilon,
+        alpha=alpha,
+        scale=scale,
+        spherical=spherical,
+    )
+    return mx.einsum("bhqk,bkhd->bqhd", weights, value)
+
+
+def yat_attention_normalized(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    mask: Optional[mx.array] = None,
+    dropout_rate: float = 0.0,
+    training: bool = False,
+    epsilon: float = 1e-5,
+    alpha: Optional[mx.array] = None,
+    scale: Optional[float] = None,
+) -> mx.array:
+    """``yat_attention`` with the QK normalization shortcut (``spherical=True``)."""
+    return yat_attention(
+        query, key, value,
+        mask=mask,
+        dropout_rate=dropout_rate,
+        training=training,
+        epsilon=epsilon,
+        alpha=alpha,
+        scale=scale,
+        spherical=True,
+    )
+
+
+class MultiHeadYatAttention(nn.Module):
+    """Multi-head YAT attention.
+
+    Architecture::
+
+        Input → Linear(Q) ─┐
+        Input → Linear(K) ─┼─→ yat_attention(Q, K, V) → Linear(out) → Output
+        Input → Linear(V) ─┘
+
+    Args:
+        embed_dim: Total embedding dimension. Must be divisible by ``num_heads``.
+        num_heads: Number of attention heads.
+        dropout: Attention dropout rate (only used in training mode).
+        use_bias: Whether the four projections use a bias.
+        use_alpha: Whether to apply alpha scaling. Ignored if ``constant_alpha`` set.
+        constant_alpha: ``True`` → √2; ``float`` → that value; ``None`` →
+            learnable scalar.
+        normalize_qk: If ``True``, L2-normalize Q and K (without the spherical
+            distance shortcut).
+        spherical: If ``True``, use the spherical YAT score
+            ``(2 − 2·q·k)`` for the distance, faster but assumes unit-norm Q/K.
+        use_out_proj: Whether to apply the output projection.
+        epsilon: YAT stability constant.
+        dtype: MLX dtype for parameters and computation.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float = 0.0,
+        use_bias: bool = True,
+        use_alpha: bool = True,
+        constant_alpha: Optional[Union[bool, float]] = None,
+        normalize_qk: bool = False,
+        spherical: bool = False,
+        use_out_proj: bool = True,
+        epsilon: float = 1e-5,
+        dtype: mx.Dtype = mx.float32,
+    ) -> None:
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by "
+                f"num_heads ({num_heads})."
+            )
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.dropout = dropout
+        self.epsilon = epsilon
+        self.use_out_proj = use_out_proj
+        self._normalize_qk = normalize_qk
+        self._spherical = spherical
+        self.dtype = dtype
+        self.use_bias = use_bias
+
+        # Alpha config.
+        self._constant_alpha_value: Optional[float] = None
+        if constant_alpha is not None and constant_alpha is not False:
+            if constant_alpha is True:
+                self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+            else:
+                self._constant_alpha_value = float(constant_alpha)
+            use_alpha = True
+        elif use_alpha:
+            self.alpha = mx.ones((1,), dtype=dtype)
+        self.use_alpha = use_alpha
+        self.constant_alpha = constant_alpha
+
+        self.is_built = False
+
+    # ------------------------------------------------------------------
+    # Build / forward
+    # ------------------------------------------------------------------
+
+    def build(self, input_dim: int) -> None:
+        if self.is_built:
+            return
+        std = math.sqrt(2.0 / (input_dim + self.embed_dim))
+
+        def make_kernel(shape):
+            return (mx.random.normal(shape=shape) * std).astype(self.dtype)
+
+        self.q_kernel = make_kernel((input_dim, self.embed_dim))
+        self.k_kernel = make_kernel((input_dim, self.embed_dim))
+        self.v_kernel = make_kernel((input_dim, self.embed_dim))
+        if self.use_bias:
+            self.q_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+            self.k_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+            self.v_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+
+        if self.use_out_proj:
+            self.out_kernel = make_kernel((self.embed_dim, self.embed_dim))
+            if self.use_bias:
+                self.out_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+
+        self.is_built = True
+
+    def _linear(self, x: mx.array, kernel: mx.array, bias: Optional[mx.array]) -> mx.array:
+        y = x @ kernel
+        if bias is not None:
+            y = y + bias
+        return y
+
+    def __call__(
+        self,
+        query: mx.array,
+        key: Optional[mx.array] = None,
+        value: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        training: bool = False,
+    ) -> mx.array:
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        if query.dtype != self.dtype:
+            query = query.astype(self.dtype)
+        if key.dtype != self.dtype:
+            key = key.astype(self.dtype)
+        if value.dtype != self.dtype:
+            value = value.astype(self.dtype)
+
+        if not self.is_built:
+            self.build(int(query.shape[-1]))
+
+        B, Q, _ = query.shape
+        K_len = key.shape[1]
+
+        q = self._linear(query, self.q_kernel, getattr(self, "q_bias", None))
+        k = self._linear(key, self.k_kernel, getattr(self, "k_bias", None))
+        v = self._linear(value, self.v_kernel, getattr(self, "v_bias", None))
+
+        q = mx.reshape(q, (B, Q, self.num_heads, self.head_dim))
+        k = mx.reshape(k, (B, K_len, self.num_heads, self.head_dim))
+        v = mx.reshape(v, (B, K_len, self.num_heads, self.head_dim))
+
+        if self._normalize_qk:
+            q, _ = normalize_qk(q, q, epsilon=1e-6)  # normalize q (key reused below)
+            k, _ = normalize_qk(k, k, epsilon=1e-6)
+
+        alpha_val = None
+        scale_val = None
+        if self.use_alpha:
+            if self._constant_alpha_value is not None:
+                scale_val = self._constant_alpha_value
+            elif getattr(self, "alpha", None) is not None:
+                alpha_val = self.alpha
+
+        x = yat_attention(
+            q, k, v,
+            mask=mask,
+            dropout_rate=self.dropout if training else 0.0,
+            training=training,
+            epsilon=self.epsilon,
+            alpha=alpha_val,
+            scale=scale_val,
+            spherical=self._spherical,
+        )
+
+        x = mx.reshape(x, (B, Q, self.embed_dim))
+
+        if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
+            x = self._linear(x, self.out_kernel, getattr(self, "out_bias", None))
+        return x

--- a/src/nmn/mlx/conv.py
+++ b/src/nmn/mlx/conv.py
@@ -49,6 +49,10 @@ def _as_tuple(x: Union[int, Sequence[int]], ndim: int) -> Tuple[int, ...]:
     return out
 
 
+_STR_NATIVE = {"VALID", "SAME"}
+_STR_PREPAD = {"CIRCULAR", "REFLECT", "CAUSAL"}
+
+
 def _resolve_padding(
     padding: Union[str, int, Sequence[int]],
     kernel_size: Tuple[int, ...],
@@ -56,7 +60,11 @@ def _resolve_padding(
     input_spatial: Tuple[int, ...],
     strides: Tuple[int, ...],
 ) -> Tuple[List[int], List[int]]:
-    """Return (low, high) padding lists per spatial axis for conv_general."""
+    """Return ``(low, high)`` padding lists per spatial axis for
+    ``mx.conv_general``. Caller is responsible for handling
+    CIRCULAR / REFLECT / CAUSAL modes via :func:`_prepad_input`
+    *before* calling this.
+    """
     if isinstance(padding, str):
         mode = padding.upper()
         if mode == "VALID":
@@ -79,6 +87,86 @@ def _resolve_padding(
     if len(pads) != len(kernel_size):
         raise ValueError(f"padding must have length {len(kernel_size)}")
     return (list(pads), list(pads))
+
+
+def _prepad_input(
+    x: mx.array,
+    mode: str,
+    kernel_size: Tuple[int, ...],
+    dilation: Tuple[int, ...],
+) -> mx.array:
+    """Pre-pad the input for CIRCULAR / REFLECT / CAUSAL padding.
+
+    The caller then runs the conv with VALID padding so the spatial
+    output size matches what JAX's ``conv_general_dilated`` would give
+    in the corresponding mode.
+
+    ``x`` is laid out as ``(N, *spatial, C_in)``; the spatial axes are
+    ``1..len(kernel_size)``.
+
+    CAUSAL is 1-D only — same restriction as the NNX backend.
+    """
+    mode = mode.upper()
+    if mode == "CAUSAL":
+        if len(kernel_size) != 1:
+            raise ValueError("CAUSAL padding is only defined for 1D convolutions.")
+        left = dilation[0] * (kernel_size[0] - 1)
+        # pad along axis 1 (the only spatial axis); 0 on N and C_in.
+        return mx.pad(x, [(0, 0), (left, 0), (0, 0)], mode="constant")
+
+    # CIRCULAR or REFLECT — pad symmetrically per spatial axis.
+    for axis, (k, d) in enumerate(zip(kernel_size, dilation), start=1):
+        effective_k = (k - 1) * d + 1
+        low = (effective_k - 1) // 2
+        high = effective_k // 2
+        if low == 0 and high == 0:
+            continue
+        size = x.shape[axis]
+        if mode == "CIRCULAR":
+            if low > size or high > size:
+                raise ValueError(
+                    f"CIRCULAR padding requires kernel ≤ input along axis {axis} "
+                    f"(got pad {(low, high)} for input size {size})"
+                )
+            prefix = _take_slice(x, axis, size - low, size) if low > 0 else None
+            suffix = _take_slice(x, axis, 0, high) if high > 0 else None
+        elif mode == "REFLECT":
+            if low >= size or high >= size:
+                raise ValueError(
+                    f"REFLECT padding requires kernel < input along axis {axis} "
+                    f"(got pad {(low, high)} for input size {size})"
+                )
+            # numpy 'reflect': mirror without repeating the edge.
+            # low side comes from x[1:low+1] reversed.
+            prefix = _reverse_slice(x, axis, 1, low + 1) if low > 0 else None
+            # high side comes from x[-(high+1):-1] reversed.
+            suffix = _reverse_slice(x, axis, size - high - 1, size - 1) if high > 0 else None
+        else:
+            raise ValueError(f"unknown pre-pad mode: {mode!r}")
+
+        parts: List[mx.array] = []
+        if prefix is not None:
+            parts.append(prefix)
+        parts.append(x)
+        if suffix is not None:
+            parts.append(suffix)
+        x = mx.concatenate(parts, axis=axis)
+    return x
+
+
+def _take_slice(x: mx.array, axis: int, start: int, stop: int) -> mx.array:
+    """``x[..., start:stop, ...]`` along ``axis`` using basic slicing."""
+    slicer: List[Union[slice, int]] = [slice(None)] * x.ndim
+    slicer[axis] = slice(start, stop)
+    return x[tuple(slicer)]
+
+
+def _reverse_slice(x: mx.array, axis: int, start: int, stop: int) -> mx.array:
+    """``x[..., start:stop, ...][::-1]`` along ``axis``."""
+    sliced = _take_slice(x, axis, start, stop)
+    rev: List[Union[slice, int]] = [slice(None)] * sliced.ndim
+    rev[axis] = slice(None, None, -1)
+    return sliced[tuple(rev)]
 
 
 # ---------------------------------------------------------------------------
@@ -221,10 +309,20 @@ class _YatConvBase(nn.Module):
             inputs = inputs.astype(self.dtype)
         self._maybe_build(inputs)
 
-        spatial = inputs.shape[1:-1]
-        low_pad, high_pad = _resolve_padding(
-            self.padding, self.kernel_size, self.dilation_rate, spatial, self.strides
-        )
+        # Custom padding modes (CIRCULAR / REFLECT / CAUSAL) → pre-pad and
+        # then run conv with VALID. The native VALID / SAME / int paths
+        # are handled by _resolve_padding directly.
+        if isinstance(self.padding, str) and self.padding.upper() in _STR_PREPAD:
+            inputs = _prepad_input(
+                inputs, self.padding, self.kernel_size, self.dilation_rate
+            )
+            low_pad = [0] * len(self.kernel_size)
+            high_pad = [0] * len(self.kernel_size)
+        else:
+            spatial = inputs.shape[1:-1]
+            low_pad, high_pad = _resolve_padding(
+                self.padding, self.kernel_size, self.dilation_rate, spatial, self.strides
+            )
         padding_arg = (low_pad, high_pad)
 
         kernel = self.kernel

--- a/src/nmn/mlx/conv.py
+++ b/src/nmn/mlx/conv.py
@@ -1,0 +1,517 @@
+"""YAT convolution layers for MLX.
+
+Implements ``YatConv{1,2,3}D`` and ``YatConvTranspose{1,2,3}D`` on top of
+``mlx.core.conv_general`` / ``mlx.core.conv_transpose{1,2,3}d``. Mirrors the
+surface of ``nmn.tf.conv`` so the cross-framework parity tests can reuse
+the same fixtures.
+
+Tensor layouts (MLX native, channels-last):
+
+* input  : ``(N, *spatial, C_in)``
+* kernel : ``(C_out, *spatial, C_in / groups)``  (MLX convention)
+* output : ``(N, *spatial', C_out)``
+
+Padding accepts ``"valid"`` / ``"same"`` strings or an integer / sequence
+of integers for explicit symmetric padding. Asymmetric padding for
+"same" is supported via ``mx.conv_general``'s tuple form.
+
+Limitations vs the NNX backend (to be lifted in later PRs):
+* No ``CIRCULAR`` / ``REFLECT`` / ``CAUSAL`` padding modes — only
+  ``valid`` / ``same`` / integer.
+* No DropConnect or mask wiring.
+* ``YatConvTranspose*`` is ``groups=1`` only (an MLX limitation, not a
+  YAT one — ``mx.core.conv_transpose*d`` does not yet support grouped
+  transposed conv).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Sequence, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ._yat_core import yat_score
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _as_tuple(x: Union[int, Sequence[int]], ndim: int) -> Tuple[int, ...]:
+    if isinstance(x, int):
+        return (x,) * ndim
+    out = tuple(int(v) for v in x)
+    if len(out) != ndim:
+        raise ValueError(f"expected sequence of length {ndim}, got {out}")
+    return out
+
+
+def _resolve_padding(
+    padding: Union[str, int, Sequence[int]],
+    kernel_size: Tuple[int, ...],
+    dilation: Tuple[int, ...],
+    input_spatial: Tuple[int, ...],
+    strides: Tuple[int, ...],
+) -> Tuple[List[int], List[int]]:
+    """Return (low, high) padding lists per spatial axis for conv_general."""
+    if isinstance(padding, str):
+        mode = padding.upper()
+        if mode == "VALID":
+            return ([0] * len(kernel_size), [0] * len(kernel_size))
+        if mode == "SAME":
+            low: List[int] = []
+            high: List[int] = []
+            for k, s, d, in_size in zip(kernel_size, strides, dilation, input_spatial):
+                out_size = (in_size + s - 1) // s
+                effective_k = (k - 1) * d + 1
+                total = max((out_size - 1) * s + effective_k - in_size, 0)
+                lo = total // 2
+                low.append(lo)
+                high.append(total - lo)
+            return low, high
+        raise ValueError(f"unknown padding mode: {padding!r}")
+    if isinstance(padding, int):
+        return ([padding] * len(kernel_size), [padding] * len(kernel_size))
+    pads = tuple(int(p) for p in padding)
+    if len(pads) != len(kernel_size):
+        raise ValueError(f"padding must have length {len(kernel_size)}")
+    return (list(pads), list(pads))
+
+
+# ---------------------------------------------------------------------------
+# Forward-conv base
+# ---------------------------------------------------------------------------
+
+
+class _YatConvBase(nn.Module):
+    """N-dimensional YAT convolution (forward / cross-correlation).
+
+    Subclasses set the spatial ``_ndim`` attribute. All shared logic lives
+    here so the 1D/2D/3D classes are thin validators.
+    """
+
+    _ndim: int = 0  # overridden by subclasses
+
+    def __init__(
+        self,
+        filters: int,
+        kernel_size: Union[int, Sequence[int]],
+        strides: Union[int, Sequence[int]] = 1,
+        padding: Union[str, int, Sequence[int]] = "valid",
+        dilation_rate: Union[int, Sequence[int]] = 1,
+        groups: int = 1,
+        use_bias: bool = True,
+        constant_bias: Optional[float] = None,
+        use_alpha: bool = True,
+        constant_alpha: Optional[Union[bool, float]] = None,
+        dtype: mx.Dtype = mx.float32,
+        epsilon: float = 1e-5,
+        learnable_epsilon: bool = False,
+    ) -> None:
+        super().__init__()
+        if self._ndim == 0:
+            raise TypeError("_YatConvBase is not meant to be instantiated directly")
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        if groups < 1:
+            raise ValueError(f"groups must be >= 1, got {groups}")
+
+        self.filters = filters
+        self.kernel_size = _as_tuple(kernel_size, self._ndim)
+        self.strides = _as_tuple(strides, self._ndim)
+        self.dilation_rate = _as_tuple(dilation_rate, self._ndim)
+        self.groups = groups
+        self.padding = padding
+        self.dtype = dtype
+        self.epsilon = epsilon
+        self.learnable_epsilon = learnable_epsilon
+
+        # Bias configuration.
+        self._constant_bias_value: Optional[float] = None
+        if constant_bias is not None and constant_bias is not False:
+            self._constant_bias_value = float(constant_bias)
+            use_bias = True
+        self.use_bias = use_bias
+        self.constant_bias = constant_bias
+
+        # Alpha configuration.
+        from .nmn import DEFAULT_CONSTANT_ALPHA
+        self._constant_alpha_value: Optional[float] = None
+        if constant_alpha is not None and constant_alpha is not False:
+            if constant_alpha is True:
+                self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+            else:
+                self._constant_alpha_value = float(constant_alpha)
+            use_alpha = True
+        self.use_alpha = use_alpha
+        self.constant_alpha = constant_alpha
+
+        self.is_built = False
+        self.input_channels: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Build
+    # ------------------------------------------------------------------
+
+    def build(self, input_channels: int) -> None:
+        if self.is_built:
+            return
+        if input_channels % self.groups != 0:
+            raise ValueError(
+                f"Input channels ({input_channels}) must be divisible by "
+                f"groups ({self.groups})"
+            )
+        if self.filters % self.groups != 0:
+            raise ValueError(
+                f"filters ({self.filters}) must be divisible by groups "
+                f"({self.groups})"
+            )
+        self.input_channels = input_channels
+
+        # MLX kernel layout: (C_out, *K, C_in / groups).
+        channels_per_group = input_channels // self.groups
+        kernel_shape = (self.filters, *self.kernel_size, channels_per_group)
+        fan_in = channels_per_group
+        for k in self.kernel_size:
+            fan_in *= k
+        std = math.sqrt(1.0 / max(fan_in, 1))
+        self.kernel = (mx.random.normal(shape=kernel_shape) * std).astype(self.dtype)
+
+        if self.use_bias and self._constant_bias_value is None:
+            self.bias = mx.zeros((self.filters,), dtype=self.dtype)
+        if self.use_alpha and self._constant_alpha_value is None:
+            self.alpha = mx.ones((1,), dtype=self.dtype)
+        if self.learnable_epsilon:
+            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
+
+        self.is_built = True
+
+    def _maybe_build(self, inputs: mx.array) -> None:
+        if not self.is_built:
+            self.build(inputs.shape[-1])
+        elif self.input_channels != inputs.shape[-1]:
+            raise ValueError(
+                f"Input channels changed: expected {self.input_channels}, "
+                f"got {inputs.shape[-1]}"
+            )
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        if inputs.ndim != self._ndim + 2:
+            raise ValueError(
+                f"expected input with {self._ndim + 2} dims "
+                f"(N, *spatial, C_in), got shape {inputs.shape}"
+            )
+        if inputs.dtype != self.dtype:
+            inputs = inputs.astype(self.dtype)
+        self._maybe_build(inputs)
+
+        spatial = inputs.shape[1:-1]
+        low_pad, high_pad = _resolve_padding(
+            self.padding, self.kernel_size, self.dilation_rate, spatial, self.strides
+        )
+        padding_arg = (low_pad, high_pad)
+
+        # Dot product map via standard cross-correlation.
+        dot_prod_map = mx.conv_general(
+            inputs,
+            self.kernel,
+            stride=list(self.strides),
+            padding=padding_arg,
+            kernel_dilation=list(self.dilation_rate),
+            groups=self.groups,
+        )
+
+        # ||x_patch||² via the ones-kernel trick. Ones kernel has one output
+        # channel per group (so groups=G makes each group only see its own
+        # input channels), then we broadcast back to filters.
+        channels_per_group = self.input_channels // self.groups
+        ones_kernel = mx.ones(
+            (self.groups, *self.kernel_size, channels_per_group),
+            dtype=self.dtype,
+        )
+        patch_sq_per_group = mx.conv_general(
+            inputs * inputs,
+            ones_kernel,
+            stride=list(self.strides),
+            padding=padding_arg,
+            kernel_dilation=list(self.dilation_rate),
+            groups=self.groups,
+        )
+        if self.groups > 1:
+            # patch_sq_per_group has C_out=groups; repeat each entry
+            # filters/groups times to map back to per-filter channels.
+            patch_sq_map = mx.repeat(
+                patch_sq_per_group, self.filters // self.groups, axis=-1
+            )
+        else:
+            patch_sq_map = mx.repeat(patch_sq_per_group, self.filters, axis=-1)
+
+        # ||W||² per filter (sum over kernel spatial + in-channel axes).
+        kernel_sq_per_filter = mx.sum(
+            self.kernel * self.kernel,
+            axis=tuple(range(1, self.kernel.ndim)),
+        )  # shape: (filters,)
+        kernel_sq_shape = [1] * (dot_prod_map.ndim - 1) + [self.filters]
+        kernel_sq_map = mx.reshape(kernel_sq_per_filter, kernel_sq_shape)
+
+        distance_sq_map = mx.maximum(
+            patch_sq_map + kernel_sq_map - 2.0 * dot_prod_map, 0.0
+        )
+        return yat_score(self, dot_prod_map, distance_sq_map)
+
+
+# ---------------------------------------------------------------------------
+# Forward conv subclasses
+# ---------------------------------------------------------------------------
+
+
+class YatConv1D(_YatConvBase):
+    """1D YAT convolution. Input: ``(N, L, C_in)``."""
+
+    _ndim = 1
+
+
+class YatConv2D(_YatConvBase):
+    """2D YAT convolution. Input: ``(N, H, W, C_in)``."""
+
+    _ndim = 2
+
+
+class YatConv3D(_YatConvBase):
+    """3D YAT convolution. Input: ``(N, D, H, W, C_in)``."""
+
+    _ndim = 3
+
+
+# ---------------------------------------------------------------------------
+# Transposed-conv base
+# ---------------------------------------------------------------------------
+
+
+class _YatConvTransposeBase(nn.Module):
+    """N-dimensional YAT transposed convolution.
+
+    MLX only supports ``groups=1`` for ``conv_transpose*d`` at the time of
+    writing — we enforce the same restriction here.
+    """
+
+    _ndim: int = 0
+
+    def __init__(
+        self,
+        filters: int,
+        kernel_size: Union[int, Sequence[int]],
+        strides: Union[int, Sequence[int]] = 1,
+        padding: Union[str, int, Sequence[int]] = "valid",
+        dilation_rate: Union[int, Sequence[int]] = 1,
+        output_padding: Union[int, Sequence[int]] = 0,
+        use_bias: bool = True,
+        constant_bias: Optional[float] = None,
+        use_alpha: bool = True,
+        constant_alpha: Optional[Union[bool, float]] = None,
+        dtype: mx.Dtype = mx.float32,
+        epsilon: float = 1e-5,
+        learnable_epsilon: bool = False,
+    ) -> None:
+        super().__init__()
+        if self._ndim == 0:
+            raise TypeError(
+                "_YatConvTransposeBase is not meant to be instantiated directly"
+            )
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+
+        self.filters = filters
+        self.kernel_size = _as_tuple(kernel_size, self._ndim)
+        self.strides = _as_tuple(strides, self._ndim)
+        self.dilation_rate = _as_tuple(dilation_rate, self._ndim)
+        self.output_padding = _as_tuple(output_padding, self._ndim)
+        self.padding = padding
+        self.dtype = dtype
+        self.epsilon = epsilon
+        self.learnable_epsilon = learnable_epsilon
+        self.groups = 1
+
+        # Bias config.
+        self._constant_bias_value: Optional[float] = None
+        if constant_bias is not None and constant_bias is not False:
+            self._constant_bias_value = float(constant_bias)
+            use_bias = True
+        self.use_bias = use_bias
+        self.constant_bias = constant_bias
+
+        # Alpha config.
+        from .nmn import DEFAULT_CONSTANT_ALPHA
+        self._constant_alpha_value: Optional[float] = None
+        if constant_alpha is not None and constant_alpha is not False:
+            if constant_alpha is True:
+                self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+            else:
+                self._constant_alpha_value = float(constant_alpha)
+            use_alpha = True
+        self.use_alpha = use_alpha
+        self.constant_alpha = constant_alpha
+
+        self.is_built = False
+        self.input_channels: Optional[int] = None
+
+    # ------------------------------------------------------------------
+    # Build / forward
+    # ------------------------------------------------------------------
+
+    def build(self, input_channels: int) -> None:
+        if self.is_built:
+            return
+        self.input_channels = input_channels
+
+        # MLX conv_transpose weight layout: (C_out, *K, C_in).
+        kernel_shape = (self.filters, *self.kernel_size, input_channels)
+        fan_in = input_channels
+        for k in self.kernel_size:
+            fan_in *= k
+        std = math.sqrt(1.0 / max(fan_in, 1))
+        self.kernel = (mx.random.normal(shape=kernel_shape) * std).astype(self.dtype)
+
+        if self.use_bias and self._constant_bias_value is None:
+            self.bias = mx.zeros((self.filters,), dtype=self.dtype)
+        if self.use_alpha and self._constant_alpha_value is None:
+            self.alpha = mx.ones((1,), dtype=self.dtype)
+        if self.learnable_epsilon:
+            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
+
+        self.is_built = True
+
+    def _maybe_build(self, inputs: mx.array) -> None:
+        if not self.is_built:
+            self.build(inputs.shape[-1])
+        elif self.input_channels != inputs.shape[-1]:
+            raise ValueError(
+                f"Input channels changed: expected {self.input_channels}, "
+                f"got {inputs.shape[-1]}"
+            )
+
+    def _conv_transpose_fn(self):
+        return {
+            1: mx.conv_transpose1d,
+            2: mx.conv_transpose2d,
+            3: mx.conv_transpose3d,
+        }[self._ndim]
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        if inputs.ndim != self._ndim + 2:
+            raise ValueError(
+                f"expected input with {self._ndim + 2} dims "
+                f"(N, *spatial, C_in), got shape {inputs.shape}"
+            )
+        if inputs.dtype != self.dtype:
+            inputs = inputs.astype(self.dtype)
+        self._maybe_build(inputs)
+
+        # MLX's conv_transpose*d takes integer / tuple padding. For "same"
+        # we approximate symmetric padding from the kernel size — works
+        # exactly for odd kernels with stride 1, slightly off otherwise.
+        if isinstance(self.padding, str):
+            mode = self.padding.upper()
+            if mode == "VALID":
+                pad_arg: Union[int, Tuple[int, ...]] = 0
+            elif mode == "SAME":
+                pad_arg = tuple(
+                    ((k - 1) * d) // 2
+                    for k, d in zip(self.kernel_size, self.dilation_rate)
+                )
+            else:
+                raise ValueError(f"unknown padding mode: {self.padding!r}")
+        else:
+            pad_arg = self.padding  # type: ignore[assignment]
+
+        conv_transpose = self._conv_transpose_fn()
+
+        # Dot-product map.
+        dot_prod_map = conv_transpose(
+            inputs,
+            self.kernel,
+            stride=self.strides if self._ndim > 1 else self.strides[0],
+            padding=pad_arg,
+            dilation=self.dilation_rate if self._ndim > 1 else self.dilation_rate[0],
+            output_padding=self.output_padding if self._ndim > 1 else self.output_padding[0],
+        )
+
+        # Per-output-position ||x_contrib||² via ones-kernel.
+        ones_kernel = mx.ones(
+            (self.filters, *self.kernel_size, self.input_channels),
+            dtype=self.dtype,
+        )
+        # Sum-of-squares of the input contributions overlapping each
+        # output position. Because conv_transpose with ones broadcasts the
+        # input squared values into every overlap site, this gives the
+        # patch-sum used for ‖x − W‖² up to the per-filter weight square.
+        # We repeat over filters by reducing back to a single-channel sum.
+        patch_sq_filter_map = conv_transpose(
+            inputs * inputs,
+            ones_kernel,
+            stride=self.strides if self._ndim > 1 else self.strides[0],
+            padding=pad_arg,
+            dilation=self.dilation_rate if self._ndim > 1 else self.dilation_rate[0],
+            output_padding=self.output_padding if self._ndim > 1 else self.output_padding[0],
+        )
+        # All filter channels carry the same sum (the kernel was all ones)
+        # — take channel 0 and broadcast.
+        patch_sq_map_one = patch_sq_filter_map[..., :1]
+        patch_sq_map = mx.repeat(patch_sq_map_one, self.filters, axis=-1)
+
+        # ||W||² per filter.
+        kernel_sq_per_filter = mx.sum(
+            self.kernel * self.kernel,
+            axis=tuple(range(1, self.kernel.ndim)),
+        )
+        kernel_sq_shape = [1] * (dot_prod_map.ndim - 1) + [self.filters]
+        kernel_sq_map = mx.reshape(kernel_sq_per_filter, kernel_sq_shape)
+
+        distance_sq_map = mx.maximum(
+            patch_sq_map + kernel_sq_map - 2.0 * dot_prod_map, 0.0
+        )
+        return yat_score(self, dot_prod_map, distance_sq_map)
+
+
+class YatConvTranspose1D(_YatConvTransposeBase):
+    """1D YAT transposed convolution. Input: ``(N, L, C_in)``."""
+
+    _ndim = 1
+
+
+class YatConvTranspose2D(_YatConvTransposeBase):
+    """2D YAT transposed convolution. Input: ``(N, H, W, C_in)``."""
+
+    _ndim = 2
+
+
+class YatConvTranspose3D(_YatConvTransposeBase):
+    """3D YAT transposed convolution. Input: ``(N, D, H, W, C_in)``."""
+
+    _ndim = 3
+
+
+# Lower-case aliases for parity with ``nmn.tf``.
+YatConv1d = YatConv1D
+YatConv2d = YatConv2D
+YatConv3d = YatConv3D
+YatConvTranspose1d = YatConvTranspose1D
+YatConvTranspose2d = YatConvTranspose2D
+YatConvTranspose3d = YatConvTranspose3D
+
+
+__all__ = [
+    "YatConv1D", "YatConv2D", "YatConv3D",
+    "YatConv1d", "YatConv2d", "YatConv3d",
+    "YatConvTranspose1D", "YatConvTranspose2D", "YatConvTranspose3D",
+    "YatConvTranspose1d", "YatConvTranspose2d", "YatConvTranspose3d",
+]

--- a/src/nmn/mlx/conv.py
+++ b/src/nmn/mlx/conv.py
@@ -107,6 +107,9 @@ class _YatConvBase(nn.Module):
         constant_bias: Optional[float] = None,
         use_alpha: bool = True,
         constant_alpha: Optional[Union[bool, float]] = None,
+        use_dropconnect: bool = False,
+        drop_rate: float = 0.0,
+        weight_normalized: bool = False,
         dtype: mx.Dtype = mx.float32,
         epsilon: float = 1e-5,
         learnable_epsilon: bool = False,
@@ -118,6 +121,8 @@ class _YatConvBase(nn.Module):
             raise ValueError(f"epsilon must be positive, got {epsilon}")
         if groups < 1:
             raise ValueError(f"groups must be >= 1, got {groups}")
+        if not 0.0 <= drop_rate < 1.0:
+            raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
 
         self.filters = filters
         self.kernel_size = _as_tuple(kernel_size, self._ndim)
@@ -128,6 +133,9 @@ class _YatConvBase(nn.Module):
         self.dtype = dtype
         self.epsilon = epsilon
         self.learnable_epsilon = learnable_epsilon
+        self.use_dropconnect = use_dropconnect
+        self.drop_rate = drop_rate
+        self.weight_normalized = weight_normalized
 
         # Bias configuration.
         self._constant_bias_value: Optional[float] = None
@@ -203,7 +211,7 @@ class _YatConvBase(nn.Module):
     # Forward
     # ------------------------------------------------------------------
 
-    def __call__(self, inputs: mx.array) -> mx.array:
+    def __call__(self, inputs: mx.array, *, deterministic: bool = True) -> mx.array:
         if inputs.ndim != self._ndim + 2:
             raise ValueError(
                 f"expected input with {self._ndim + 2} dims "
@@ -219,10 +227,25 @@ class _YatConvBase(nn.Module):
         )
         padding_arg = (low_pad, high_pad)
 
+        kernel = self.kernel
+        # Weight normalization: normalize each filter to unit norm at forward
+        # time so the ||W||² term collapses to a constant 1 below.
+        if self.weight_normalized:
+            reduce_axes = tuple(range(1, kernel.ndim))
+            norm = mx.sqrt(
+                mx.sum(kernel * kernel, axis=reduce_axes, keepdims=True)
+            )
+            kernel = kernel / (norm + 1e-8)
+        # DropConnect on the kernel.
+        if self.use_dropconnect and not deterministic and self.drop_rate > 0.0:
+            keep_prob = 1.0 - self.drop_rate
+            dc_mask = mx.random.bernoulli(p=keep_prob, shape=kernel.shape)
+            kernel = (kernel * dc_mask.astype(kernel.dtype)) / keep_prob
+
         # Dot product map via standard cross-correlation.
         dot_prod_map = mx.conv_general(
             inputs,
-            self.kernel,
+            kernel,
             stride=list(self.strides),
             padding=padding_arg,
             kernel_dilation=list(self.dilation_rate),
@@ -254,11 +277,14 @@ class _YatConvBase(nn.Module):
         else:
             patch_sq_map = mx.repeat(patch_sq_per_group, self.filters, axis=-1)
 
-        # ||W||² per filter (sum over kernel spatial + in-channel axes).
-        kernel_sq_per_filter = mx.sum(
-            self.kernel * self.kernel,
-            axis=tuple(range(1, self.kernel.ndim)),
-        )  # shape: (filters,)
+        # ||W||² per filter — collapses to 1 in weight-normalized mode.
+        if self.weight_normalized:
+            kernel_sq_per_filter = mx.ones((self.filters,), dtype=kernel.dtype)
+        else:
+            kernel_sq_per_filter = mx.sum(
+                kernel * kernel,
+                axis=tuple(range(1, kernel.ndim)),
+            )
         kernel_sq_shape = [1] * (dot_prod_map.ndim - 1) + [self.filters]
         kernel_sq_map = mx.reshape(kernel_sq_per_filter, kernel_sq_shape)
 
@@ -317,6 +343,8 @@ class _YatConvTransposeBase(nn.Module):
         constant_bias: Optional[float] = None,
         use_alpha: bool = True,
         constant_alpha: Optional[Union[bool, float]] = None,
+        use_dropconnect: bool = False,
+        drop_rate: float = 0.0,
         dtype: mx.Dtype = mx.float32,
         epsilon: float = 1e-5,
         learnable_epsilon: bool = False,
@@ -328,6 +356,8 @@ class _YatConvTransposeBase(nn.Module):
             )
         if epsilon <= 0:
             raise ValueError(f"epsilon must be positive, got {epsilon}")
+        if not 0.0 <= drop_rate < 1.0:
+            raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
 
         self.filters = filters
         self.kernel_size = _as_tuple(kernel_size, self._ndim)
@@ -339,6 +369,8 @@ class _YatConvTransposeBase(nn.Module):
         self.epsilon = epsilon
         self.learnable_epsilon = learnable_epsilon
         self.groups = 1
+        self.use_dropconnect = use_dropconnect
+        self.drop_rate = drop_rate
 
         # Bias config.
         self._constant_bias_value: Optional[float] = None
@@ -406,7 +438,7 @@ class _YatConvTransposeBase(nn.Module):
             3: mx.conv_transpose3d,
         }[self._ndim]
 
-    def __call__(self, inputs: mx.array) -> mx.array:
+    def __call__(self, inputs: mx.array, *, deterministic: bool = True) -> mx.array:
         if inputs.ndim != self._ndim + 2:
             raise ValueError(
                 f"expected input with {self._ndim + 2} dims "
@@ -435,10 +467,16 @@ class _YatConvTransposeBase(nn.Module):
 
         conv_transpose = self._conv_transpose_fn()
 
+        kernel = self.kernel
+        if self.use_dropconnect and not deterministic and self.drop_rate > 0.0:
+            keep_prob = 1.0 - self.drop_rate
+            dc_mask = mx.random.bernoulli(p=keep_prob, shape=kernel.shape)
+            kernel = (kernel * dc_mask.astype(kernel.dtype)) / keep_prob
+
         # Dot-product map.
         dot_prod_map = conv_transpose(
             inputs,
-            self.kernel,
+            kernel,
             stride=self.strides if self._ndim > 1 else self.strides[0],
             padding=pad_arg,
             dilation=self.dilation_rate if self._ndim > 1 else self.dilation_rate[0],
@@ -468,10 +506,11 @@ class _YatConvTransposeBase(nn.Module):
         patch_sq_map_one = patch_sq_filter_map[..., :1]
         patch_sq_map = mx.repeat(patch_sq_map_one, self.filters, axis=-1)
 
-        # ||W||² per filter.
+        # ||W||² per filter (uses the DropConnect-masked kernel so the
+        # distance reflects the actual weights used in dot_prod_map).
         kernel_sq_per_filter = mx.sum(
-            self.kernel * self.kernel,
-            axis=tuple(range(1, self.kernel.ndim)),
+            kernel * kernel,
+            axis=tuple(range(1, kernel.ndim)),
         )
         kernel_sq_shape = [1] * (dot_prod_map.ndim - 1) + [self.filters]
         kernel_sq_map = mx.reshape(kernel_sq_per_filter, kernel_sq_shape)

--- a/src/nmn/mlx/embed.py
+++ b/src/nmn/mlx/embed.py
@@ -1,0 +1,135 @@
+"""YAT embedding layer for MLX.
+
+Standard embedding lookup via ``__call__`` plus an ``attend`` method that
+computes YAT similarity between query vectors and every embedding — useful
+for weight-tying between embedding and output layers in LMs. Mirrors
+``nmn.tf.embed.YatEmbed``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+__all__ = ["YatEmbed"]
+
+
+DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
+
+
+class YatEmbed(nn.Module):
+    """Embedding table with a YAT-flavoured ``attend`` method.
+
+    Args:
+        num_embeddings: Vocabulary size.
+        features: Dimension of each embedding vector.
+        use_alpha: Whether to apply an alpha scale in ``attend`` (default ``True``).
+            Ignored when ``constant_alpha`` is set.
+        constant_alpha: If ``True``, use √2; if a ``float``, use that value;
+            if ``None``, fall back to a learnable scalar when ``use_alpha=True``.
+        epsilon: Stability constant added to the YAT denominator.
+        spherical: If ``True``, L2-normalize the query and each embedding row
+            before computing the YAT score.
+        weight_normalized: If ``True``, normalize embeddings to unit row norm
+            **at init only** (the matrix is not re-normalized during training).
+        dtype: MLX dtype for parameters and computation.
+    """
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        features: int,
+        use_alpha: bool = True,
+        constant_alpha: Optional[Union[bool, float]] = None,
+        epsilon: float = 1e-5,
+        spherical: bool = False,
+        weight_normalized: bool = False,
+        dtype: mx.Dtype = mx.float32,
+    ) -> None:
+        super().__init__()
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+
+        self.num_embeddings = num_embeddings
+        self.features = features
+        self.epsilon = epsilon
+        self.spherical = spherical
+        self.weight_normalized = weight_normalized
+        self.dtype = dtype
+
+        std = 1.0 / math.sqrt(features)
+        initial = mx.random.normal(shape=(num_embeddings, features)) * std
+        if weight_normalized:
+            norms = mx.sqrt(mx.sum(initial * initial, axis=1, keepdims=True))
+            initial = initial / (norms + 1e-8)
+        self.embedding = initial.astype(dtype)
+
+        # Alpha configuration.
+        self._constant_alpha_value: Optional[float] = None
+        if constant_alpha is not None and constant_alpha is not False:
+            if constant_alpha is True:
+                self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+            else:
+                self._constant_alpha_value = float(constant_alpha)
+            use_alpha = True
+        elif use_alpha:
+            self.alpha = mx.ones((1,), dtype=dtype)
+        self.use_alpha = use_alpha
+        self.constant_alpha = constant_alpha
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        """Standard ``gather`` lookup.
+
+        Args:
+            inputs: Integer array of token ids; any shape.
+
+        Returns:
+            Array of shape ``inputs.shape + (features,)``.
+        """
+        if inputs.dtype not in (mx.int32, mx.int64, mx.uint32, mx.uint64):
+            raise ValueError(
+                f"YatEmbed inputs must be integer; got dtype {inputs.dtype}"
+            )
+        return mx.take(self.embedding, inputs, axis=0)
+
+    def attend(self, query: mx.array) -> mx.array:
+        """YAT similarity between ``query`` and every embedding row.
+
+        Args:
+            query: Array with last dimension equal to ``features``.
+
+        Returns:
+            Array of shape ``query.shape[:-1] + (num_embeddings,)``.
+        """
+        if query.dtype != self.dtype:
+            query = query.astype(self.dtype)
+        embedding = self.embedding
+
+        if self.spherical:
+            query = query / (
+                mx.sqrt(mx.sum(query * query, axis=-1, keepdims=True)) + 1e-8
+            )
+            embedding = embedding / (
+                mx.sqrt(mx.sum(embedding * embedding, axis=1, keepdims=True)) + 1e-8
+            )
+
+        y = query @ embedding.T
+
+        if self.spherical:
+            distances = mx.maximum(2.0 - 2.0 * y, 0.0)
+        else:
+            query_sq = mx.sum(query * query, axis=-1, keepdims=True)
+            embed_sq = mx.sum(embedding * embedding, axis=1, keepdims=True).T
+            distances = mx.maximum(query_sq + embed_sq - 2.0 * y, 0.0)
+
+        y = (y * y) / (distances + self.epsilon)
+
+        if self._constant_alpha_value is not None:
+            y = y * mx.array(self._constant_alpha_value, dtype=self.dtype)
+        elif self.use_alpha and getattr(self, "alpha", None) is not None:
+            y = y * self.alpha
+        return y

--- a/src/nmn/mlx/examples/mnist.py
+++ b/src/nmn/mlx/examples/mnist.py
@@ -1,0 +1,185 @@
+"""MLX MNIST training with YatNMN.
+
+Run:
+    python -m nmn.mlx.examples.mnist
+or:
+    python src/nmn/mlx/examples/mnist.py
+
+Trains a 2-layer YatNMN MLP for 3 epochs on Apple Silicon (Metal GPU by
+default). Uses ``torchvision`` to fetch MNIST so no tensorflow-datasets
+dependency is required.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+import numpy as np
+from torchvision import datasets, transforms
+
+from nmn.mlx import YatNMN
+
+
+class YatMLP(nn.Module):
+    def __init__(self, in_features: int = 28 * 28, hidden1: int = 256,
+                 hidden2: int = 128, num_classes: int = 10):
+        super().__init__()
+        self.fc1 = YatNMN(features=hidden1)
+        self.fc2 = YatNMN(features=hidden2)
+        self.out = nn.Linear(hidden2, num_classes)
+        # Build the YatNMN parameters eagerly so optimizer / value_and_grad
+        # see the full parameter tree from step 0.
+        dummy = mx.zeros((1, in_features))
+        _ = self.fc1(dummy)
+        _ = self.fc2(self.fc1(dummy))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = x.reshape((x.shape[0], -1))
+        x = self.fc1(x)
+        x = self.fc2(x)
+        return self.out(x)
+
+
+def loss_fn(model: YatMLP, x: mx.array, y: mx.array) -> mx.array:
+    logits = model(x)
+    return mx.mean(nn.losses.cross_entropy(logits, y))
+
+
+def eval_batches(model: YatMLP, images: np.ndarray, labels: np.ndarray,
+                 batch_size: int = 512) -> tuple[float, float]:
+    n = images.shape[0]
+    total_loss = 0.0
+    correct = 0
+    for start in range(0, n, batch_size):
+        x = mx.array(images[start:start + batch_size])
+        y = mx.array(labels[start:start + batch_size])
+        logits = model(x)
+        total_loss += float(mx.sum(nn.losses.cross_entropy(logits, y)))
+        correct += int(mx.sum(mx.argmax(logits, axis=1) == y))
+    return total_loss / n, correct / n
+
+
+def iter_batches(images: np.ndarray, labels: np.ndarray, batch_size: int,
+                 shuffle: bool, rng: np.random.Generator):
+    n = images.shape[0]
+    idx = np.arange(n)
+    if shuffle:
+        rng.shuffle(idx)
+    for start in range(0, n - batch_size + 1, batch_size):
+        b = idx[start:start + batch_size]
+        yield mx.array(images[b]), mx.array(labels[b])
+
+
+def load_mnist(root: str) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    tfm = transforms.ToTensor()
+    train = datasets.MNIST(root, train=True, download=True, transform=tfm)
+    test = datasets.MNIST(root, train=False, download=True, transform=tfm)
+    x_train = (train.data.numpy().astype(np.float32) / 255.0)[..., None]
+    y_train = train.targets.numpy().astype(np.int32)
+    x_test = (test.data.numpy().astype(np.float32) / 255.0)[..., None]
+    y_test = test.targets.numpy().astype(np.int32)
+    return x_train, y_train, x_test, y_test
+
+
+def _count_params(params) -> int:
+    total = 0
+    for v in mx.tree_flatten(params)[0] if hasattr(mx, "tree_flatten") else []:
+        total += v.size
+    if total == 0:
+        # Fallback: walk the dict manually.
+        def walk(p):
+            nonlocal total
+            if isinstance(p, mx.array):
+                total += p.size
+            elif isinstance(p, dict):
+                for v in p.values():
+                    walk(v)
+            elif isinstance(p, (list, tuple)):
+                for v in p:
+                    walk(v)
+        walk(params)
+    return total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="YatNMN MNIST training (MLX)")
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--lr", type=float, default=3e-4)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--data-root", type=str, default=".data")
+    parser.add_argument("--device", choices=["gpu", "cpu"], default="gpu",
+                        help="MLX device (default: gpu / Metal)")
+    parser.add_argument("--report", type=str, default=None,
+                        help="optional path to write JSON results")
+    args = parser.parse_args()
+
+    if args.device == "cpu":
+        mx.set_default_device(mx.cpu)
+    else:
+        mx.set_default_device(mx.gpu)
+    mx.random.seed(args.seed)
+    print(f"mlx device: {mx.default_device()}")
+
+    x_train, y_train, x_test, y_test = load_mnist(args.data_root)
+    rng = np.random.default_rng(args.seed)
+
+    model = YatMLP()
+    optimizer = optim.AdamW(learning_rate=args.lr)
+
+    n_params = _count_params(model.parameters())
+    print(f"params={n_params:,}")
+
+    grad_fn = nn.value_and_grad(model, loss_fn)
+
+    history: list[dict] = []
+    wall0 = time.perf_counter()
+    for epoch in range(args.epochs):
+        t0 = time.perf_counter()
+        running = 0.0
+        steps = 0
+        for x, y in iter_batches(x_train, y_train, args.batch_size, True, rng):
+            loss, grads = grad_fn(model, x, y)
+            optimizer.update(model, grads)
+            mx.eval(model.parameters(), optimizer.state)
+            running += float(loss)
+            steps += 1
+        train_loss = running / steps
+        epoch_s = time.perf_counter() - t0
+
+        test_loss, test_acc = eval_batches(model, x_test, y_test)
+        print(
+            f"epoch {epoch}: train_loss={train_loss:.4f} "
+            f"test_loss={test_loss:.4f} test_acc={test_acc:.4f} "
+            f"time={epoch_s:.1f}s"
+        )
+        history.append({
+            "epoch": epoch, "train_loss": train_loss,
+            "test_loss": test_loss, "test_acc": test_acc, "epoch_s": epoch_s,
+        })
+    total_s = time.perf_counter() - wall0
+
+    result = {
+        "framework": "mlx",
+        "device": str(mx.default_device()),
+        "params": int(n_params),
+        "epochs": args.epochs,
+        "batch_size": args.batch_size,
+        "total_s": total_s,
+        "final_test_acc": history[-1]["test_acc"],
+        "final_test_loss": history[-1]["test_loss"],
+        "history": history,
+    }
+    if args.report:
+        Path(args.report).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.report).write_text(json.dumps(result, indent=2))
+        print(f"report -> {args.report}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nmn/mlx/fused.py
+++ b/src/nmn/mlx/fused.py
@@ -1,0 +1,220 @@
+"""Fused YAT score for MLX via ``mx.fast.metal_kernel``.
+
+Computes ``y = α · (x · Wᵀ + b)² / (‖x − W‖² + ε)`` in a single Metal
+kernel launch when the active device is the GPU; falls back to standard
+MLX ops on CPU so the same call site works everywhere.
+
+Wrapped in :class:`mx.custom_function` so gradients flow through it the
+same way they would through the unfused YAT path — the VJP uses
+standard MLX ops (not the kernel) because the win here is *forward*
+activation-memory reduction; doing a full backward kernel is much more
+involved and out of scope for this PR.
+
+Use via the convenience helper :func:`fused_yat_score`, or pass
+``fused=True`` to :class:`nmn.mlx.YatNMN`.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import mlx.core as mx
+
+
+__all__ = ["fused_yat_score", "is_gpu_available"]
+
+
+_METAL_SOURCE = """
+    uint o = thread_position_in_grid.x;
+    uint b = thread_position_in_grid.y;
+    if (o >= out_features || b >= batch_size) return;
+
+    float dot = 0.0f;
+    float dist = 0.0f;
+    for (uint i = 0; i < in_features; i++) {
+        float xv = (float)x[b * in_features + i];
+        float wv = (float)w[o * in_features + i];
+        dot += xv * wv;
+        float d = xv - wv;
+        dist += d * d;
+    }
+    float num = dot + (float)bias[o];
+    float denom = dist + (float)eps[0];
+    out[b * out_features + o] = (T)(alpha[0] * num * num / denom);
+"""
+
+
+# Lazily-compiled kernel handle. ``mx.fast.metal_kernel`` is cheap to
+# construct but we still cache the handle so the JIT compile only fires
+# once per process.
+_kernel_cache: Optional[object] = None
+
+
+def _get_kernel() -> object:
+    global _kernel_cache
+    if _kernel_cache is None:
+        _kernel_cache = mx.fast.metal_kernel(
+            name="nmn_fused_yat_score",
+            input_names=["x", "w", "bias", "alpha", "eps"],
+            output_names=["out"],
+            source=_METAL_SOURCE,
+        )
+    return _kernel_cache
+
+
+def is_gpu_available() -> bool:
+    """``True`` iff the current default device is the Metal GPU."""
+    return str(mx.default_device()) == "Device(gpu, 0)"
+
+
+def _metal_forward(
+    x: mx.array,
+    w: mx.array,
+    b: mx.array,
+    alpha: mx.array,
+    eps: mx.array,
+) -> mx.array:
+    """Launch the fused-YAT Metal kernel for a 2-D input batch."""
+    if x.ndim != 2 or w.ndim != 2:
+        raise ValueError(
+            f"fused metal kernel expects 2-D x and w; got x.shape={x.shape}, "
+            f"w.shape={w.shape}. Flatten leading batch dims before calling."
+        )
+    B, In = x.shape
+    Out, In2 = w.shape
+    if In != In2:
+        raise ValueError(f"in_features mismatch: x has {In}, w has {In2}")
+    kernel = _get_kernel()
+    outputs = kernel(
+        inputs=[x, w, b, alpha, eps],
+        template=[
+            ("T", x.dtype),
+            ("in_features", In),
+            ("out_features", Out),
+            ("batch_size", B),
+        ],
+        grid=(Out, B, 1),
+        threadgroup=(min(32, Out), min(8, max(B, 1)), 1),
+        output_shapes=[(B, Out)],
+        output_dtypes=[x.dtype],
+    )
+    return outputs[0]
+
+
+def _standard_forward(
+    x: mx.array,
+    w: mx.array,
+    b: mx.array,
+    alpha: mx.array,
+    eps: mx.array,
+) -> mx.array:
+    """Reference forward using standard MLX ops — used as the CPU fallback."""
+    dot = x @ w.T
+    x_sq = mx.sum(x * x, axis=-1, keepdims=True)
+    w_sq = mx.sum(w * w, axis=-1)[None, :]
+    dist = mx.maximum(x_sq + w_sq - 2.0 * dot, 0.0)
+    num = dot + b
+    return alpha * (num * num) / (dist + eps)
+
+
+@mx.custom_function
+def _fused_yat_core(
+    x: mx.array,
+    w: mx.array,
+    b: mx.array,
+    alpha: mx.array,
+    eps: mx.array,
+) -> mx.array:
+    """Functional fused YAT score; dispatches by device."""
+    if is_gpu_available():
+        return _metal_forward(x, w, b, alpha, eps)
+    return _standard_forward(x, w, b, alpha, eps)
+
+
+@_fused_yat_core.vjp
+def _fused_yat_core_vjp(primals, cotangent, output):
+    """Chain-rule the YAT score using standard MLX ops.
+
+    out = α · num² / dist
+    num = x · Wᵀ + b
+    dist = ‖x‖² + ‖W‖² − 2·x·Wᵀ + ε
+
+    ∂out/∂num  =  α · 2 · num / dist
+    ∂out/∂dist = −α · num² / dist²
+    """
+    x, w, b, alpha, eps = primals
+    g = cotangent
+
+    raw_dot = x @ w.T
+    x_sq = mx.sum(x * x, axis=-1, keepdims=True)
+    w_sq = mx.sum(w * w, axis=-1)[None, :]
+    dist_raw = mx.maximum(x_sq + w_sq - 2.0 * raw_dot, 0.0) + eps
+    num = raw_dot + b
+    inv = 1.0 / dist_raw
+
+    g_num = g * (alpha * 2.0 * num * inv)
+    g_dist = g * (-alpha * num * num * (inv * inv))
+
+    # dot enters num (+1) and dist (−2·dot in the expansion).
+    g_dot_total = g_num + g_dist * (-2.0)
+
+    # ∂dist/∂x picks up 2·x via ‖x‖²; sum over the out-features axis.
+    g_x = g_dot_total @ w + mx.sum(g_dist, axis=-1, keepdims=True) * (2.0 * x)
+    # ∂dist/∂w picks up 2·w via ‖W‖²; sum the broadcast over the batch.
+    g_w = g_dot_total.T @ x + mx.sum(g_dist, axis=0)[..., None] * (2.0 * w)
+
+    g_b = mx.sum(g_num, axis=0)
+    # raw_yat = num² / dist  →  dα = Σ g · raw_yat
+    raw_yat = num * num * inv
+    g_alpha = mx.sum(g * raw_yat).reshape(alpha.shape)
+    g_eps = mx.sum(g * (-alpha * num * num * (inv * inv))).reshape(eps.shape)
+
+    return g_x, g_w, g_b, g_alpha, g_eps
+
+
+def fused_yat_score(
+    x: mx.array,
+    w: mx.array,
+    bias: Optional[mx.array] = None,
+    alpha: Optional[mx.array] = None,
+    epsilon: float = 1e-5,
+) -> mx.array:
+    """Convenience wrapper that fills in defaults and flattens batch dims.
+
+    Args:
+        x: ``(..., in_features)``. Leading batch dims are flattened then
+            restored on the way out.
+        w: ``(out_features, in_features)`` — same layout as
+            :class:`nmn.mlx.YatNMN.kernel`.
+        bias: Optional ``(out_features,)``; defaults to all zeros.
+        alpha: Optional scalar (or 1-element array); defaults to 1.0.
+        epsilon: Stability constant.
+
+    Returns:
+        ``(..., out_features)``.
+    """
+    out_features = w.shape[0]
+    in_features = w.shape[1]
+    if x.shape[-1] != in_features:
+        raise ValueError(
+            f"x last dim ({x.shape[-1]}) must match w in_features ({in_features})"
+        )
+
+    leading = x.shape[:-1]
+    flat_x = mx.reshape(x, (int(_prod(leading)), in_features))
+    if bias is None:
+        bias = mx.zeros((out_features,), dtype=x.dtype)
+    if alpha is None:
+        alpha = mx.ones((1,), dtype=x.dtype)
+    elif alpha.ndim == 0:
+        alpha = mx.reshape(alpha, (1,))
+    eps_arr = mx.array([epsilon], dtype=x.dtype)
+
+    out_flat = _fused_yat_core(flat_x, w, bias, alpha, eps_arr)
+    return mx.reshape(out_flat, leading + (out_features,))
+
+
+def _prod(shape) -> int:
+    p = 1
+    for d in shape:
+        p *= int(d)
+    return p

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -76,6 +76,8 @@ class YatNMN(nn.Module):
         use_alpha: bool = True,
         constant_alpha: Optional[Union[bool, float]] = None,
         positive_init: bool = False,
+        use_dropconnect: bool = False,
+        drop_rate: float = 0.0,
         dtype: mx.Dtype = mx.float32,
         epsilon: float = 1e-5,
         learnable_epsilon: bool = False,
@@ -86,6 +88,8 @@ class YatNMN(nn.Module):
         super().__init__()
         if epsilon <= 0:
             raise ValueError(f"epsilon must be positive, got {epsilon}")
+        if not 0.0 <= drop_rate < 1.0:
+            raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
 
         self.features = features
         self.dtype = dtype
@@ -95,6 +99,8 @@ class YatNMN(nn.Module):
         self.weight_normalized = weight_normalized
         self.return_weights = return_weights
         self.positive_init = positive_init
+        self.use_dropconnect = use_dropconnect
+        self.drop_rate = drop_rate
 
         # ── Bias config ────────────────────────────────────────────────
         self._constant_bias_value: Optional[float] = None
@@ -157,7 +163,10 @@ class YatNMN(nn.Module):
     # -----------------------------------------------------------------
 
     def __call__(
-        self, inputs: mx.array
+        self,
+        inputs: mx.array,
+        *,
+        deterministic: bool = True,
     ) -> Union[mx.array, Tuple[mx.array, mx.array]]:
         if inputs.dtype != self.dtype:
             inputs = inputs.astype(self.dtype)
@@ -172,6 +181,12 @@ class YatNMN(nn.Module):
             )
 
         kernel = self.kernel
+
+        # DropConnect: randomly drop weights at the kernel level.
+        if self.use_dropconnect and not deterministic and self.drop_rate > 0.0:
+            keep_prob = 1.0 - self.drop_rate
+            dc_mask = mx.random.bernoulli(p=keep_prob, shape=kernel.shape)
+            kernel = (kernel * dc_mask.astype(kernel.dtype)) / keep_prob
 
         # Spherical: normalize inputs and each kernel row to unit norm.
         if self.spherical:

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -78,6 +78,7 @@ class YatNMN(nn.Module):
         positive_init: bool = False,
         use_dropconnect: bool = False,
         drop_rate: float = 0.0,
+        fused: bool = False,
         dtype: mx.Dtype = mx.float32,
         epsilon: float = 1e-5,
         learnable_epsilon: bool = False,
@@ -101,6 +102,7 @@ class YatNMN(nn.Module):
         self.positive_init = positive_init
         self.use_dropconnect = use_dropconnect
         self.drop_rate = drop_rate
+        self.fused = fused
 
         # ── Bias config ────────────────────────────────────────────────
         self._constant_bias_value: Optional[float] = None
@@ -187,6 +189,44 @@ class YatNMN(nn.Module):
             keep_prob = 1.0 - self.drop_rate
             dc_mask = mx.random.bernoulli(p=keep_prob, shape=kernel.shape)
             kernel = (kernel * dc_mask.astype(kernel.dtype)) / keep_prob
+
+        # Fused path: skip when an option that isn't supported by the
+        # kernel is active (spherical, weight_normalized — those alter
+        # the kernel before the YAT formula, and we don't want to drift
+        # from the eager path).
+        if (
+            self.fused
+            and not self.spherical
+            and not self.weight_normalized
+            and not self.return_weights
+        ):
+            from .fused import fused_yat_score
+
+            if self.use_bias:
+                if self._constant_bias_value is not None:
+                    bias = mx.full(
+                        (self.features,), self._constant_bias_value, dtype=self.dtype
+                    )
+                else:
+                    bias = self.bias
+                    if self.softplus_bias if hasattr(self, "softplus_bias") else False:
+                        pass  # not supported in fused path
+            else:
+                bias = mx.zeros((self.features,), dtype=self.dtype)
+            if self._constant_alpha_value is not None:
+                alpha_arr = mx.array(
+                    [self._constant_alpha_value], dtype=self.dtype
+                )
+            elif self.use_alpha and getattr(self, "alpha", None) is not None:
+                alpha_arr = self.alpha
+            else:
+                alpha_arr = mx.ones((1,), dtype=self.dtype)
+            if self.learnable_epsilon and getattr(self, "epsilon_param", None) is not None:
+                eps_val = float(nn.softplus(self.epsilon_param)[0])
+            else:
+                eps_val = self.epsilon
+            return fused_yat_score(inputs, kernel, bias=bias, alpha=alpha_arr,
+                                   epsilon=eps_val)
 
         # Spherical: normalize inputs and each kernel row to unit norm.
         if self.spherical:

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -1,0 +1,277 @@
+"""YAT dense layer for MLX (``mlx.nn.Module``-based).
+
+Mirrors the surface of ``nmn.tf.nmn.YatNMN`` (Tier-0 feature set):
+
+* learnable / constant / off bias inside the numerator square
+* learnable / constant / off alpha output scaling
+* learnable epsilon (softplus-reparameterized) or constant
+* spherical mode (unit-norm inputs + kernel rows)
+* weight normalization (unit-norm kernel rows at forward time)
+* ``positive_init`` (``abs()`` of initial kernel)
+* lazy build on first call so the input dimension does not need to be
+  specified up front, matching the TF/Keras ergonomics
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
+
+
+class YatNMN(nn.Module):
+    """Dense layer implementing the ⵟ-Product (YAT) transformation.
+
+    Computes ``y = (x · Wᵀ + b)² / (‖x − W_row‖² + ε)`` over the last
+    dimension of the input. No separate activation function is needed —
+    the non-linearity is intrinsic.
+
+    Args:
+        features: Number of output features.
+        use_bias: If ``True``, add a bias inside the squared numerator.
+        constant_bias: If a ``float``, use that value as a fixed (non-learnable)
+            bias constant. If ``None``, use a learnable bias when
+            ``use_bias=True``.
+        use_alpha: Whether to apply output scaling via an alpha parameter.
+            Has no effect when ``constant_alpha`` is set.
+        constant_alpha: If ``True``, applies a fixed √2 scale factor. If a
+            ``float``, applies that value as a fixed scale. If ``None``,
+            a learnable scalar ``alpha`` is created when ``use_alpha=True``.
+        positive_init: Initialise kernel weights with ``abs(.)`` so all
+            entries are non-negative (default: ``False``).
+        dtype: MLX dtype used for parameters and computation (default
+            ``mx.float32``).
+        epsilon: Small constant added to the denominator to avoid division
+            by zero (default ``1e-5``).
+        learnable_epsilon: If ``True``, epsilon becomes a learnable parameter
+            passed through softplus to guarantee strict positivity.
+        spherical: If ``True``, normalize inputs and each kernel row to unit
+            norm before computing the YAT formula.
+        weight_normalized: If ``True``, normalize each kernel row to unit
+            norm at forward time. Skips the ``‖W‖²`` recomputation in the
+            distance term as it is known to be 1.
+        return_weights: If ``True``, ``__call__`` returns
+            ``(output, kernel)`` instead of just ``output``.
+
+    Example::
+
+        >>> import mlx.core as mx
+        >>> from nmn.mlx import YatNMN
+        >>> layer = YatNMN(features=10)
+        >>> x = mx.zeros((4, 8))
+        >>> layer(x).shape
+        (4, 10)
+    """
+
+    def __init__(
+        self,
+        features: int,
+        use_bias: bool = True,
+        constant_bias: Optional[float] = None,
+        use_alpha: bool = True,
+        constant_alpha: Optional[Union[bool, float]] = None,
+        positive_init: bool = False,
+        dtype: mx.Dtype = mx.float32,
+        epsilon: float = 1e-5,
+        learnable_epsilon: bool = False,
+        spherical: bool = False,
+        weight_normalized: bool = False,
+        return_weights: bool = False,
+    ) -> None:
+        super().__init__()
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+
+        self.features = features
+        self.dtype = dtype
+        self.epsilon = epsilon
+        self.learnable_epsilon = learnable_epsilon
+        self.spherical = spherical
+        self.weight_normalized = weight_normalized
+        self.return_weights = return_weights
+        self.positive_init = positive_init
+
+        # ── Bias config ────────────────────────────────────────────────
+        self._constant_bias_value: Optional[float] = None
+        if constant_bias is not None and constant_bias is not False:
+            self._constant_bias_value = float(constant_bias)
+            use_bias = True  # constant bias is still "applied"
+        self.use_bias = use_bias
+        self.constant_bias = constant_bias
+
+        # ── Alpha config ───────────────────────────────────────────────
+        self._constant_alpha_value: Optional[float] = None
+        if constant_alpha is not None and constant_alpha is not False:
+            if constant_alpha is True:
+                self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+            else:
+                self._constant_alpha_value = float(constant_alpha)
+            use_alpha = True
+        self.use_alpha = use_alpha
+        self.constant_alpha = constant_alpha
+
+        # Parameters created lazily on first call so users don't have to
+        # supply in_features up front (matches the TF/Keras ergonomics).
+        self.is_built = False
+        self.input_dim: Optional[int] = None
+
+    # -----------------------------------------------------------------
+    # Build
+    # -----------------------------------------------------------------
+
+    def build(self, last_dim: int) -> None:
+        """Allocate parameters once the input feature dimension is known."""
+        if self.is_built:
+            return
+        self.input_dim = int(last_dim)
+
+        # Xavier-normal initialisation (consistent with the TF backend).
+        fan_in = last_dim
+        fan_out = self.features
+        std = math.sqrt(2.0 / (fan_in + fan_out))
+        kernel = mx.random.normal(shape=(self.features, last_dim)) * std
+        if self.positive_init:
+            kernel = mx.abs(kernel)
+        self.kernel = kernel.astype(self.dtype)
+
+        if self.use_alpha and self._constant_alpha_value is None:
+            self.alpha = mx.ones((1,), dtype=self.dtype)
+
+        if self.use_bias and self._constant_bias_value is None:
+            self.bias = mx.zeros((self.features,), dtype=self.dtype)
+
+        if self.learnable_epsilon:
+            # softplus(raw) = epsilon  ->  raw = log(exp(epsilon) - 1)
+            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
+
+        self.is_built = True
+
+    # -----------------------------------------------------------------
+    # Forward
+    # -----------------------------------------------------------------
+
+    def __call__(
+        self, inputs: mx.array
+    ) -> Union[mx.array, Tuple[mx.array, mx.array]]:
+        if inputs.dtype != self.dtype:
+            inputs = inputs.astype(self.dtype)
+
+        last_dim = inputs.shape[-1]
+        if not self.is_built:
+            self.build(last_dim)
+        elif self.input_dim != last_dim:
+            raise ValueError(
+                f"Input shape changed: expected last dimension "
+                f"{self.input_dim}, got {last_dim}"
+            )
+
+        kernel = self.kernel
+
+        # Spherical: normalize inputs and each kernel row to unit norm.
+        if self.spherical:
+            inputs = inputs / (
+                mx.sqrt(mx.sum(inputs * inputs, axis=-1, keepdims=True)) + 1e-8
+            )
+            kernel = kernel / (
+                mx.sqrt(mx.sum(kernel * kernel, axis=-1, keepdims=True)) + 1e-8
+            )
+
+        # Weight normalization: normalize each kernel row at forward time.
+        if self.weight_normalized:
+            kernel = kernel / (
+                mx.sqrt(mx.sum(kernel * kernel, axis=-1, keepdims=True)) + 1e-8
+            )
+
+        # y = x @ Wᵀ
+        y = inputs @ kernel.T
+
+        # Squared distance ||x − W_row||² broadcast across the (batch, feat)
+        # axes.  For spherical inputs we use the closed-form 2 − 2·dot.
+        if self.spherical:
+            distances = mx.maximum(2.0 - 2.0 * y, 0.0)
+        else:
+            inputs_sq_sum = mx.sum(inputs * inputs, axis=-1, keepdims=True)
+            if self.weight_normalized:
+                kernel_sq_sum = mx.ones((self.features,), dtype=kernel.dtype)
+            else:
+                kernel_sq_sum = mx.sum(kernel * kernel, axis=-1)
+            kernel_sq_sum = mx.reshape(
+                kernel_sq_sum, [1] * (y.ndim - 1) + [self.features]
+            )
+            distances = mx.maximum(inputs_sq_sum + kernel_sq_sum - 2.0 * y, 0.0)
+
+        # Bias inside the squared numerator (learnable or constant).
+        if self.use_bias:
+            bias_shape = [1] * (y.ndim - 1) + [self.features]
+            if self._constant_bias_value is not None:
+                bias_const = mx.full(
+                    (self.features,),
+                    self._constant_bias_value,
+                    dtype=self.dtype,
+                )
+                y = y + mx.reshape(bias_const, bias_shape)
+            else:
+                y = y + mx.reshape(self.bias, bias_shape)
+
+        # Effective epsilon.
+        if self.learnable_epsilon and getattr(self, "epsilon_param", None) is not None:
+            eps = nn.softplus(self.epsilon_param)
+        else:
+            eps = self.epsilon
+
+        y = (y * y) / (distances + eps)
+
+        # Alpha scaling.
+        if self._constant_alpha_value is not None:
+            y = y * mx.array(self._constant_alpha_value, dtype=self.dtype)
+        elif self.use_alpha and getattr(self, "alpha", None) is not None:
+            y = y * self.alpha
+
+        if self.return_weights:
+            return y, self.kernel
+        return y
+
+    # -----------------------------------------------------------------
+    # Weight accessors — kept symmetric with nmn.tf.nmn.YatNMN.
+    # -----------------------------------------------------------------
+
+    def get_weights(self) -> List[mx.array]:
+        if not self.is_built:
+            raise ValueError("Layer must be built before weights can be retrieved.")
+        weights: List[mx.array] = [self.kernel]
+        if self.use_bias and self._constant_bias_value is None:
+            weights.append(self.bias)
+        if self.use_alpha and self._constant_alpha_value is None:
+            weights.append(self.alpha)
+        if self.learnable_epsilon:
+            weights.append(self.epsilon_param)
+        return weights
+
+    def set_weights(self, weights: List[mx.array]) -> None:
+        if not self.is_built:
+            raise ValueError("Layer must be built before weights can be set.")
+        expected = self.get_weights()
+        if len(weights) != len(expected):
+            raise ValueError(
+                f"Expected {len(expected)} weight tensors, got {len(weights)}"
+            )
+        self.kernel = weights[0].astype(self.dtype)
+        idx = 1
+        if self.use_bias and self._constant_bias_value is None:
+            self.bias = weights[idx].astype(self.dtype)
+            idx += 1
+        if self.use_alpha and self._constant_alpha_value is None:
+            self.alpha = weights[idx].astype(self.dtype)
+            idx += 1
+        if self.learnable_epsilon:
+            self.epsilon_param = weights[idx].astype(self.dtype)
+
+
+# Backward-compat alias used by the other backends.
+YatDense = YatNMN

--- a/src/nmn/mlx/performer.py
+++ b/src/nmn/mlx/performer.py
@@ -1,0 +1,203 @@
+"""Spherical-YAT-Performer attention for MLX.
+
+Linearized spherical YAT attention via the anchor approach:
+
+  K(q, k) = (q·k)² / (C − 2·q·k)
+          = ∫₀^∞ e^{−sC} · (q·k)² · e^{2s·q·k} ds
+          ≈ Σ_r w_r · (q·k)² · exp(2 s_r · q·k)
+
+Each term factorizes as ``φ_poly(q)·φ_poly(k) · φ_PRF(q;s_r)·φ_PRF(k;s_r)``,
+giving a kernel feature map ``φ(x)`` that lets attention run in
+``O(seq_len)`` via the standard reordering trick (``Σ_k φ(k) v_kᵀ``
+then ``φ(q) · …``).
+
+Mirrors ``nmn.nnx.layers.attention.spherical_yat_performer`` (without
+the docstring's experimental approximation-quality table — the
+math is unchanged).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import mlx.core as mx
+import numpy as np
+
+
+__all__ = [
+    "create_yat_tp_projection",
+    "yat_tp_features",
+    "yat_tp_attention",
+]
+
+
+def create_yat_tp_projection(
+    head_dim: int,
+    num_prf_features: int = 8,
+    num_quad_nodes: int = 1,
+    num_anchor_features: int = 16,
+    epsilon: float = 1e-5,
+    dtype: mx.Dtype = mx.float32,
+    seed: Optional[int] = None,
+) -> dict[str, Any]:
+    """Precompute the parameters for anchor-based YAT attention.
+
+    Args:
+        head_dim: Per-head dimension.
+        num_prf_features: ``M`` — PRF features per quadrature node.
+        num_quad_nodes: ``R`` — Gauss-Laguerre quadrature nodes.
+        num_anchor_features: ``P`` — anchor features for ``(q·k)²``.
+        epsilon: Stability constant (``C = 2 + epsilon``).
+        dtype: MLX dtype for the precomputed arrays.
+        seed: Optional integer seed for deterministic projections.
+
+    Returns:
+        Dict with ``projections``, ``anchors``, ``quad_nodes``,
+        ``quad_weights``, plus the integers ``head_dim``,
+        ``num_prf_features``, ``num_anchor_features``, ``num_scales``.
+    """
+    rng = np.random.default_rng(seed)
+
+    C = 2.0 + epsilon
+
+    # Gauss-Laguerre nodes/weights — change of variables t = C·s.
+    nodes_np, weights_np = np.polynomial.laguerre.laggauss(num_quad_nodes)
+    quad_nodes = mx.array((nodes_np / C).astype(np.float32)).astype(dtype)
+    quad_weights = mx.array((weights_np / C).astype(np.float32)).astype(dtype)
+
+    # Anchor vectors on the unit sphere.
+    anchors_np = rng.standard_normal((num_anchor_features, head_dim)).astype(np.float32)
+    anchors_np = anchors_np / (
+        np.sqrt((anchors_np ** 2).sum(axis=-1, keepdims=True)) + 1e-8
+    )
+    anchors = mx.array(anchors_np).astype(dtype)
+
+    # PRF projections: one ``(M, head_dim)`` matrix per quadrature node.
+    projections_np = rng.standard_normal(
+        (num_quad_nodes, num_prf_features, head_dim)
+    ).astype(np.float32)
+    projections = mx.array(projections_np).astype(dtype)
+
+    return {
+        "projections": projections,        # (R, M, d)
+        "anchors": anchors,                # (P, d)
+        "quad_nodes": quad_nodes,          # (R,)
+        "quad_weights": quad_weights,      # (R,)
+        "head_dim": head_dim,
+        "num_prf_features": num_prf_features,
+        "num_anchor_features": num_anchor_features,
+        "num_scales": num_quad_nodes,
+    }
+
+
+def yat_tp_features(
+    x: mx.array,
+    params: dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> mx.array:
+    """Compute ``φ(x) ∈ ℝ^(R·P·M)`` for each ``(seq, head)`` token.
+
+    Args:
+        x: ``(..., seq_len, num_heads, head_dim)``.
+        params: Output of :func:`create_yat_tp_projection`.
+        normalize: L2-normalize inputs first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., seq_len, num_heads, R·P·M)``.
+    """
+    if normalize:
+        x_norm = mx.sqrt(mx.sum(x * x, axis=-1, keepdims=True) + epsilon)
+        x = x / x_norm
+
+    projections = params["projections"]       # (R, M, d)
+    anchors = params["anchors"]               # (P, d)
+    quad_nodes = params["quad_nodes"]         # (R,)
+    quad_weights = params["quad_weights"]     # (R,)
+    M = params["num_prf_features"]
+    P = params["num_anchor_features"]
+    R = params["num_scales"]
+
+    # Polynomial features: (a·x)² / √P  →  (..., P)
+    dots = mx.einsum("...d,pd->...p", x, anchors)
+    poly_feat = (dots * dots) / math.sqrt(P)
+
+    # PRF projections for every node at once: (..., R, M)
+    proj_all = mx.einsum("...d,rmd->...rm", x, projections)
+
+    sqrt_2s = mx.sqrt(mx.maximum(quad_nodes * 2.0, 0.0)).astype(x.dtype)
+    s_vals = quad_nodes.astype(x.dtype)
+    sq_w = mx.sqrt(mx.maximum(quad_weights, 0.0)).astype(x.dtype)
+
+    sqrt_2s_b = sqrt_2s.reshape((R, 1))
+    s_b = s_vals.reshape((R, 1))
+
+    exp_arg = mx.clip(proj_all * sqrt_2s_b - s_b, -20.0, 20.0)
+    prf_all = mx.exp(exp_arg) / math.sqrt(M)  # (..., R, M)
+
+    # Outer product φ_poly(x) ⊗ φ_PRF(x; s_r) per quadrature node, with
+    # √w_r applied. R is small (1-2) so a Python loop is fine.
+    leading_shape = poly_feat.shape[:-1]
+    fused_per_r = []
+    for r in range(R):
+        prf_r = prf_all[..., r, :]                       # (..., M)
+        outer = poly_feat[..., :, None] * prf_r[..., None, :]   # (..., P, M)
+        fused = mx.reshape(outer, leading_shape + (P * M,)) * sq_w[r]
+        fused_per_r.append(fused)
+
+    # Stack on a new last axis then flatten the (R, P*M) tail → (..., R*P*M).
+    stacked = mx.stack(fused_per_r, axis=-2)  # (..., R, P*M)
+    return mx.reshape(stacked, leading_shape + (R * P * M,))
+
+
+def yat_tp_attention(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    params: dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> mx.array:
+    """Linear-complexity YAT attention via tensor-product features.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, v_dim)``.
+        params: Output of :func:`create_yat_tp_projection`.
+        causal: If ``True``, use prefix sums so each query only sees keys
+            up to its own position.
+        epsilon: Numerical stability constant.
+
+    Returns:
+        ``(B, Q, H, v_dim)``.
+    """
+    if query.dtype != value.dtype:
+        value = value.astype(query.dtype)
+    if key.dtype != query.dtype:
+        key = key.astype(query.dtype)
+
+    q_feat = yat_tp_features(query, params, normalize=True, epsilon=epsilon) + epsilon
+    k_feat = yat_tp_features(key, params, normalize=True, epsilon=epsilon) + epsilon
+
+    if causal:
+        # kv[b, k, h, m, d] = k_feat[b, k, h, m] * value[b, k, h, d]
+        kv = mx.einsum("bkhm,bkhd->bkhmd", k_feat, value)
+        kv_cum = mx.cumsum(kv, axis=1)
+        k_cum = mx.cumsum(k_feat, axis=1)
+
+        num = mx.einsum("bqhm,bqhmd->bqhd", q_feat, kv_cum)
+        den = mx.einsum("bqhm,bqhm->bqh", q_feat, k_cum)
+        den = den[..., None] + epsilon
+        return num / den
+
+    # Non-causal: O(n) via the associativity trick.
+    kv = mx.einsum("bkhm,bkhd->bhmd", k_feat, value)
+    num = mx.einsum("bqhm,bhmd->bqhd", q_feat, kv)
+
+    k_sum = mx.sum(k_feat, axis=1)
+    den = mx.einsum("bqhm,bhm->bqh", q_feat, k_sum)
+    den = den[..., None] + epsilon
+    return num / den

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -1,0 +1,336 @@
+"""Rotary YAT Attention for MLX.
+
+Combines Rotary Position Embeddings (RoPE) with the YAT attention
+formula:
+
+    1. Apply RoPE: q' = RoPE(q, pos), k' = RoPE(k, pos)
+    2. Compute YAT: softmax((q'·k')² / (‖q' − k'‖² + ε)) · V
+
+Mirrors ``nmn.nnx.layers.attention.rotary_yat`` (without the autoregressive
+KV-cache, Performer, and LayerNorm-QK paths — those are deferred to a
+future PR).
+
+References:
+    - RoFormer (https://arxiv.org/abs/2104.09864)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .attention import yat_attention_weights
+
+
+__all__ = [
+    "precompute_freqs_cis",
+    "apply_rotary_emb",
+    "rotary_yat_attention_weights",
+    "rotary_yat_attention",
+    "RotaryYatAttention",
+]
+
+
+DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
+
+
+def precompute_freqs_cis(
+    dim: int,
+    max_seq_len: int,
+    theta: float = 10000.0,
+    dtype: mx.Dtype = mx.float32,
+) -> Tuple[mx.array, mx.array]:
+    """Precompute cosine and sine frequencies for RoPE.
+
+    Args:
+        dim: Per-head dimension (must be even).
+        max_seq_len: Maximum sequence length to precompute.
+        theta: Base for the frequency computation.
+        dtype: Output dtype.
+
+    Returns:
+        (cos_freqs, sin_freqs), each of shape ``(max_seq_len, dim // 2)``.
+    """
+    if dim % 2 != 0:
+        raise ValueError(f"RoPE dim must be even, got {dim}")
+    inv_freq = 1.0 / (theta ** (np.arange(0, dim, 2)[: dim // 2] / dim))
+    t = np.arange(max_seq_len)
+    freqs = np.outer(t, inv_freq)
+    return (
+        mx.array(np.cos(freqs).astype(np.float32)).astype(dtype),
+        mx.array(np.sin(freqs).astype(np.float32)).astype(dtype),
+    )
+
+
+def apply_rotary_emb(
+    x: mx.array,
+    freqs_cos: mx.array,
+    freqs_sin: mx.array,
+    position_offset: int = 0,
+) -> mx.array:
+    """Apply RoPE to a tensor of shape ``(..., seq_len, num_heads, head_dim)``.
+
+    The rotation pair is taken from the even / odd interleaved channels
+    of the last axis, matching the reference implementation.
+    """
+    seq_len = x.shape[-3]
+    max_seq_len = freqs_cos.shape[0]
+    if position_offset + seq_len > max_seq_len:
+        raise ValueError(
+            f"Rotary frequencies precomputed for max_seq_len={max_seq_len}, "
+            f"but position_offset + seq_len = {position_offset + seq_len} "
+            f"exceeds it."
+        )
+
+    cos = freqs_cos[position_offset:position_offset + seq_len]
+    sin = freqs_sin[position_offset:position_offset + seq_len]
+
+    x_even = x[..., 0::2]
+    x_odd = x[..., 1::2]
+
+    # Reshape cos / sin to (1, seq_len, 1, dim//2) — broadcasts across batch
+    # and heads.
+    cos = mx.reshape(cos, (1, seq_len, 1, -1))
+    sin = mx.reshape(sin, (1, seq_len, 1, -1))
+
+    rotated_even = x_even * cos - x_odd * sin
+    rotated_odd = x_even * sin + x_odd * cos
+
+    # Interleave back: stack on a new last axis, then flatten the last
+    # two dims.
+    out = mx.stack([rotated_even, rotated_odd], axis=-1)
+    return mx.reshape(out, x.shape)
+
+
+def rotary_yat_attention_weights(
+    query: mx.array,
+    key: mx.array,
+    freqs_cos: mx.array,
+    freqs_sin: mx.array,
+    mask: Optional[mx.array] = None,
+    dropout_rate: float = 0.0,
+    training: bool = False,
+    epsilon: float = 1e-5,
+    alpha: Optional[mx.array] = None,
+    scale: Optional[float] = None,
+    position_offset: int = 0,
+) -> mx.array:
+    """Softmax-normalized YAT attention weights after applying RoPE to Q/K."""
+    q_rot = apply_rotary_emb(query, freqs_cos, freqs_sin, position_offset)
+    k_rot = apply_rotary_emb(key, freqs_cos, freqs_sin, position_offset)
+    return yat_attention_weights(
+        q_rot, k_rot,
+        mask=mask,
+        dropout_rate=dropout_rate,
+        training=training,
+        epsilon=epsilon,
+        alpha=alpha,
+        scale=scale,
+        spherical=False,
+    )
+
+
+def rotary_yat_attention(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    freqs_cos: mx.array,
+    freqs_sin: mx.array,
+    mask: Optional[mx.array] = None,
+    dropout_rate: float = 0.0,
+    training: bool = False,
+    epsilon: float = 1e-5,
+    alpha: Optional[mx.array] = None,
+    scale: Optional[float] = None,
+    position_offset: int = 0,
+) -> mx.array:
+    """RoPE → YAT attention → V."""
+    weights = rotary_yat_attention_weights(
+        query, key,
+        freqs_cos, freqs_sin,
+        mask=mask,
+        dropout_rate=dropout_rate,
+        training=training,
+        epsilon=epsilon,
+        alpha=alpha,
+        scale=scale,
+        position_offset=position_offset,
+    )
+    return mx.einsum("bhqk,bkhd->bqhd", weights, value)
+
+
+class RotaryYatAttention(nn.Module):
+    """Multi-head YAT attention with Rotary Position Embeddings.
+
+    Architecture::
+
+        Input → Linear(Q) → RoPE ─┐
+        Input → Linear(K) → RoPE ─┼─→ yat_attention(Q', K', V) → Linear(out)
+        Input → Linear(V) ────────┘
+
+    The RoPE frequency tables are computed once at construction and
+    cached as module attributes (``freqs_cos`` / ``freqs_sin``).
+
+    Args:
+        embed_dim: Total embedding dimension. Must be divisible by ``num_heads``.
+        num_heads: Number of attention heads.
+        max_seq_len: Maximum sequence length supported (defines the RoPE
+            table size).
+        theta: RoPE base frequency.
+        dropout: Attention-dropout rate (only used in training mode).
+        use_bias: Whether the projections carry a bias.
+        use_alpha / constant_alpha: Same as ``MultiHeadYatAttention``.
+        use_out_proj: Whether to apply the output projection.
+        epsilon: YAT stability constant.
+        dtype: MLX dtype for parameters and computation.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        max_seq_len: int = 2048,
+        *,
+        theta: float = 10000.0,
+        dropout: float = 0.0,
+        use_bias: bool = True,
+        use_alpha: bool = True,
+        constant_alpha: Optional[Union[bool, float]] = None,
+        use_out_proj: bool = True,
+        epsilon: float = 1e-5,
+        dtype: mx.Dtype = mx.float32,
+    ) -> None:
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by "
+                f"num_heads ({num_heads})."
+            )
+        head_dim = embed_dim // num_heads
+        if head_dim % 2 != 0:
+            raise ValueError(
+                f"head_dim ({head_dim}) must be even for RoPE."
+            )
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.max_seq_len = max_seq_len
+        self.theta = theta
+        self.dropout = dropout
+        self.use_bias = use_bias
+        self.use_out_proj = use_out_proj
+        self.epsilon = epsilon
+        self.dtype = dtype
+
+        # Alpha configuration.
+        self._constant_alpha_value: Optional[float] = None
+        if constant_alpha is not None and constant_alpha is not False:
+            if constant_alpha is True:
+                self._constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+            else:
+                self._constant_alpha_value = float(constant_alpha)
+            use_alpha = True
+        elif use_alpha:
+            self.alpha = mx.ones((1,), dtype=dtype)
+        self.use_alpha = use_alpha
+        self.constant_alpha = constant_alpha
+
+        # RoPE frequency tables — cached on the module so MLX places them
+        # on the active device.
+        cos_freqs, sin_freqs = precompute_freqs_cis(head_dim, max_seq_len, theta, dtype)
+        self.freqs_cos = cos_freqs
+        self.freqs_sin = sin_freqs
+
+        self.is_built = False
+
+    def build(self, input_dim: int) -> None:
+        if self.is_built:
+            return
+        std = math.sqrt(2.0 / (input_dim + self.embed_dim))
+
+        def make_kernel(shape):
+            return (mx.random.normal(shape=shape) * std).astype(self.dtype)
+
+        self.q_kernel = make_kernel((input_dim, self.embed_dim))
+        self.k_kernel = make_kernel((input_dim, self.embed_dim))
+        self.v_kernel = make_kernel((input_dim, self.embed_dim))
+        if self.use_bias:
+            self.q_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+            self.k_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+            self.v_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+
+        if self.use_out_proj:
+            self.out_kernel = make_kernel((self.embed_dim, self.embed_dim))
+            if self.use_bias:
+                self.out_bias = mx.zeros((self.embed_dim,), dtype=self.dtype)
+
+        self.is_built = True
+
+    def _linear(
+        self, x: mx.array, kernel: mx.array, bias: Optional[mx.array]
+    ) -> mx.array:
+        y = x @ kernel
+        if bias is not None:
+            y = y + bias
+        return y
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        *,
+        training: bool = False,
+        position_offset: int = 0,
+    ) -> mx.array:
+        if x.dtype != self.dtype:
+            x = x.astype(self.dtype)
+        if not self.is_built:
+            self.build(int(x.shape[-1]))
+
+        B, L, _ = x.shape
+        if position_offset + L > self.max_seq_len:
+            raise ValueError(
+                f"position_offset + seq_len = {position_offset + L} exceeds "
+                f"max_seq_len={self.max_seq_len}. Recreate the layer with a "
+                f"larger max_seq_len."
+            )
+
+        q = self._linear(x, self.q_kernel, getattr(self, "q_bias", None))
+        k = self._linear(x, self.k_kernel, getattr(self, "k_bias", None))
+        v = self._linear(x, self.v_kernel, getattr(self, "v_bias", None))
+
+        q = mx.reshape(q, (B, L, self.num_heads, self.head_dim))
+        k = mx.reshape(k, (B, L, self.num_heads, self.head_dim))
+        v = mx.reshape(v, (B, L, self.num_heads, self.head_dim))
+
+        alpha_val = None
+        scale_val = None
+        if self.use_alpha:
+            if self._constant_alpha_value is not None:
+                scale_val = self._constant_alpha_value
+            elif getattr(self, "alpha", None) is not None:
+                alpha_val = self.alpha
+
+        out = rotary_yat_attention(
+            q, k, v,
+            self.freqs_cos, self.freqs_sin,
+            mask=mask,
+            dropout_rate=self.dropout if training else 0.0,
+            training=training,
+            epsilon=self.epsilon,
+            alpha=alpha_val,
+            scale=scale_val,
+            position_offset=position_offset,
+        )
+
+        out = mx.reshape(out, (B, L, self.embed_dim))
+        if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
+            out = self._linear(out, self.out_kernel, getattr(self, "out_bias", None))
+        return out

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -38,6 +38,20 @@ __all__ = [
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
 
+def _splice(cache: mx.array, new: mx.array, start: int) -> mx.array:
+    """Insert ``new`` into ``cache`` along axis 1 starting at ``start``.
+
+    Equivalent to ``jax.lax.dynamic_update_slice`` on a ``(B, T, H, D)``
+    cache: returns ``cache`` with ``cache[:, start:start + L]`` replaced
+    by ``new``. Implemented as concatenate-of-slices since MLX doesn't
+    expose an in-place scatter that lives nicely with autograd.
+    """
+    L = new.shape[1]
+    prefix = cache[:, :start]
+    suffix = cache[:, start + L:]
+    return mx.concatenate([prefix, new, suffix], axis=1)
+
+
 def precompute_freqs_cis(
     dim: int,
     max_seq_len: int,
@@ -248,6 +262,11 @@ class RotaryYatAttention(nn.Module):
         self.freqs_cos = cos_freqs
         self.freqs_sin = sin_freqs
 
+        # KV cache for autoregressive decode (populated by init_cache).
+        self.cached_key: Optional[mx.array] = None
+        self.cached_value: Optional[mx.array] = None
+        self.cache_index: int = 0
+
         self.is_built = False
 
     def build(self, input_dim: int) -> None:
@@ -281,6 +300,41 @@ class RotaryYatAttention(nn.Module):
             y = y + bias
         return y
 
+    # ------------------------------------------------------------------
+    # KV cache for autoregressive decoding
+    # ------------------------------------------------------------------
+
+    def init_cache(self, batch_size: int, max_length: Optional[int] = None) -> None:
+        """Allocate a KV cache for autoregressive decoding.
+
+        Args:
+            batch_size: Batch size of the decoding stream.
+            max_length: Maximum number of tokens to decode. Defaults to
+                ``max_seq_len``.
+        """
+        if not self.is_built:
+            raise ValueError(
+                "Module is not built yet — call it once with a real input "
+                "first so the projection shapes are known."
+            )
+        if max_length is None:
+            max_length = self.max_seq_len
+        if max_length > self.max_seq_len:
+            raise ValueError(
+                f"max_length={max_length} exceeds RoPE table size "
+                f"max_seq_len={self.max_seq_len}."
+            )
+        shape = (batch_size, max_length, self.num_heads, self.head_dim)
+        self.cached_key = mx.zeros(shape, dtype=self.dtype)
+        self.cached_value = mx.zeros(shape, dtype=self.dtype)
+        self.cache_index = 0
+
+    def reset_cache(self) -> None:
+        """Clear the KV cache."""
+        self.cached_key = None
+        self.cached_value = None
+        self.cache_index = 0
+
     def __call__(
         self,
         x: mx.array,
@@ -288,16 +342,40 @@ class RotaryYatAttention(nn.Module):
         *,
         training: bool = False,
         position_offset: int = 0,
+        decode: bool = False,
     ) -> mx.array:
+        """Run multi-head Rotary YAT attention.
+
+        When ``decode=True`` the layer appends the new tokens' K and V to
+        an internal cache (populated by ``init_cache``) and uses the
+        ``cache_index`` as the implicit ``position_offset``.
+        """
         if x.dtype != self.dtype:
             x = x.astype(self.dtype)
         if not self.is_built:
             self.build(int(x.shape[-1]))
 
         B, L, _ = x.shape
-        if position_offset + L > self.max_seq_len:
+
+        if decode:
+            if self.cached_key is None or self.cached_value is None:
+                raise ValueError(
+                    "decode=True requires init_cache() to have been called."
+                )
+            if self.cache_index + L > self.cached_key.shape[1]:
+                raise ValueError(
+                    f"KV cache full: cache_index={self.cache_index} + "
+                    f"new tokens={L} exceeds capacity "
+                    f"{self.cached_key.shape[1]}."
+                )
+            # RoPE positions for the new tokens start at cache_index.
+            effective_offset = self.cache_index
+        else:
+            effective_offset = position_offset
+
+        if effective_offset + L > self.max_seq_len:
             raise ValueError(
-                f"position_offset + seq_len = {position_offset + L} exceeds "
+                f"position_offset + seq_len = {effective_offset + L} exceeds "
                 f"max_seq_len={self.max_seq_len}. Recreate the layer with a "
                 f"larger max_seq_len."
             )
@@ -310,27 +388,89 @@ class RotaryYatAttention(nn.Module):
         k = mx.reshape(k, (B, L, self.num_heads, self.head_dim))
         v = mx.reshape(v, (B, L, self.num_heads, self.head_dim))
 
-        alpha_val = None
-        scale_val = None
-        if self.use_alpha:
-            if self._constant_alpha_value is not None:
-                scale_val = self._constant_alpha_value
-            elif getattr(self, "alpha", None) is not None:
-                alpha_val = self.alpha
+        if decode:
+            cache_old = self.cache_index
+            # Splice the new K / V into the cache and read back the full
+            # accumulated history.
+            new_key = _splice(self.cached_key, k, cache_old)
+            new_value = _splice(self.cached_value, v, cache_old)
+            self.cached_key = new_key
+            self.cached_value = new_value
+            self.cache_index = cache_old + L
+            cache_new = self.cache_index
 
-        out = rotary_yat_attention(
-            q, k, v,
-            self.freqs_cos, self.freqs_sin,
-            mask=mask,
-            dropout_rate=self.dropout if training else 0.0,
-            training=training,
-            epsilon=self.epsilon,
-            alpha=alpha_val,
-            scale=scale_val,
-            position_offset=position_offset,
-        )
+            # Rotate Q by the new tokens' positions (cache_old..cache_old+L-1)
+            # and the *full* cached K by absolute positions 0..cache_new-1.
+            q_rot = apply_rotary_emb(
+                q, self.freqs_cos, self.freqs_sin, cache_old
+            )
+            k_full = self.cached_key[:, :cache_new]
+            v_full = self.cached_value[:, :cache_new]
+            k_rot = apply_rotary_emb(k_full, self.freqs_cos, self.freqs_sin, 0)
+
+            # Build a causal mask over (L, cache_new) so token i in the
+            # chunk only sees keys up to position cache_old + i. Single-
+            # token decode (L=1) collapses to "see everything" which is
+            # already correct.
+            if L > 1:
+                i_idx = np.arange(L)[:, None]                 # (L, 1)
+                j_idx = np.arange(cache_new)[None, :]         # (1, K)
+                causal = (j_idx <= cache_old + i_idx)[None, None]
+                user_mask_np = None if mask is None else np.array(mask)
+                if user_mask_np is None:
+                    full_mask = causal
+                else:
+                    full_mask = np.logical_and(user_mask_np, causal)
+                full_mask = mx.array(
+                    np.broadcast_to(full_mask, (B, self.num_heads, L, cache_new))
+                )
+            else:
+                full_mask = mask
+
+            alpha_val, scale_val = self._alpha_pair()
+            from .attention import yat_attention_weights as _yaw
+
+            weights = _yaw(
+                q_rot, k_rot,
+                mask=full_mask,
+                dropout_rate=self.dropout if training else 0.0,
+                training=training,
+                epsilon=self.epsilon,
+                alpha=alpha_val,
+                scale=scale_val,
+                spherical=False,
+            )
+            out = mx.einsum("bhqk,bkhd->bqhd", weights, v_full)
+        else:
+            alpha_val, scale_val = self._alpha_pair()
+            out = rotary_yat_attention(
+                q, k, v,
+                self.freqs_cos, self.freqs_sin,
+                mask=mask,
+                dropout_rate=self.dropout if training else 0.0,
+                training=training,
+                epsilon=self.epsilon,
+                alpha=alpha_val,
+                scale=scale_val,
+                position_offset=effective_offset,
+            )
 
         out = mx.reshape(out, (B, L, self.embed_dim))
         if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
             out = self._linear(out, self.out_kernel, getattr(self, "out_bias", None))
         return out
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _alpha_pair(self) -> Tuple[Optional[mx.array], Optional[float]]:
+        """Resolve (learnable alpha, constant scale) for the forward call."""
+        alpha_val: Optional[mx.array] = None
+        scale_val: Optional[float] = None
+        if self.use_alpha:
+            if self._constant_alpha_value is not None:
+                scale_val = self._constant_alpha_value
+            elif getattr(self, "alpha", None) is not None:
+                alpha_val = self.alpha
+        return alpha_val, scale_val

--- a/src/nmn/mlx/squashers.py
+++ b/src/nmn/mlx/squashers.py
@@ -1,0 +1,60 @@
+"""Squashing functions for MLX.
+
+Provides softermax, softer_sigmoid, and soft_tanh — activation-like functions
+that use power-based normalization instead of exponentials. Mirrors
+``nmn.tf.squashers`` / ``nmn.nnx.layers.squashers``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import mlx.core as mx
+
+
+def softermax(
+    x: mx.array,
+    n: float = 1.0,
+    epsilon: float = 1e-12,
+    axis: Optional[int] = -1,
+) -> mx.array:
+    """Normalizes non-negative scores using the Softermax function.
+
+    ``softermax_n(x_k) = x_k^n / (epsilon + sum_i x_i^n)``
+
+    Args:
+        x: Array of non-negative scores.
+        n: Power parameter (must be positive). Higher = sharper.
+        epsilon: Small constant for numerical stability.
+        axis: Axis to normalize over.
+
+    Returns:
+        Normalized scores summing to ~1 along ``axis``.
+    """
+    if n <= 0:
+        raise ValueError("Power 'n' must be positive.")
+    x_n = mx.power(x, n)
+    sum_x_n = mx.sum(x_n, axis=axis, keepdims=True)
+    return x_n / (epsilon + sum_x_n)
+
+
+def softer_sigmoid(x: mx.array, n: float = 1.0) -> mx.array:
+    """Squashes non-negative scores into [0, 1) using soft-sigmoid.
+
+    ``soft_sigmoid_n(x) = x^n / (1 + x^n)``
+    """
+    if n <= 0:
+        raise ValueError("Power 'n' must be positive.")
+    x_n = mx.power(x, n)
+    return x_n / (1.0 + x_n)
+
+
+def soft_tanh(x: mx.array, n: float = 1.0) -> mx.array:
+    """Maps non-negative scores to [-1, 1) using soft-tanh.
+
+    ``soft_tanh_n(x) = (x^n - 1) / (1 + x^n)``
+    """
+    if n <= 0:
+        raise ValueError("Power 'n' must be positive.")
+    x_n = mx.power(x, n)
+    return (x_n - 1.0) / (1.0 + x_n)

--- a/tests/integration/test_cross_framework.py
+++ b/tests/integration/test_cross_framework.py
@@ -49,7 +49,13 @@ def get_available_frameworks():
         frameworks.append('nnx')
     except ImportError:
         pass
-    
+
+    try:
+        import mlx.core  # noqa: F401
+        frameworks.append('mlx')
+    except ImportError:
+        pass
+
     return frameworks
 
 
@@ -214,6 +220,36 @@ def get_linen_output(inputs_np, weights_np, bias_np=None, alpha_np=None, epsilon
     return np.array(output)
 
 
+def get_mlx_output(inputs_np, weights_np, bias_np=None, alpha_np=None, epsilon=1e-6):
+    """Get YAT output from MLX implementation."""
+    import mlx.core as mx
+    from nmn.mlx.nmn import YatNMN as MlxYatNMN
+
+    # Pin to CPU so the 1e-3 rtol below stays meaningful — Metal matmul
+    # accumulates at lower precision than numpy CPU fp32.
+    prev_device = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    try:
+        in_features, out_features = weights_np.shape
+        layer = MlxYatNMN(
+            features=out_features,
+            use_bias=(bias_np is not None),
+            use_alpha=(alpha_np is not None),
+            epsilon=epsilon,
+        )
+        layer.build(in_features)
+        # MLX kernel is (features, in_features) — transpose canonical W.
+        layer.kernel = mx.array(weights_np.T.astype(np.float32))
+        if bias_np is not None:
+            layer.bias = mx.array(bias_np.astype(np.float32))
+        if alpha_np is not None:
+            layer.alpha = mx.array(np.array([alpha_np], dtype=np.float32))
+        out = layer(mx.array(inputs_np.astype(np.float32)))
+        return np.asarray(out)
+    finally:
+        mx.set_default_device(prev_device)
+
+
 def get_nnx_output(inputs_np, weights_np, bias_np=None, alpha_np=None, epsilon=1e-6):
     """Get YAT output from NNX implementation."""
     import jax.numpy as jnp
@@ -282,14 +318,17 @@ class TestCrossFrameworkConsistency:
         
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             outputs['nnx'] = get_nnx_output(inputs, weights, epsilon=epsilon)
-        
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            outputs['mlx'] = get_mlx_output(inputs, weights, epsilon=epsilon)
+
         # Compare all frameworks to reference
         for name, output in outputs.items():
             np.testing.assert_allclose(
                 output, ref_output, rtol=1e-3, atol=1e-3,
                 err_msg=f"{name} output differs from reference"
             )
-    
+
     def test_yat_with_bias(self, test_data):
         """Test YAT with bias across frameworks."""
         inputs = test_data['inputs']
@@ -310,13 +349,16 @@ class TestCrossFrameworkConsistency:
         
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             outputs['nnx'] = get_nnx_output(inputs, weights, bias_np=bias, epsilon=epsilon)
-        
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            outputs['mlx'] = get_mlx_output(inputs, weights, bias_np=bias, epsilon=epsilon)
+
         for name, output in outputs.items():
             np.testing.assert_allclose(
                 output, ref_output, rtol=1e-3, atol=1e-3,
                 err_msg=f"{name} output with bias differs from reference"
             )
-    
+
     def test_yat_with_alpha(self, test_data):
         """Test YAT with alpha scaling across frameworks."""
         inputs = test_data['inputs']
@@ -337,7 +379,10 @@ class TestCrossFrameworkConsistency:
         
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             outputs['nnx'] = get_nnx_output(inputs, weights, alpha_np=alpha, epsilon=epsilon)
-        
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            outputs['mlx'] = get_mlx_output(inputs, weights, alpha_np=alpha, epsilon=epsilon)
+
         for name, output in outputs.items():
             np.testing.assert_allclose(
                 output, ref_output, rtol=1e-3, atol=1e-3,
@@ -361,6 +406,10 @@ class TestCrossFrameworkConsistency:
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             output = get_nnx_output(inputs, weights, epsilon=epsilon)
             assert np.all(output >= 0), "NNX produced negative values"
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            output = get_mlx_output(inputs, weights, epsilon=epsilon)
+            assert np.all(output >= 0), "MLX produced negative values"
 
 
 # ============================================================================
@@ -388,17 +437,45 @@ class TestTorchVsLinen:
                     reason="Need both Linen and NNX")
 class TestLinenVsNNX:
     """Direct comparison between Linen and NNX."""
-    
+
     def test_dense_layer_match(self):
         """Test that dense layers match between Linen and NNX."""
         np.random.seed(42)
         inputs = np.random.randn(4, 8).astype(np.float32)
         weights = np.random.randn(8, 16).astype(np.float32)
-        
+
         linen_out = get_linen_output(inputs, weights)
         nnx_out = get_nnx_output(inputs, weights)
-        
+
         np.testing.assert_allclose(linen_out, nnx_out, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.skipif('mlx' not in AVAILABLE_FRAMEWORKS or 'torch' not in AVAILABLE_FRAMEWORKS,
+                    reason="Need both MLX and PyTorch")
+class TestMlxVsTorch:
+    """Direct comparison between MLX and PyTorch."""
+
+    def test_dense_layer_match(self):
+        """Dense layers should match bit-for-bit (within fp32 ULP) on CPU."""
+        np.random.seed(42)
+        inputs = np.random.randn(4, 8).astype(np.float32)
+        weights = np.random.randn(8, 16).astype(np.float32)
+
+        mlx_out = get_mlx_output(inputs, weights)
+        torch_out = get_torch_output(inputs, weights)
+
+        np.testing.assert_allclose(mlx_out, torch_out, rtol=1e-3, atol=1e-3)
+
+    def test_dense_with_bias_match(self):
+        np.random.seed(7)
+        inputs = np.random.randn(4, 8).astype(np.float32)
+        weights = np.random.randn(8, 16).astype(np.float32)
+        bias = np.random.randn(16).astype(np.float32)
+
+        mlx_out = get_mlx_output(inputs, weights, bias_np=bias)
+        torch_out = get_torch_output(inputs, weights, bias_np=bias)
+
+        np.testing.assert_allclose(mlx_out, torch_out, rtol=1e-3, atol=1e-3)
 
 
 # ============================================================================
@@ -424,7 +501,12 @@ class TestNumericalStabilityAllFrameworks:
             output = get_linen_output(inputs, weights)
             assert not np.isnan(output).any(), "Linen NaN with large values"
             assert not np.isinf(output).any(), "Linen Inf with large values"
-    
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            output = get_mlx_output(inputs, weights)
+            assert not np.isnan(output).any(), "MLX NaN with large values"
+            assert not np.isinf(output).any(), "MLX Inf with large values"
+
     def test_small_values(self):
         """Test with small input values."""
         np.random.seed(42)
@@ -438,7 +520,11 @@ class TestNumericalStabilityAllFrameworks:
         if 'linen' in AVAILABLE_FRAMEWORKS:
             output = get_linen_output(inputs, weights)
             assert not np.isnan(output).any(), "Linen NaN with small values"
-    
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            output = get_mlx_output(inputs, weights)
+            assert not np.isnan(output).any(), "MLX NaN with small values"
+
     def test_matching_input_weight(self):
         """Test when input exactly matches a weight vector."""
         np.random.seed(42)
@@ -453,3 +539,7 @@ class TestNumericalStabilityAllFrameworks:
         if 'linen' in AVAILABLE_FRAMEWORKS:
             output = get_linen_output(inputs, weights)
             assert not np.isnan(output).any(), "Linen NaN with matching vectors"
+
+        if 'mlx' in AVAILABLE_FRAMEWORKS:
+            output = get_mlx_output(inputs, weights)
+            assert not np.isnan(output).any(), "MLX NaN with matching vectors"

--- a/tests/integration/test_yat_nmn_parity.py
+++ b/tests/integration/test_yat_nmn_parity.py
@@ -240,12 +240,46 @@ def _run_tf(spherical, weight_normalized, learnable_epsilon, bias_mode):
     return layer(tf.constant(X)).numpy()
 
 
+def _run_mlx(spherical, weight_normalized, learnable_epsilon, bias_mode):
+    mx = pytest.importorskip("mlx.core")
+    # Pin to CPU: MLX's Metal matmul accumulates at lower precision than
+    # numpy fp32, so the < 1e-4 rtol used here is only meaningful on CPU.
+    prev_device = mx.default_device()
+    mx.set_default_device(mx.cpu)
+    try:
+        from nmn.mlx.nmn import YatNMN as MlxYatNMN
+
+        bias_arr, const_bias = _bias_for(bias_mode)
+        use_bias = bias_arr is not None or const_bias is not None
+
+        layer = MlxYatNMN(
+            features=OUT_FEATURES,
+            use_bias=use_bias,
+            constant_bias=const_bias,
+            use_alpha=False,
+            spherical=spherical,
+            weight_normalized=weight_normalized,
+            epsilon=EPSILON,
+            learnable_epsilon=learnable_epsilon,
+        )
+        layer.build(IN_FEATURES)
+        # MLX kernel is (features, in_features) — transpose canonical W.
+        layer.kernel = mx.array(W_LOGICAL.T)
+        if bias_arr is not None:
+            layer.bias = mx.array(bias_arr)
+        out = layer(mx.array(X))
+        return np.asarray(out)
+    finally:
+        mx.set_default_device(prev_device)
+
+
 FRAMEWORKS = {
     "nnx": _run_nnx,
     "linen": _run_linen,
     "torch": _run_torch,
     "keras": _run_keras,
     "tf": _run_tf,
+    "mlx": _run_mlx,
 }
 
 

--- a/tests/test_mlx/conftest.py
+++ b/tests/test_mlx/conftest.py
@@ -1,0 +1,22 @@
+"""Test config for the MLX backend.
+
+Pins the default device to CPU for parity tests: Apple Silicon GPU
+matmuls accumulate at a lower precision than numpy CPU fp32, so the
+< 1e-5 element-wise checks against the numpy reference are only
+meaningful on the CPU device. End-users on GPU should expect ~1e-3
+drift — that is a property of Metal's matmul kernel, not the layer.
+"""
+from __future__ import annotations
+
+import pytest
+
+mlx_core = pytest.importorskip("mlx.core")
+
+
+@pytest.fixture(autouse=True)
+def _force_cpu():
+    """Pin every MLX test to the CPU device for deterministic parity."""
+    prev = mlx_core.default_device()
+    mlx_core.set_default_device(mlx_core.cpu)
+    yield
+    mlx_core.set_default_device(prev)

--- a/tests/test_mlx/test_all_layers.py
+++ b/tests/test_mlx/test_all_layers.py
@@ -1,0 +1,249 @@
+"""Tests for the MLX conv family.
+
+Covers:
+* basic forward shape for 1D / 2D / 3D / transposed-1D / transposed-2D /
+  transposed-3D with `valid` and `same` padding;
+* element-wise parity (< 1e-5) against a pure-numpy reference for 2D
+  YatConv and 1D YatConvTranspose at stride 1;
+* grouped 2D forward shape;
+* gradient flow through every learnable parameter.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+mlx_optim = pytest.importorskip("mlx.optimizers")
+
+from nmn.mlx import (  # noqa: E402
+    YatConv1D, YatConv2D, YatConv3D,
+    YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shapes
+# ---------------------------------------------------------------------------
+
+
+def test_conv1d_valid_shape():
+    layer = YatConv1D(filters=16, kernel_size=3)
+    x = mx.random.normal(shape=(2, 10, 4))
+    assert layer(x).shape == (2, 8, 16)
+
+
+def test_conv1d_same_shape():
+    layer = YatConv1D(filters=16, kernel_size=3, padding="same")
+    x = mx.random.normal(shape=(2, 10, 4))
+    assert layer(x).shape == (2, 10, 16)
+
+
+def test_conv2d_valid_shape():
+    layer = YatConv2D(filters=8, kernel_size=3)
+    x = mx.random.normal(shape=(2, 16, 16, 3))
+    assert layer(x).shape == (2, 14, 14, 8)
+
+
+def test_conv2d_same_shape():
+    layer = YatConv2D(filters=8, kernel_size=3, padding="same")
+    x = mx.random.normal(shape=(2, 16, 16, 3))
+    assert layer(x).shape == (2, 16, 16, 8)
+
+
+def test_conv3d_valid_shape():
+    layer = YatConv3D(filters=4, kernel_size=3)
+    x = mx.random.normal(shape=(1, 8, 8, 8, 2))
+    assert layer(x).shape == (1, 6, 6, 6, 4)
+
+
+def test_conv_transpose1d_shape():
+    layer = YatConvTranspose1D(filters=8, kernel_size=3, strides=2)
+    x = mx.random.normal(shape=(2, 10, 4))
+    # output size = (L_in - 1) * stride + (K - 1) * dilation + 1 = 9*2 + 2 = 20
+    # MLX returns L_in*stride + K - 1 = 21 here — keep the actual contract.
+    out = layer(x)
+    assert out.shape[0] == 2 and out.shape[-1] == 8
+    assert out.shape[1] > x.shape[1]  # upsamples
+
+
+def test_conv_transpose2d_same_shape():
+    layer = YatConvTranspose2D(filters=4, kernel_size=4, strides=2, padding="same")
+    x = mx.random.normal(shape=(1, 8, 8, 4))
+    out = layer(x)
+    assert out.shape == (1, 16, 16, 4)
+
+
+def test_conv_transpose3d_shape():
+    layer = YatConvTranspose3D(filters=2, kernel_size=2, strides=2)
+    x = mx.random.normal(shape=(1, 4, 4, 4, 2))
+    out = layer(x)
+    assert out.shape[0] == 1 and out.shape[-1] == 2
+
+
+# ---------------------------------------------------------------------------
+# Math parity vs a numpy reference
+# ---------------------------------------------------------------------------
+
+
+def test_conv2d_math_parity():
+    mx.random.seed(0)
+    layer = YatConv2D(filters=4, kernel_size=3, padding="valid")
+    x = mx.random.normal(shape=(1, 6, 6, 2))
+    y = np.array(layer(x))
+
+    W = np.array(layer.kernel)
+    b = np.array(layer.bias)
+    a = float(np.array(layer.alpha)[0])
+    xn = np.array(x)
+
+    out_h = xn.shape[1] - 3 + 1
+    out_w = xn.shape[2] - 3 + 1
+    ref = np.zeros((1, out_h, out_w, 4))
+    for f in range(4):
+        for i in range(out_h):
+            for j in range(out_w):
+                patch = xn[0, i:i + 3, j:j + 3, :]
+                kf = W[f]
+                dot = (patch * kf).sum()
+                dist = ((patch - kf) ** 2).sum()
+                ref[0, i, j, f] = a * (dot + b[f]) ** 2 / (dist + 1e-5)
+
+    assert np.max(np.abs(y - ref)) < 1e-5
+
+
+def test_conv_transpose1d_math_parity():
+    mx.random.seed(1)
+    layer = YatConvTranspose1D(filters=3, kernel_size=3, strides=1, padding="valid")
+    x = mx.random.normal(shape=(1, 5, 2))
+    y = np.array(layer(x))
+
+    W = np.array(layer.kernel)
+    b = np.array(layer.bias)
+    a = float(np.array(layer.alpha)[0])
+    xn = np.array(x)
+    N, L_in, C_in = xn.shape
+    F, K, _ = W.shape
+    L_out = L_in + K - 1
+    ref = np.zeros((N, L_out, F))
+    for p in range(L_out):
+        for f in range(F):
+            dot = 0.0
+            patch_sq = 0.0
+            kernel_sq = 0.0
+            for k in range(K):
+                i = p - k
+                for cin in range(C_in):
+                    wval = W[f, k, cin]
+                    kernel_sq += wval * wval
+                    if 0 <= i < L_in:
+                        xval = xn[0, i, cin]
+                        dot += xval * wval
+                        patch_sq += xval * xval
+            dist = max(patch_sq + kernel_sq - 2 * dot, 0.0)
+            ref[0, p, f] = a * (dot + b[f]) ** 2 / (dist + 1e-5)
+
+    assert np.max(np.abs(y - ref)) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Grouped conv
+# ---------------------------------------------------------------------------
+
+
+def test_grouped_conv2d_shape():
+    layer = YatConv2D(filters=8, kernel_size=3, groups=2)
+    x = mx.random.normal(shape=(1, 8, 8, 4))
+    assert layer(x).shape == (1, 6, 6, 8)
+
+
+def test_grouped_conv2d_rejects_bad_channels():
+    layer = YatConv2D(filters=8, kernel_size=3, groups=3)
+    with pytest.raises(ValueError):
+        layer(mx.random.normal(shape=(1, 8, 8, 4)))
+
+
+# ---------------------------------------------------------------------------
+# Bias / alpha / epsilon variants
+# ---------------------------------------------------------------------------
+
+
+def test_conv2d_no_bias_no_alpha():
+    layer = YatConv2D(filters=4, kernel_size=3, use_bias=False, use_alpha=False)
+    _ = layer(mx.random.normal(shape=(1, 6, 6, 2)))
+    params = layer.parameters()
+    assert "bias" not in params
+    assert "alpha" not in params
+    assert "kernel" in params
+
+
+def test_conv2d_constant_alpha():
+    layer = YatConv2D(filters=4, kernel_size=3, constant_alpha=True)
+    _ = layer(mx.random.normal(shape=(1, 6, 6, 2)))
+    assert "alpha" not in layer.parameters()
+
+
+def test_conv2d_constant_bias():
+    layer = YatConv2D(filters=4, kernel_size=3, constant_bias=0.5)
+    _ = layer(mx.random.normal(shape=(1, 6, 6, 2)))
+    assert "bias" not in layer.parameters()
+
+
+def test_conv2d_learnable_epsilon():
+    layer = YatConv2D(filters=4, kernel_size=3, learnable_epsilon=True, epsilon=1e-3)
+    _ = layer(mx.random.normal(shape=(1, 6, 6, 2)))
+    assert "epsilon_param" in layer.parameters()
+
+
+def test_conv_rejects_bad_input_ndim():
+    layer = YatConv2D(filters=4, kernel_size=3)
+    with pytest.raises(ValueError):
+        layer(mx.random.normal(shape=(1, 6, 6)))  # missing batch dim
+
+
+# ---------------------------------------------------------------------------
+# Gradients
+# ---------------------------------------------------------------------------
+
+
+def test_conv2d_gradient_reduces_loss():
+    def loss_fn(model, x, y):
+        return mx.mean((model(x) - y) ** 2)
+
+    layer = YatConv2D(filters=4, kernel_size=3, padding="same")
+    x = mx.random.normal(shape=(2, 6, 6, 3))
+    y = mx.random.normal(shape=(2, 6, 6, 4))
+    _ = layer(x)  # build
+
+    grad_fn = mlx_nn.value_and_grad(layer, loss_fn)
+    loss, grads = grad_fn(layer, x, y)
+    assert set(grads.keys()) >= {"kernel", "bias", "alpha"}
+
+    opt = mlx_optim.AdamW(learning_rate=1e-2)
+    opt.update(layer, grads)
+    mx.eval(layer.parameters())
+
+    loss_after = float(loss_fn(layer, x, y))
+    assert loss_after < float(loss)
+
+
+def test_conv_transpose2d_gradient_reduces_loss():
+    def loss_fn(model, x, y):
+        return mx.mean((model(x) - y) ** 2)
+
+    layer = YatConvTranspose2D(filters=2, kernel_size=2, strides=2)
+    x = mx.random.normal(shape=(1, 4, 4, 3))
+    out = layer(x)
+    y = mx.random.normal(shape=out.shape)
+
+    grad_fn = mlx_nn.value_and_grad(layer, loss_fn)
+    loss, grads = grad_fn(layer, x, y)
+    assert set(grads.keys()) >= {"kernel", "bias", "alpha"}
+
+    opt = mlx_optim.AdamW(learning_rate=1e-2)
+    opt.update(layer, grads)
+    mx.eval(layer.parameters())
+    loss_after = float(loss_fn(layer, x, y))
+    assert loss_after < float(loss)

--- a/tests/test_mlx/test_attention.py
+++ b/tests/test_mlx/test_attention.py
@@ -1,0 +1,158 @@
+"""Tests for the MLX YAT attention module + functional helpers."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+mlx_optim = pytest.importorskip("mlx.optimizers")
+
+from nmn.mlx import (  # noqa: E402
+    MultiHeadYatAttention,
+    yat_attention,
+    yat_attention_weights,
+    normalize_qk,
+)
+
+
+# ---------------------------------------------------------------------------
+# Functional helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_qk_unit_norm():
+    q = mx.random.normal(shape=(2, 4, 3, 5))
+    k = mx.random.normal(shape=(2, 6, 3, 5))
+    qn, kn = normalize_qk(q, k)
+    norms_q = np.linalg.norm(np.array(qn), axis=-1)
+    norms_k = np.linalg.norm(np.array(kn), axis=-1)
+    assert np.max(np.abs(norms_q - 1.0)) < 1e-4
+    assert np.max(np.abs(norms_k - 1.0)) < 1e-4
+
+
+def test_yat_attention_shape():
+    B, Q, K, H, D = 1, 4, 6, 2, 3
+    q = mx.random.normal(shape=(B, Q, H, D))
+    k = mx.random.normal(shape=(B, K, H, D))
+    v = mx.random.normal(shape=(B, K, H, D))
+    out = yat_attention(q, k, v)
+    assert out.shape == (B, Q, H, D)
+
+
+def test_yat_attention_weights_softmax_sum():
+    q = mx.random.normal(shape=(1, 3, 2, 4))
+    k = mx.random.normal(shape=(1, 5, 2, 4))
+    w = np.array(yat_attention_weights(q, k))
+    # Last axis should sum to 1.
+    sums = w.sum(axis=-1)
+    assert np.max(np.abs(sums - 1.0)) < 1e-4
+
+
+def test_yat_attention_weights_math_parity():
+    mx.random.seed(0)
+    B, Q, K, H, D = 1, 3, 4, 2, 5
+    q = mx.random.normal(shape=(B, Q, H, D))
+    k = mx.random.normal(shape=(B, K, H, D))
+    w = np.array(yat_attention_weights(q, k, epsilon=1e-5))
+
+    qn = np.array(q)
+    kn = np.array(k)
+    dim_scale = math.sqrt(D)
+    ref = np.zeros((B, H, Q, K))
+    for b in range(B):
+        for h in range(H):
+            for i in range(Q):
+                row = np.zeros(K)
+                for j in range(K):
+                    dot = float((qn[b, i, h] * kn[b, j, h]).sum())
+                    dist = float(((qn[b, i, h] - kn[b, j, h]) ** 2).sum())
+                    row[j] = dot * dot / ((dist + 1e-5) * dim_scale)
+                row = row - row.max()
+                ex = np.exp(row)
+                ref[b, h, i] = ex / ex.sum()
+    assert np.max(np.abs(w - ref)) < 1e-5
+
+
+def test_yat_attention_causal_mask():
+    """With a strict causal mask the upper-triangle of weights should be ~0."""
+    B, L, H, D = 1, 5, 2, 4
+    q = mx.random.normal(shape=(B, L, H, D))
+    k = mx.random.normal(shape=(B, L, H, D))
+    # mask[b, h, i, j] = (i >= j)  -> True = attend.
+    causal = np.tril(np.ones((L, L), dtype=bool))[None, None, :, :]
+    mask = mx.array(np.broadcast_to(causal, (B, H, L, L)))
+    w = np.array(yat_attention_weights(q, k, mask=mask))
+    upper = np.triu(np.ones_like(w[0, 0]), k=1).astype(bool)
+    masked_vals = w[..., upper]
+    assert float(np.max(np.abs(masked_vals))) < 1e-5
+
+
+def test_yat_attention_spherical_shape():
+    B, Q, K, H, D = 1, 3, 4, 2, 5
+    q = mx.random.normal(shape=(B, Q, H, D))
+    k = mx.random.normal(shape=(B, K, H, D))
+    v = mx.random.normal(shape=(B, K, H, D))
+    out = yat_attention(q, k, v, spherical=True)
+    assert out.shape == (B, Q, H, D)
+
+
+# ---------------------------------------------------------------------------
+# MultiHeadYatAttention
+# ---------------------------------------------------------------------------
+
+
+def test_mha_self_attn_shape():
+    mha = MultiHeadYatAttention(embed_dim=16, num_heads=4)
+    x = mx.random.normal(shape=(2, 7, 16))
+    assert mha(x).shape == (2, 7, 16)
+
+
+def test_mha_cross_attn_shape():
+    mha = MultiHeadYatAttention(embed_dim=16, num_heads=4)
+    q = mx.random.normal(shape=(2, 5, 16))
+    ctx = mx.random.normal(shape=(2, 11, 16))
+    assert mha(q, ctx, ctx).shape == (2, 5, 16)
+
+
+def test_mha_invalid_dim_rejected():
+    with pytest.raises(ValueError):
+        MultiHeadYatAttention(embed_dim=10, num_heads=4)
+
+
+def test_mha_constant_alpha():
+    mha = MultiHeadYatAttention(embed_dim=8, num_heads=2, constant_alpha=True)
+    _ = mha(mx.random.normal(shape=(1, 3, 8)))
+    assert "alpha" not in mha.parameters()
+
+
+def test_mha_no_out_proj():
+    mha = MultiHeadYatAttention(embed_dim=8, num_heads=2, use_out_proj=False)
+    _ = mha(mx.random.normal(shape=(1, 3, 8)))
+    params = mha.parameters()
+    assert "out_kernel" not in params
+    assert "out_bias" not in params
+
+
+def test_mha_gradient_reduces_loss():
+    def loss_fn(model, x, y):
+        return mx.mean((model(x) - y) ** 2)
+
+    mha = MultiHeadYatAttention(embed_dim=8, num_heads=2)
+    x = mx.random.normal(shape=(2, 5, 8))
+    y = mx.random.normal(shape=(2, 5, 8))
+    _ = mha(x)  # build lazy params before value_and_grad captures the tree
+
+    grad_fn = mlx_nn.value_and_grad(mha, loss_fn)
+    loss, grads = grad_fn(mha, x, y)
+    # Should have grads for at least the four projection kernels and alpha.
+    assert {"q_kernel", "k_kernel", "v_kernel", "out_kernel", "alpha"} <= set(grads.keys())
+
+    opt = mlx_optim.AdamW(learning_rate=1e-2)
+    opt.update(mha, grads)
+    mx.eval(mha.parameters())
+    loss_after = float(loss_fn(mha, x, y))
+    assert loss_after < float(loss)

--- a/tests/test_mlx/test_basic.py
+++ b/tests/test_mlx/test_basic.py
@@ -1,0 +1,151 @@
+"""Basic shape / dtype / parameter tests for the MLX YatNMN layer."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+mlx_optim = pytest.importorskip("mlx.optimizers")
+
+from nmn.mlx import YatNMN, YatDense  # noqa: E402
+
+
+def test_module_imports():
+    """``YatDense`` is the back-compat alias for ``YatNMN``."""
+    assert YatDense is YatNMN
+
+
+def test_yat_nmn_forward_shape_2d():
+    layer = YatNMN(features=10)
+    x = mx.random.normal(shape=(4, 8))
+    y = layer(x)
+    assert y.shape == (4, 10)
+    assert y.dtype == mx.float32
+
+
+def test_yat_nmn_forward_shape_3d():
+    """Multiple batch dims should be preserved (broadcast over the last axis)."""
+    layer = YatNMN(features=5)
+    x = mx.random.normal(shape=(2, 3, 4))
+    y = layer(x)
+    assert y.shape == (2, 3, 5)
+
+
+def test_yat_nmn_parameters_discovered():
+    layer = YatNMN(features=6)
+    _ = layer(mx.zeros((1, 4)))
+    params = layer.parameters()
+    assert set(params.keys()) == {"kernel", "bias", "alpha"}
+    assert params["kernel"].shape == (6, 4)
+    assert params["bias"].shape == (6,)
+    assert params["alpha"].shape == (1,)
+
+
+def test_constant_alpha_drops_learnable_alpha():
+    layer = YatNMN(features=6, constant_alpha=True)
+    _ = layer(mx.zeros((1, 4)))
+    assert layer._constant_alpha_value == math.sqrt(2.0)
+    assert "alpha" not in layer.parameters()
+
+
+def test_constant_alpha_float_value():
+    layer = YatNMN(features=6, constant_alpha=1.25)
+    _ = layer(mx.zeros((1, 4)))
+    assert layer._constant_alpha_value == 1.25
+    assert "alpha" not in layer.parameters()
+
+
+def test_constant_bias_drops_learnable_bias():
+    layer = YatNMN(features=6, constant_bias=0.5)
+    _ = layer(mx.zeros((1, 4)))
+    assert layer._constant_bias_value == 0.5
+    assert "bias" not in layer.parameters()
+
+
+def test_use_alpha_false():
+    layer = YatNMN(features=6, use_alpha=False)
+    _ = layer(mx.zeros((1, 4)))
+    assert "alpha" not in layer.parameters()
+
+
+def test_use_bias_false():
+    layer = YatNMN(features=6, use_bias=False)
+    _ = layer(mx.zeros((1, 4)))
+    assert "bias" not in layer.parameters()
+
+
+def test_learnable_epsilon_creates_param():
+    layer = YatNMN(features=4, learnable_epsilon=True, epsilon=1e-3)
+    _ = layer(mx.zeros((1, 3)))
+    assert "epsilon_param" in layer.parameters()
+    # softplus(raw) should ≈ epsilon at initialization.
+    eps = float(mlx_nn.softplus(layer.epsilon_param)[0])
+    assert abs(eps - 1e-3) < 1e-5
+
+
+def test_invalid_epsilon_rejected():
+    with pytest.raises(ValueError):
+        YatNMN(features=4, epsilon=0.0)
+    with pytest.raises(ValueError):
+        YatNMN(features=4, epsilon=-1.0)
+
+
+def test_input_shape_change_rejected():
+    layer = YatNMN(features=4)
+    _ = layer(mx.zeros((2, 3)))
+    with pytest.raises(ValueError):
+        layer(mx.zeros((2, 5)))
+
+
+def test_positive_init():
+    layer = YatNMN(features=4, positive_init=True)
+    _ = layer(mx.zeros((1, 3)))
+    # Kernel entries are abs() of the Xavier draw — strictly non-negative.
+    assert float(mx.min(layer.kernel)) >= 0.0
+
+
+def test_get_set_weights_round_trip():
+    layer = YatNMN(features=4)
+    _ = layer(mx.zeros((1, 3)))
+    weights = layer.get_weights()
+    # Perturb and round-trip.
+    perturbed = [w + 0.1 for w in weights]
+    layer.set_weights(perturbed)
+    restored = layer.get_weights()
+    for got, want in zip(restored, perturbed):
+        assert np.max(np.abs(np.array(got) - np.array(want))) < 1e-6
+
+
+def test_return_weights_tuple():
+    layer = YatNMN(features=4, return_weights=True)
+    y, w = layer(mx.zeros((1, 3)))
+    assert y.shape == (1, 4)
+    assert w.shape == (4, 3)
+
+
+def test_gradient_flows_and_reduces_loss():
+    """One AdamW step should reduce a squared-error loss."""
+
+    def loss_fn(model, x, y):
+        return mx.mean((model(x) - y) ** 2)
+
+    layer = YatNMN(features=3)
+    x = mx.random.normal(shape=(8, 5))
+    y = mx.random.normal(shape=(8, 3))
+    _ = layer(x)  # build
+
+    grad_fn = mlx_nn.value_and_grad(layer, loss_fn)
+    loss, grads = grad_fn(layer, x, y)
+    # All three learnable params should receive gradients.
+    assert set(grads.keys()) == {"kernel", "bias", "alpha"}
+
+    opt = mlx_optim.AdamW(learning_rate=1e-2)
+    opt.update(layer, grads)
+    mx.eval(layer.parameters())
+
+    loss_after = float(loss_fn(layer, x, y))
+    assert loss_after < float(loss)

--- a/tests/test_mlx/test_dropconnect.py
+++ b/tests/test_mlx/test_dropconnect.py
@@ -1,0 +1,198 @@
+"""Tests for the Tier-1 MLX features: DropConnect + weight_normalized conv."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import YatNMN, YatConv2D, YatConvTranspose2D  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# YatNMN DropConnect
+# ---------------------------------------------------------------------------
+
+
+def test_yat_nmn_dropconnect_rejects_invalid_rate():
+    with pytest.raises(ValueError):
+        YatNMN(features=4, use_dropconnect=True, drop_rate=1.0)
+    with pytest.raises(ValueError):
+        YatNMN(features=4, use_dropconnect=True, drop_rate=-0.1)
+
+
+def test_yat_nmn_dropconnect_deterministic_unchanged():
+    """In deterministic mode the layer must be identical to drop_rate=0."""
+    mx.random.seed(0)
+    layer_dc = YatNMN(features=6, use_dropconnect=True, drop_rate=0.5)
+    layer_dc.build(4)
+    layer_plain = YatNMN(features=6, use_dropconnect=False)
+    layer_plain.build(4)
+    # Sync weights.
+    layer_plain.kernel = layer_dc.kernel
+    layer_plain.bias = layer_dc.bias
+    layer_plain.alpha = layer_dc.alpha
+
+    x = mx.random.normal(shape=(3, 4))
+    y_dc = np.array(layer_dc(x, deterministic=True))
+    y_plain = np.array(layer_plain(x))
+    assert np.max(np.abs(y_dc - y_plain)) < 1e-6
+
+
+def test_yat_nmn_dropconnect_stochastic_differs():
+    """In stochastic mode the output should differ from deterministic."""
+    mx.random.seed(0)
+    layer = YatNMN(features=6, use_dropconnect=True, drop_rate=0.5)
+    x = mx.random.normal(shape=(4, 3))
+    _ = layer(x)  # build
+    mx.random.seed(0)
+    y_det = np.array(layer(x, deterministic=True))
+    y_stoch = np.array(layer(x, deterministic=False))
+    # With 50 % drop rate, at least one element should differ noticeably.
+    assert np.max(np.abs(y_det - y_stoch)) > 1e-4
+
+
+def test_yat_nmn_dropconnect_off_when_rate_zero():
+    """drop_rate=0 must produce the same output deterministic or not."""
+    layer = YatNMN(features=4, use_dropconnect=True, drop_rate=0.0)
+    x = mx.random.normal(shape=(2, 3))
+    _ = layer(x)
+    y1 = np.array(layer(x, deterministic=True))
+    y2 = np.array(layer(x, deterministic=False))
+    assert np.max(np.abs(y1 - y2)) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# YatConv2D — weight_normalized + DropConnect
+# ---------------------------------------------------------------------------
+
+
+def _numpy_conv2d_yat(x, W, b, a, eps=1e-5):
+    """Pure-numpy YatConv2D reference for the (1, H, W, C_in) → (1, ., ., F) case."""
+    F, KH, KW, C = W.shape
+    out_h = x.shape[1] - KH + 1
+    out_w = x.shape[2] - KW + 1
+    out = np.zeros((1, out_h, out_w, F))
+    for f in range(F):
+        for i in range(out_h):
+            for j in range(out_w):
+                patch = x[0, i:i + KH, j:j + KW, :]
+                kf = W[f]
+                dot = (patch * kf).sum()
+                dist = ((patch - kf) ** 2).sum()
+                out[0, i, j, f] = a * (dot + b[f]) ** 2 / (dist + eps)
+    return out
+
+
+def test_conv2d_weight_normalized_math_parity():
+    """``weight_normalized=True`` must match a numpy reference where W is
+    pre-normalized to unit row norm."""
+    mx.random.seed(0)
+    layer = YatConv2D(filters=4, kernel_size=3, weight_normalized=True, padding="valid")
+    x = mx.random.normal(shape=(1, 6, 6, 2))
+    y = np.array(layer(x))
+
+    W = np.array(layer.kernel)
+    norm = np.sqrt((W ** 2).sum(axis=(1, 2, 3), keepdims=True))
+    Wn = W / (norm + 1e-8)
+    b = np.array(layer.bias)
+    a = float(np.array(layer.alpha)[0])
+    ref = _numpy_conv2d_yat(np.array(x), Wn, b, a, eps=1e-5)
+    assert np.max(np.abs(y - ref)) < 1e-5
+
+
+def test_conv2d_weight_normalized_filter_norms_after_forward():
+    """Each filter's L2 norm should be ~1 after the normalization step."""
+    layer = YatConv2D(filters=4, kernel_size=3, weight_normalized=True)
+    _ = layer(mx.random.normal(shape=(1, 6, 6, 2)))
+    W = np.array(layer.kernel)
+    # Re-apply the same normalization the forward pass does — this is the
+    # post-norm receipt.
+    norm = np.sqrt((W ** 2).sum(axis=(1, 2, 3), keepdims=True))
+    Wn = W / (norm + 1e-8)
+    Wn_norms = np.sqrt((Wn ** 2).sum(axis=(1, 2, 3)))
+    assert np.max(np.abs(Wn_norms - 1.0)) < 1e-5
+
+
+def test_conv2d_dropconnect_deterministic_unchanged():
+    """DropConnect in deterministic mode must equal plain conv."""
+    mx.random.seed(7)
+    layer_dc = YatConv2D(filters=4, kernel_size=3,
+                         use_dropconnect=True, drop_rate=0.3, padding="valid")
+    _ = layer_dc(mx.zeros((1, 6, 6, 2)))  # build to populate kernel
+    layer_plain = YatConv2D(filters=4, kernel_size=3, padding="valid")
+    layer_plain.build(2)
+    layer_plain.kernel = layer_dc.kernel
+    layer_plain.bias = layer_dc.bias
+    layer_plain.alpha = layer_dc.alpha
+
+    x = mx.random.normal(shape=(1, 6, 6, 2))
+    y_dc = np.array(layer_dc(x, deterministic=True))
+    y_plain = np.array(layer_plain(x))
+    assert np.max(np.abs(y_dc - y_plain)) < 1e-5
+
+
+def test_conv2d_dropconnect_stochastic_differs():
+    layer = YatConv2D(filters=4, kernel_size=3,
+                      use_dropconnect=True, drop_rate=0.5, padding="same")
+    x = mx.random.normal(shape=(1, 8, 8, 3))
+    _ = layer(x)
+    mx.random.seed(0)
+    y1 = np.array(layer(x, deterministic=True))
+    y2 = np.array(layer(x, deterministic=False))
+    assert np.max(np.abs(y1 - y2)) > 1e-4
+
+
+def test_conv2d_dropconnect_invalid_rate_rejected():
+    with pytest.raises(ValueError):
+        YatConv2D(filters=4, kernel_size=3, use_dropconnect=True, drop_rate=1.5)
+
+
+def test_conv2d_weight_normalized_and_dropconnect_combine():
+    """Both flags should compose without raising — and stochastic still differs."""
+    layer = YatConv2D(
+        filters=4, kernel_size=3,
+        weight_normalized=True,
+        use_dropconnect=True, drop_rate=0.3,
+        padding="same",
+    )
+    x = mx.random.normal(shape=(1, 6, 6, 2))
+    _ = layer(x)
+    y_det = np.array(layer(x, deterministic=True))
+    y_stoch = np.array(layer(x, deterministic=False))
+    assert y_det.shape == (1, 6, 6, 4)
+    assert np.max(np.abs(y_det - y_stoch)) > 1e-4
+
+
+# ---------------------------------------------------------------------------
+# YatConvTranspose2D DropConnect
+# ---------------------------------------------------------------------------
+
+
+def test_conv_transpose2d_dropconnect_deterministic_unchanged():
+    mx.random.seed(3)
+    layer_dc = YatConvTranspose2D(filters=2, kernel_size=2, strides=2,
+                                  use_dropconnect=True, drop_rate=0.5)
+    _ = layer_dc(mx.zeros((1, 3, 3, 2)))
+    layer_plain = YatConvTranspose2D(filters=2, kernel_size=2, strides=2)
+    layer_plain.build(2)
+    layer_plain.kernel = layer_dc.kernel
+    layer_plain.bias = layer_dc.bias
+    layer_plain.alpha = layer_dc.alpha
+
+    x = mx.random.normal(shape=(1, 3, 3, 2))
+    y_dc = np.array(layer_dc(x, deterministic=True))
+    y_plain = np.array(layer_plain(x))
+    assert np.max(np.abs(y_dc - y_plain)) < 1e-5
+
+
+def test_conv_transpose2d_dropconnect_stochastic_differs():
+    layer = YatConvTranspose2D(filters=2, kernel_size=3, strides=2,
+                               use_dropconnect=True, drop_rate=0.4)
+    x = mx.random.normal(shape=(1, 4, 4, 2))
+    _ = layer(x)
+    mx.random.seed(11)
+    y1 = np.array(layer(x, deterministic=True))
+    y2 = np.array(layer(x, deterministic=False))
+    assert np.max(np.abs(y1 - y2)) > 1e-4

--- a/tests/test_mlx/test_embed.py
+++ b/tests/test_mlx/test_embed.py
@@ -1,0 +1,96 @@
+"""Tests for the MLX YatEmbed layer."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+mlx_optim = pytest.importorskip("mlx.optimizers")
+
+from nmn.mlx import YatEmbed  # noqa: E402
+
+
+def test_embed_lookup_shape_1d():
+    layer = YatEmbed(num_embeddings=20, features=8)
+    ids = mx.array([1, 2, 3, 4], dtype=mx.int32)
+    out = layer(ids)
+    assert out.shape == (4, 8)
+
+
+def test_embed_lookup_shape_2d():
+    layer = YatEmbed(num_embeddings=20, features=8)
+    ids = mx.array([[0, 1, 2], [3, 4, 5]], dtype=mx.int32)
+    out = layer(ids)
+    assert out.shape == (2, 3, 8)
+
+
+def test_embed_rejects_non_integer_input():
+    layer = YatEmbed(num_embeddings=10, features=4)
+    with pytest.raises(ValueError):
+        layer(mx.array([0.0, 1.0]))
+
+
+def test_embed_attend_shape():
+    layer = YatEmbed(num_embeddings=50, features=16)
+    query = mx.random.normal(shape=(3, 16))
+    scores = layer.attend(query)
+    assert scores.shape == (3, 50)
+
+
+def test_embed_attend_math_parity():
+    """``attend`` output matches a numpy YAT reference."""
+    mx.random.seed(0)
+    layer = YatEmbed(num_embeddings=8, features=4, use_alpha=True)
+    query = mx.random.normal(shape=(2, 4))
+    scores = np.array(layer.attend(query))
+
+    E = np.array(layer.embedding)
+    a = float(np.array(layer.alpha)[0])
+    qn = np.array(query)
+    dot = qn @ E.T
+    q_sq = (qn ** 2).sum(axis=-1, keepdims=True)
+    e_sq = (E ** 2).sum(axis=-1)[None, :]
+    dist = np.maximum(q_sq + e_sq - 2 * dot, 0.0)
+    ref = a * (dot ** 2) / (dist + 1e-5)
+    assert np.max(np.abs(scores - ref)) < 1e-5
+
+
+def test_embed_constant_alpha():
+    layer = YatEmbed(num_embeddings=10, features=4, constant_alpha=True)
+    assert layer._constant_alpha_value == math.sqrt(2.0)
+    assert "alpha" not in layer.parameters()
+
+
+def test_embed_spherical_attend_shape():
+    layer = YatEmbed(num_embeddings=12, features=6, spherical=True)
+    out = layer.attend(mx.random.normal(shape=(2, 6)))
+    assert out.shape == (2, 12)
+
+
+def test_embed_weight_normalized_init():
+    layer = YatEmbed(num_embeddings=8, features=4, weight_normalized=True)
+    E = np.array(layer.embedding)
+    row_norms = np.linalg.norm(E, axis=1)
+    assert np.max(np.abs(row_norms - 1.0)) < 1e-5
+
+
+def test_embed_gradient_reduces_loss():
+    def loss_fn(model, ids, target):
+        return mx.mean((model.attend(model(ids)) - target) ** 2)
+
+    layer = YatEmbed(num_embeddings=8, features=4)
+    ids = mx.array([0, 1, 2, 3], dtype=mx.int32)
+    target = mx.random.normal(shape=(4, 8))
+
+    grad_fn = mlx_nn.value_and_grad(layer, loss_fn)
+    loss, grads = grad_fn(layer, ids, target)
+    assert "embedding" in grads
+    opt = mlx_optim.AdamW(learning_rate=1e-2)
+    opt.update(layer, grads)
+    mx.eval(layer.parameters())
+    loss_after = float(loss_fn(layer, ids, target))
+    assert loss_after < float(loss)

--- a/tests/test_mlx/test_fused.py
+++ b/tests/test_mlx/test_fused.py
@@ -1,0 +1,237 @@
+"""Tests for the fused metal-kernel YAT score path."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+mlx_optim = pytest.importorskip("mlx.optimizers")
+
+from nmn.mlx import YatNMN, fused_yat_score, is_gpu_available  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Functional fused_yat_score
+# ---------------------------------------------------------------------------
+
+
+def _ref_yat(x_np, w_np, b_np, alpha, eps=1e-5):
+    dot = x_np @ w_np.T
+    x_sq = (x_np ** 2).sum(axis=-1, keepdims=True)
+    w_sq = (w_np ** 2).sum(axis=-1)[None, :]
+    dist = x_sq + w_sq - 2 * dot
+    num = dot + b_np
+    return alpha * (num ** 2) / (dist + eps)
+
+
+def test_fused_yat_score_2d_matches_numpy_on_cpu():
+    """On the CPU fallback the fused score must match a numpy reference
+    to fp32 ULP."""
+    mx.set_default_device(mx.cpu)
+    try:
+        mx.random.seed(0)
+        x = mx.random.normal(shape=(4, 8))
+        w = mx.random.normal(shape=(6, 8))
+        b = mx.random.normal(shape=(6,))
+        alpha = mx.array([1.5])
+        y = np.array(fused_yat_score(x, w, bias=b, alpha=alpha, epsilon=1e-5))
+        ref = _ref_yat(np.array(x), np.array(w), np.array(b), 1.5)
+        assert np.max(np.abs(y - ref)) < 1e-5
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_fused_yat_score_higher_rank_input():
+    """``(...., in_features)`` shapes flatten and restore correctly."""
+    mx.set_default_device(mx.cpu)
+    try:
+        x = mx.random.normal(shape=(2, 3, 4, 5))
+        w = mx.random.normal(shape=(7, 5))
+        y = fused_yat_score(x, w)
+        assert y.shape == (2, 3, 4, 7)
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_fused_yat_score_rejects_dim_mismatch():
+    mx.set_default_device(mx.cpu)
+    try:
+        x = mx.zeros((1, 4))
+        w = mx.zeros((6, 5))
+        with pytest.raises(ValueError):
+            fused_yat_score(x, w)
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+# ---------------------------------------------------------------------------
+# Autograd via custom_function.vjp
+# ---------------------------------------------------------------------------
+
+
+def test_fused_yat_gradient_matches_finite_difference():
+    """Compare the analytic gradient to a centred finite-difference at
+    every primal element (small dim so it's fast)."""
+    mx.set_default_device(mx.cpu)
+    try:
+        mx.random.seed(0)
+        x = mx.random.normal(shape=(2, 3))
+        w = mx.random.normal(shape=(2, 3))
+        b = mx.random.normal(shape=(2,))
+        alpha = mx.array([1.2])
+
+        def loss_fn(x, w, b, alpha):
+            return mx.sum(fused_yat_score(x, w, bias=b, alpha=alpha))
+
+        _, (gx, gw, gb, ga) = mx.value_and_grad(loss_fn, argnums=(0, 1, 2, 3))(
+            x, w, b, alpha
+        )
+
+        def loss_np(x_np, w_np, b_np, a_np):
+            return float(_ref_yat(x_np, w_np, b_np, float(a_np[0])).sum())
+
+        h = 1e-2
+        xn, wn, bn, an = (np.array(t).copy() for t in (x, w, b, alpha))
+
+        def fd(arr, idx):
+            arr_p = arr.copy(); arr_m = arr.copy()
+            arr_p.flat[idx] += h; arr_m.flat[idx] -= h
+            return arr_p, arr_m
+
+        gx_np = np.array(gx)
+        gw_np = np.array(gw)
+        gb_np = np.array(gb)
+        ga_np = np.array(ga)
+
+        # Check a handful of elements per gradient — full grid would be slow
+        # in pure-Python finite-difference, the spot-checks catch sign / scale
+        # errors equally well.
+        for idx in [0, gx_np.size - 1, gx_np.size // 2]:
+            xp, xm = fd(xn, idx)
+            ref = (loss_np(xp, wn, bn, an) - loss_np(xm, wn, bn, an)) / (2 * h)
+            assert abs(ref - gx_np.flat[idx]) < 0.1, f"gx[{idx}] mismatch"
+
+        for idx in [0, gw_np.size - 1]:
+            wp, wm = fd(wn, idx)
+            ref = (loss_np(xn, wp, bn, an) - loss_np(xn, wm, bn, an)) / (2 * h)
+            assert abs(ref - gw_np.flat[idx]) < 0.2, f"gw[{idx}] mismatch"
+
+        for idx in range(gb_np.size):
+            bp, bm = fd(bn, idx)
+            ref = (loss_np(xn, wn, bp, an) - loss_np(xn, wn, bm, an)) / (2 * h)
+            assert abs(ref - gb_np.flat[idx]) < 0.1, f"gb[{idx}] mismatch"
+
+        ap, am = fd(an, 0)
+        ref = (loss_np(xn, wn, bn, ap) - loss_np(xn, wn, bn, am)) / (2 * h)
+        assert abs(ref - ga_np.flat[0]) < 0.1
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+# ---------------------------------------------------------------------------
+# YatNMN(fused=True) integration
+# ---------------------------------------------------------------------------
+
+
+def test_yat_nmn_fused_matches_plain_on_cpu():
+    """fused=True must produce numerically identical output to fused=False
+    when only the basic features are in use."""
+    mx.set_default_device(mx.cpu)
+    try:
+        mx.random.seed(0)
+        plain = YatNMN(features=8)
+        plain.build(16)
+        fused = YatNMN(features=8, fused=True)
+        fused.build(16)
+        fused.kernel = plain.kernel
+        fused.bias = plain.bias
+        fused.alpha = plain.alpha
+
+        x = mx.random.normal(shape=(4, 16))
+        y_plain = np.array(plain(x))
+        y_fused = np.array(fused(x))
+        assert np.max(np.abs(y_plain - y_fused)) < 1e-5
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_yat_nmn_fused_supports_constant_bias():
+    mx.set_default_device(mx.cpu)
+    try:
+        mx.random.seed(0)
+        plain = YatNMN(features=4, constant_bias=0.25)
+        plain.build(6)
+        fused = YatNMN(features=4, constant_bias=0.25, fused=True)
+        fused.build(6)
+        fused.kernel = plain.kernel
+        fused.alpha = plain.alpha
+
+        x = mx.random.normal(shape=(3, 6))
+        assert np.max(np.abs(np.array(plain(x)) - np.array(fused(x)))) < 1e-5
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_yat_nmn_fused_supports_constant_alpha():
+    mx.set_default_device(mx.cpu)
+    try:
+        mx.random.seed(1)
+        plain = YatNMN(features=4, constant_alpha=True)
+        plain.build(6)
+        fused = YatNMN(features=4, constant_alpha=True, fused=True)
+        fused.build(6)
+        fused.kernel = plain.kernel
+        fused.bias = plain.bias
+
+        x = mx.random.normal(shape=(3, 6))
+        assert np.max(np.abs(np.array(plain(x)) - np.array(fused(x)))) < 1e-5
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_yat_nmn_fused_falls_back_when_spherical():
+    """spherical / weight_normalized / return_weights aren't supported in
+    the fused path — the layer should silently fall back to the eager
+    forward (no kernel launch) and still produce the right output."""
+    mx.set_default_device(mx.cpu)
+    try:
+        mx.random.seed(2)
+        plain = YatNMN(features=4, spherical=True)
+        plain.build(6)
+        fused = YatNMN(features=4, spherical=True, fused=True)
+        fused.build(6)
+        fused.kernel = plain.kernel
+        fused.bias = plain.bias
+        fused.alpha = plain.alpha
+
+        x = mx.random.normal(shape=(3, 6))
+        assert np.max(np.abs(np.array(plain(x)) - np.array(fused(x)))) < 1e-5
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_yat_nmn_fused_gradient_flow():
+    """One AdamW step through the fused path reduces a squared-error loss."""
+
+    def loss_fn(model, x, y):
+        return mx.mean((model(x) - y) ** 2)
+
+    mx.set_default_device(mx.cpu)
+    try:
+        layer = YatNMN(features=4, fused=True)
+        x = mx.random.normal(shape=(8, 6))
+        y = mx.random.normal(shape=(8, 4))
+        _ = layer(x)  # build
+
+        grad_fn = mlx_nn.value_and_grad(layer, loss_fn)
+        loss, grads = grad_fn(layer, x, y)
+        assert set(grads.keys()) >= {"kernel", "bias", "alpha"}
+
+        opt = mlx_optim.AdamW(learning_rate=1e-2)
+        opt.update(layer, grads)
+        mx.eval(layer.parameters())
+        assert float(loss_fn(layer, x, y)) < float(loss)
+    finally:
+        mx.set_default_device(mx.cpu)

--- a/tests/test_mlx/test_kv_cache.py
+++ b/tests/test_mlx/test_kv_cache.py
@@ -1,0 +1,149 @@
+"""Tests for the autoregressive KV cache on RotaryYatAttention."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import RotaryYatAttention  # noqa: E402
+
+
+def _build(embed_dim=32, num_heads=2, max_seq_len=16):
+    mx.random.seed(0)
+    mha = RotaryYatAttention(embed_dim=embed_dim, num_heads=num_heads,
+                             max_seq_len=max_seq_len)
+    _ = mha(mx.zeros((1, 1, embed_dim)))  # build lazy params
+    return mha
+
+
+# ---------------------------------------------------------------------------
+# Cache lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_init_cache_allocates_zero_buffers():
+    mha = _build()
+    mha.init_cache(batch_size=2, max_length=10)
+    assert mha.cached_key.shape == (2, 10, 2, mha.head_dim)
+    assert mha.cached_value.shape == (2, 10, 2, mha.head_dim)
+    assert mha.cache_index == 0
+    assert float(mx.max(mx.abs(mha.cached_key))) == 0.0
+    assert float(mx.max(mx.abs(mha.cached_value))) == 0.0
+
+
+def test_reset_cache_clears_state():
+    mha = _build()
+    mha.init_cache(batch_size=1)
+    _ = mha(mx.random.normal(shape=(1, 1, 32)), decode=True)
+    assert mha.cache_index == 1
+    mha.reset_cache()
+    assert mha.cached_key is None
+    assert mha.cached_value is None
+    assert mha.cache_index == 0
+
+
+def test_init_cache_rejects_unbuilt_module():
+    mha = RotaryYatAttention(embed_dim=32, num_heads=2, max_seq_len=8)
+    with pytest.raises(ValueError):
+        mha.init_cache(batch_size=1)
+
+
+def test_init_cache_rejects_too_large_max_length():
+    mha = _build(max_seq_len=8)
+    with pytest.raises(ValueError):
+        mha.init_cache(batch_size=1, max_length=99)
+
+
+def test_decode_without_init_cache_rejected():
+    mha = _build()
+    with pytest.raises(ValueError):
+        mha(mx.random.normal(shape=(1, 1, 32)), decode=True)
+
+
+def test_decode_cache_overflow_rejected():
+    mha = _build(max_seq_len=16)
+    mha.init_cache(batch_size=1, max_length=4)
+    for _ in range(4):
+        _ = mha(mx.random.normal(shape=(1, 1, 32)), decode=True)
+    with pytest.raises(ValueError):
+        mha(mx.random.normal(shape=(1, 1, 32)), decode=True)
+
+
+# ---------------------------------------------------------------------------
+# Cache correctness
+# ---------------------------------------------------------------------------
+
+
+def test_decode_advances_cache_index():
+    mha = _build()
+    mha.init_cache(batch_size=1, max_length=10)
+    _ = mha(mx.random.normal(shape=(1, 3, 32)), decode=True)
+    assert mha.cache_index == 3
+    _ = mha(mx.random.normal(shape=(1, 2, 32)), decode=True)
+    assert mha.cache_index == 5
+
+
+def test_decode_matches_causal_prefill_byte_identical():
+    """Full causal prefill and step-by-step decode must produce identical
+    outputs at every position — the strongest correctness signal."""
+    mha = _build()
+    L = 6
+    x = mx.random.normal(shape=(1, L, 32))
+
+    # Causal mask for prefill.
+    causal = np.tril(np.ones((L, L), dtype=bool))[None, None]
+    mask = mx.array(np.broadcast_to(causal, (1, mha.num_heads, L, L)))
+    out_prefill = np.array(mha(x, mask=mask))
+
+    # Decode token-by-token.
+    mha.reset_cache()
+    mha.init_cache(batch_size=1, max_length=L)
+    out_decode = np.concatenate(
+        [np.array(mha(x[:, t:t + 1], decode=True)) for t in range(L)],
+        axis=1,
+    )
+    assert np.max(np.abs(out_prefill - out_decode)) < 1e-4
+
+
+def test_decode_multi_token_chunk_matches_single_step():
+    """Decoding tokens in a 2-token chunk should give the same result as
+    decoding them one at a time (the cache_index lookup is the only
+    difference)."""
+    mha = _build()
+    x = mx.random.normal(shape=(1, 4, 32))
+
+    # Chunked: 2 tokens, then 2 tokens.
+    mha.init_cache(batch_size=1, max_length=4)
+    out_chunked = np.concatenate(
+        [np.array(mha(x[:, :2], decode=True)),
+         np.array(mha(x[:, 2:], decode=True))],
+        axis=1,
+    )
+
+    # Step-by-step.
+    mha.reset_cache()
+    mha.init_cache(batch_size=1, max_length=4)
+    out_step = np.concatenate(
+        [np.array(mha(x[:, t:t + 1], decode=True)) for t in range(4)],
+        axis=1,
+    )
+    assert np.max(np.abs(out_chunked - out_step)) < 1e-4
+
+
+def test_decode_independent_of_future_tokens():
+    """The output for token t must be invariant to the input at token t+1
+    (basic causality check on the decode path itself)."""
+    mha = _build()
+    mha.init_cache(batch_size=1, max_length=8)
+    x = mx.random.normal(shape=(1, 1, 32))
+    out_first = np.array(mha(x, decode=True))
+    # Decode a different next token — out_first should not change.
+    _ = mha(mx.random.normal(shape=(1, 1, 32)), decode=True)
+    # And re-run the decode trajectory from scratch with the same first
+    # token: we should get the same out_first.
+    mha.reset_cache()
+    mha.init_cache(batch_size=1, max_length=8)
+    out_first_again = np.array(mha(x, decode=True))
+    assert np.max(np.abs(out_first - out_first_again)) < 1e-6

--- a/tests/test_mlx/test_padding_modes.py
+++ b/tests/test_mlx/test_padding_modes.py
@@ -1,0 +1,173 @@
+"""Tests for the CIRCULAR / REFLECT / CAUSAL conv padding modes."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import YatConv1D, YatConv2D  # noqa: E402
+from nmn.mlx.conv import _prepad_input  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _prepad_input — bit-for-bit numpy parity
+# ---------------------------------------------------------------------------
+
+
+def test_prepad_circular_1d_matches_numpy_wrap():
+    xn = np.arange(7, dtype=np.float32)
+    x = mx.array(xn.reshape(1, 7, 1))
+    out = np.array(_prepad_input(x, "CIRCULAR", (5,), (1,))).flatten()
+    np.testing.assert_array_equal(out, np.pad(xn, (2, 2), "wrap"))
+
+
+def test_prepad_reflect_1d_matches_numpy_reflect():
+    xn = np.arange(7, dtype=np.float32)
+    x = mx.array(xn.reshape(1, 7, 1))
+    out = np.array(_prepad_input(x, "REFLECT", (5,), (1,))).flatten()
+    np.testing.assert_array_equal(out, np.pad(xn, (2, 2), "reflect"))
+
+
+def test_prepad_circular_2d_matches_numpy_wrap():
+    xn = np.arange(16, dtype=np.float32).reshape(4, 4)
+    x = mx.array(xn.reshape(1, 4, 4, 1))
+    out = np.array(_prepad_input(x, "CIRCULAR", (3, 3), (1, 1)))
+    np.testing.assert_array_equal(
+        out.reshape(6, 6), np.pad(xn, ((1, 1), (1, 1)), "wrap")
+    )
+
+
+def test_prepad_reflect_2d_matches_numpy_reflect():
+    xn = np.arange(16, dtype=np.float32).reshape(4, 4)
+    x = mx.array(xn.reshape(1, 4, 4, 1))
+    out = np.array(_prepad_input(x, "REFLECT", (3, 3), (1, 1)))
+    np.testing.assert_array_equal(
+        out.reshape(6, 6), np.pad(xn, ((1, 1), (1, 1)), "reflect")
+    )
+
+
+def test_prepad_causal_1d_left_zero_only():
+    xn = np.arange(5, dtype=np.float32)
+    x = mx.array(xn.reshape(1, 5, 1))
+    out = np.array(_prepad_input(x, "CAUSAL", (3,), (1,))).flatten()
+    np.testing.assert_array_equal(out, np.pad(xn, (2, 0), "constant"))
+
+
+def test_prepad_causal_with_dilation():
+    """left_pad = dilation * (kernel_size - 1)."""
+    xn = np.arange(4, dtype=np.float32)
+    x = mx.array(xn.reshape(1, 4, 1))
+    out = np.array(_prepad_input(x, "CAUSAL", (3,), (2,))).flatten()
+    np.testing.assert_array_equal(out, np.pad(xn, (4, 0), "constant"))
+
+
+def test_prepad_causal_rejects_multi_dim():
+    x = mx.zeros((1, 4, 4, 1))
+    with pytest.raises(ValueError):
+        _prepad_input(x, "CAUSAL", (3, 3), (1, 1))
+
+
+def test_prepad_circular_rejects_too_large_kernel():
+    x = mx.zeros((1, 3, 1))  # spatial size 3
+    with pytest.raises(ValueError):
+        _prepad_input(x, "CIRCULAR", (9,), (1,))
+
+
+def test_prepad_reflect_rejects_too_large_kernel():
+    x = mx.zeros((1, 3, 1))
+    with pytest.raises(ValueError):
+        _prepad_input(x, "REFLECT", (9,), (1,))
+
+
+# ---------------------------------------------------------------------------
+# Conv forward — output shape matches input size for SAME-like modes
+# ---------------------------------------------------------------------------
+
+
+def test_conv1d_circular_preserves_length():
+    layer = YatConv1D(filters=4, kernel_size=3, padding="circular")
+    out = layer(mx.random.normal(shape=(1, 16, 2)))
+    assert out.shape == (1, 16, 4)
+
+
+def test_conv1d_reflect_preserves_length():
+    layer = YatConv1D(filters=4, kernel_size=5, padding="reflect")
+    out = layer(mx.random.normal(shape=(1, 16, 2)))
+    assert out.shape == (1, 16, 4)
+
+
+def test_conv1d_causal_preserves_length():
+    layer = YatConv1D(filters=4, kernel_size=3, padding="causal")
+    out = layer(mx.random.normal(shape=(1, 16, 2)))
+    assert out.shape == (1, 16, 4)
+
+
+def test_conv2d_circular_preserves_shape():
+    layer = YatConv2D(filters=4, kernel_size=3, padding="circular")
+    out = layer(mx.random.normal(shape=(1, 12, 12, 2)))
+    assert out.shape == (1, 12, 12, 4)
+
+
+def test_conv2d_reflect_preserves_shape():
+    layer = YatConv2D(filters=4, kernel_size=5, padding="reflect")
+    out = layer(mx.random.normal(shape=(1, 12, 12, 2)))
+    assert out.shape == (1, 12, 12, 4)
+
+
+def test_conv_causal_only_in_1d():
+    layer = YatConv2D(filters=4, kernel_size=3, padding="causal")
+    with pytest.raises(ValueError):
+        layer(mx.random.normal(shape=(1, 8, 8, 2)))
+
+
+# ---------------------------------------------------------------------------
+# Causal correctness: output[t] must not depend on input[t' > t]
+# ---------------------------------------------------------------------------
+
+
+def test_conv1d_causal_does_not_leak_future():
+    mx.random.seed(0)
+    layer = YatConv1D(filters=4, kernel_size=3, padding="causal")
+    x = mx.random.normal(shape=(1, 10, 2))
+    out_a = np.array(layer(x))
+    # Perturb the last timestep — output at t=0..3 must be unchanged
+    # (kernel size 3, dilation 1 → each position only sees the 2 prior
+    # timesteps + itself).
+    x_perturbed = mx.concatenate([x[:, :9], x[:, 9:10] + 100.0], axis=1)
+    out_b = np.array(layer(x_perturbed))
+    assert np.max(np.abs(out_a[:, :9] - out_b[:, :9])) < 1e-4
+    # But timestep 9 changes.
+    assert np.max(np.abs(out_a[:, 9] - out_b[:, 9])) > 1e-2
+
+
+# ---------------------------------------------------------------------------
+# YAT math parity for CIRCULAR mode (sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_conv1d_circular_yat_math_parity():
+    """Compare against a hand-rolled numpy reference where we explicitly
+    pre-pad the input with 'wrap' and run the YAT formula."""
+    mx.random.seed(0)
+    layer = YatConv1D(filters=3, kernel_size=3, padding="circular")
+    x = mx.random.normal(shape=(1, 6, 2))
+    y = np.array(layer(x))
+
+    W = np.array(layer.kernel)  # (3, 3, 2)
+    b = np.array(layer.bias)
+    a = float(np.array(layer.alpha)[0])
+    xn = np.array(x)[0]                                  # (6, 2)
+    xn_padded = np.pad(xn, ((1, 1), (0, 0)), "wrap")     # (8, 2)
+
+    out_len = 6
+    ref = np.zeros((1, out_len, 3))
+    for f in range(3):
+        for t in range(out_len):
+            patch = xn_padded[t:t + 3]                   # (3, 2)
+            kf = W[f]                                    # (3, 2) per MLX (C_out, K, C_in)
+            dot = (patch * kf).sum()
+            dist = ((patch - kf) ** 2).sum()
+            ref[0, t, f] = a * (dot + b[f]) ** 2 / (dist + 1e-5)
+    assert np.max(np.abs(y - ref)) < 1e-5

--- a/tests/test_mlx/test_performer.py
+++ b/tests/test_mlx/test_performer.py
@@ -1,0 +1,177 @@
+"""Tests for the MLX Spherical-YAT-Performer."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import (  # noqa: E402
+    create_yat_tp_projection,
+    yat_tp_features,
+    yat_tp_attention,
+)
+
+
+# ---------------------------------------------------------------------------
+# create_yat_tp_projection
+# ---------------------------------------------------------------------------
+
+
+def test_projection_shapes():
+    params = create_yat_tp_projection(
+        head_dim=16, num_prf_features=8, num_quad_nodes=2,
+        num_anchor_features=16, seed=0,
+    )
+    assert params["projections"].shape == (2, 8, 16)
+    assert params["anchors"].shape == (16, 16)
+    assert params["quad_nodes"].shape == (2,)
+    assert params["quad_weights"].shape == (2,)
+    assert params["num_prf_features"] == 8
+    assert params["num_anchor_features"] == 16
+    assert params["num_scales"] == 2
+
+
+def test_anchors_unit_norm():
+    params = create_yat_tp_projection(
+        head_dim=8, num_anchor_features=10, num_prf_features=4, seed=0,
+    )
+    anchors = np.array(params["anchors"])
+    norms = np.linalg.norm(anchors, axis=-1)
+    assert np.max(np.abs(norms - 1.0)) < 1e-5
+
+
+def test_seeded_projection_is_deterministic():
+    p1 = create_yat_tp_projection(head_dim=8, num_anchor_features=4,
+                                  num_prf_features=4, seed=42)
+    p2 = create_yat_tp_projection(head_dim=8, num_anchor_features=4,
+                                  num_prf_features=4, seed=42)
+    assert np.array_equal(np.array(p1["anchors"]), np.array(p2["anchors"]))
+    assert np.array_equal(np.array(p1["projections"]), np.array(p2["projections"]))
+
+
+# ---------------------------------------------------------------------------
+# yat_tp_features
+# ---------------------------------------------------------------------------
+
+
+def test_feature_shape_matches_rpm():
+    """Feature dim should equal R·P·M."""
+    R, P, M, d = 2, 16, 8, 16
+    params = create_yat_tp_projection(
+        head_dim=d, num_quad_nodes=R, num_anchor_features=P,
+        num_prf_features=M, seed=0,
+    )
+    x = mx.random.normal(shape=(1, 5, 2, d))
+    feat = yat_tp_features(x, params)
+    assert feat.shape == (1, 5, 2, R * P * M)
+
+
+def test_feature_non_negative():
+    """φ(x) = √w · (a·x)² · exp(...) ≥ 0 always."""
+    params = create_yat_tp_projection(
+        head_dim=8, num_anchor_features=8, num_prf_features=4, seed=0,
+    )
+    x = mx.random.normal(shape=(1, 4, 2, 8)) * 3.0
+    feat = np.array(yat_tp_features(x, params))
+    # Tiny negatives only from fp32 rounding inside the normalization
+    # denominator — allow ~1e-7 slack.
+    assert float(feat.min()) >= -1e-6
+
+
+def test_feature_normalization_is_optional():
+    """``normalize=False`` should produce different features than the
+    default (which L2-normalizes)."""
+    params = create_yat_tp_projection(
+        head_dim=8, num_anchor_features=4, num_prf_features=4, seed=0,
+    )
+    x = mx.random.normal(shape=(1, 4, 2, 8)) * 5.0
+    feat_norm = np.array(yat_tp_features(x, params, normalize=True))
+    feat_raw = np.array(yat_tp_features(x, params, normalize=False))
+    assert np.max(np.abs(feat_norm - feat_raw)) > 1e-2
+
+
+# ---------------------------------------------------------------------------
+# yat_tp_attention
+# ---------------------------------------------------------------------------
+
+
+def test_attention_output_shape_non_causal():
+    params = create_yat_tp_projection(head_dim=16, seed=0)
+    q = mx.random.normal(shape=(2, 4, 3, 16))
+    k = mx.random.normal(shape=(2, 5, 3, 16))
+    v = mx.random.normal(shape=(2, 5, 3, 16))
+    out = yat_tp_attention(q, k, v, params, causal=False)
+    assert out.shape == (2, 4, 3, 16)
+
+
+def test_attention_output_shape_causal():
+    params = create_yat_tp_projection(head_dim=16, seed=0)
+    q = mx.random.normal(shape=(1, 6, 2, 16))
+    out = yat_tp_attention(q, q, q, params, causal=True)
+    assert out.shape == (1, 6, 2, 16)
+
+
+def test_causal_attention_position_0_unaffected_by_future_values():
+    """Mutating value[t > 0] must not change output[t = 0] under causal mask."""
+    mx.random.seed(0)
+    params = create_yat_tp_projection(head_dim=8, seed=0)
+    x = mx.random.normal(shape=(1, 5, 1, 8))
+    v = mx.random.normal(shape=(1, 5, 1, 8))
+    out_a = yat_tp_attention(x, x, v, params, causal=True)
+    # Perturb v at the last timestep.
+    v_perturbed = mx.concatenate([v[:, :4], v[:, 4:5] + 100.0], axis=1)
+    out_b = yat_tp_attention(x, x, v_perturbed, params, causal=True)
+    assert float(mx.max(mx.abs(out_a[:, 0] - out_b[:, 0]))) < 1e-3
+    # And the later position should change.
+    assert float(mx.max(mx.abs(out_a[:, 4] - out_b[:, 4]))) > 1e-2
+
+
+def test_causal_and_non_causal_differ():
+    mx.random.seed(0)
+    params = create_yat_tp_projection(head_dim=16, seed=0)
+    x = mx.random.normal(shape=(1, 8, 2, 16))
+    v = mx.random.normal(shape=(1, 8, 2, 16))
+    out_nc = yat_tp_attention(x, x, v, params, causal=False)
+    out_c = yat_tp_attention(x, x, v, params, causal=True)
+    assert float(mx.max(mx.abs(out_nc - out_c))) > 1e-3
+
+
+def test_kernel_approximation_quality_at_dot_zero():
+    """When q·k = 0, the exact spherical YAT score is 0; the linearized
+    feature inner product should be small too."""
+    params = create_yat_tp_projection(
+        head_dim=16, num_anchor_features=32, num_prf_features=8,
+        num_quad_nodes=2, seed=0,
+    )
+    # Build q and k orthogonal unit vectors.
+    rng = np.random.default_rng(0)
+    q_np = rng.standard_normal(16).astype(np.float32)
+    q_np /= np.linalg.norm(q_np)
+    k_np = rng.standard_normal(16).astype(np.float32)
+    k_np -= np.dot(k_np, q_np) * q_np
+    k_np /= np.linalg.norm(k_np)
+    assert abs(float(np.dot(q_np, k_np))) < 1e-5
+
+    q = mx.array(q_np).reshape((1, 1, 1, 16))
+    k = mx.array(k_np).reshape((1, 1, 1, 16))
+    qf = yat_tp_features(q, params)
+    kf = yat_tp_features(k, params)
+    score = float(mx.sum(qf * kf))
+    # Exact: (q·k)² / (C − 2·q·k) = 0 / (2+ε − 0) = 0.
+    # Approx should be very small (PRF tails decay → magnitude ~ 1/√(P·M·R)).
+    assert score < 0.05
+
+
+def test_yat_tp_attention_dtype_promotion():
+    """Mixed dtypes should not crash — query dtype wins."""
+    params = create_yat_tp_projection(head_dim=8, seed=0, dtype=mx.float32)
+    q = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float32)
+    k = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float32)
+    v = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float16)
+    out = yat_tp_attention(q, k, v, params)
+    assert out.dtype == mx.float32
+    assert out.shape == (1, 3, 1, 8)

--- a/tests/test_mlx/test_rotary.py
+++ b/tests/test_mlx/test_rotary.py
@@ -1,0 +1,236 @@
+"""Tests for MLX Rotary YAT Attention."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+mlx_optim = pytest.importorskip("mlx.optimizers")
+
+from nmn.mlx import (  # noqa: E402
+    RotaryYatAttention,
+    precompute_freqs_cis,
+    apply_rotary_emb,
+    rotary_yat_attention,
+    rotary_yat_attention_weights,
+    yat_attention_weights,
+)
+
+
+# ---------------------------------------------------------------------------
+# precompute_freqs_cis
+# ---------------------------------------------------------------------------
+
+
+def test_precompute_freqs_cis_shape():
+    cos, sin = precompute_freqs_cis(64, 128)
+    assert cos.shape == (128, 32)
+    assert sin.shape == (128, 32)
+
+
+def test_precompute_freqs_cis_rejects_odd_dim():
+    with pytest.raises(ValueError):
+        precompute_freqs_cis(63, 16)
+
+
+def test_precompute_freqs_cis_first_row_is_zero_angle():
+    """t=0 -> all angles are 0, cos=1, sin=0."""
+    cos, sin = precompute_freqs_cis(32, 4)
+    np.testing.assert_allclose(np.array(cos[0]), np.ones(16), atol=1e-6)
+    np.testing.assert_allclose(np.array(sin[0]), np.zeros(16), atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# apply_rotary_emb
+# ---------------------------------------------------------------------------
+
+
+def test_apply_rotary_emb_shape_preserved():
+    cos, sin = precompute_freqs_cis(16, 32)
+    x = mx.random.normal(shape=(2, 8, 3, 16))
+    out = apply_rotary_emb(x, cos, sin)
+    assert out.shape == x.shape
+
+
+def test_apply_rotary_emb_preserves_per_pair_norm():
+    """RoPE is a rotation of each (even, odd) pair → preserves vector norms."""
+    cos, sin = precompute_freqs_cis(64, 32)
+    x = mx.random.normal(shape=(2, 8, 4, 64))
+    x_rot = apply_rotary_emb(x, cos, sin)
+    in_norms = np.linalg.norm(np.array(x), axis=-1)
+    out_norms = np.linalg.norm(np.array(x_rot), axis=-1)
+    assert np.max(np.abs(in_norms - out_norms)) < 1e-4
+
+
+def test_apply_rotary_emb_offset_changes_output():
+    """Same input, different ``position_offset`` → different rotated output."""
+    mx.random.seed(0)
+    cos, sin = precompute_freqs_cis(32, 64)
+    x = mx.random.normal(shape=(1, 10, 2, 32))
+    out_0 = np.array(apply_rotary_emb(x, cos, sin, position_offset=0))
+    out_5 = np.array(apply_rotary_emb(x, cos, sin, position_offset=5))
+    assert np.max(np.abs(out_0 - out_5)) > 1e-2
+
+
+def test_apply_rotary_emb_rejects_overflow():
+    cos, sin = precompute_freqs_cis(16, 8)
+    x = mx.zeros((1, 8, 1, 16))
+    with pytest.raises(ValueError):
+        apply_rotary_emb(x, cos, sin, position_offset=4)
+
+
+def test_apply_rotary_emb_matches_numpy_reference():
+    """Compare against a hand-rolled numpy implementation."""
+    mx.random.seed(3)
+    head_dim = 16
+    cos, sin = precompute_freqs_cis(head_dim, 8)
+    x = mx.random.normal(shape=(1, 5, 2, head_dim))
+    y = np.array(apply_rotary_emb(x, cos, sin))
+
+    xn = np.array(x)
+    cn = np.array(cos)[:5]
+    sn = np.array(sin)[:5]
+    x_even = xn[..., 0::2]
+    x_odd = xn[..., 1::2]
+    cn_b = cn.reshape(1, 5, 1, -1)
+    sn_b = sn.reshape(1, 5, 1, -1)
+    rot_even = x_even * cn_b - x_odd * sn_b
+    rot_odd = x_even * sn_b + x_odd * cn_b
+    ref = np.stack([rot_even, rot_odd], axis=-1).reshape(xn.shape)
+    assert np.max(np.abs(y - ref)) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# Functional rotary YAT attention
+# ---------------------------------------------------------------------------
+
+
+def test_rotary_yat_attention_weights_relative_position_invariance():
+    """Shifting Q and K by the same offset must leave attention weights
+    unchanged (only relative position matters in RoPE+YAT)."""
+    mx.random.seed(11)
+    cos, sin = precompute_freqs_cis(16, 32)
+    q = mx.random.normal(shape=(1, 6, 2, 16))
+    k = mx.random.normal(shape=(1, 6, 2, 16))
+    w0 = np.array(rotary_yat_attention_weights(q, k, cos, sin, position_offset=0))
+    w3 = np.array(rotary_yat_attention_weights(q, k, cos, sin, position_offset=3))
+    # Should be equal up to fp32 noise.
+    assert np.max(np.abs(w0 - w3)) < 1e-4
+
+
+def test_rotary_yat_attention_softmax_sums_to_one():
+    cos, sin = precompute_freqs_cis(16, 32)
+    q = mx.random.normal(shape=(1, 4, 2, 16))
+    k = mx.random.normal(shape=(1, 5, 2, 16))
+    w = np.array(rotary_yat_attention_weights(q, k, cos, sin))
+    assert np.max(np.abs(w.sum(axis=-1) - 1.0)) < 1e-4
+
+
+def test_rotary_yat_attention_v_output_shape():
+    cos, sin = precompute_freqs_cis(16, 32)
+    q = mx.random.normal(shape=(1, 4, 2, 16))
+    k = mx.random.normal(shape=(1, 5, 2, 16))
+    v = mx.random.normal(shape=(1, 5, 2, 16))
+    out = rotary_yat_attention(q, k, v, cos, sin)
+    assert out.shape == (1, 4, 2, 16)
+
+
+def test_rotary_yat_attention_diverges_from_no_rope():
+    """With RoPE the weights should differ from plain YAT (otherwise we'd
+    be losing the positional signal)."""
+    mx.random.seed(0)
+    cos, sin = precompute_freqs_cis(16, 16)
+    q = mx.random.normal(shape=(1, 8, 1, 16))
+    k = mx.random.normal(shape=(1, 8, 1, 16))
+    w_no_rope = np.array(yat_attention_weights(q, k))
+    w_rope = np.array(rotary_yat_attention_weights(q, k, cos, sin))
+    assert np.max(np.abs(w_no_rope - w_rope)) > 1e-2
+
+
+# ---------------------------------------------------------------------------
+# RotaryYatAttention module
+# ---------------------------------------------------------------------------
+
+
+def test_module_self_attn_shape():
+    mha = RotaryYatAttention(embed_dim=64, num_heads=8, max_seq_len=128)
+    x = mx.random.normal(shape=(2, 10, 64))
+    out = mha(x)
+    assert out.shape == (2, 10, 64)
+
+
+def test_module_rejects_bad_embed_dim():
+    with pytest.raises(ValueError):
+        RotaryYatAttention(embed_dim=10, num_heads=4, max_seq_len=32)
+
+
+def test_module_rejects_odd_head_dim():
+    with pytest.raises(ValueError):
+        RotaryYatAttention(embed_dim=15, num_heads=3, max_seq_len=32)
+
+
+def test_module_rejects_too_long_input():
+    mha = RotaryYatAttention(embed_dim=32, num_heads=2, max_seq_len=8)
+    with pytest.raises(ValueError):
+        mha(mx.random.normal(shape=(1, 10, 32)))
+
+
+def test_module_constant_alpha_drops_learnable():
+    mha = RotaryYatAttention(
+        embed_dim=32, num_heads=2, max_seq_len=16, constant_alpha=True
+    )
+    _ = mha(mx.random.normal(shape=(1, 4, 32)))
+    assert mha._constant_alpha_value == math.sqrt(2.0)
+    assert "alpha" not in mha.parameters()
+
+
+def test_module_no_out_proj():
+    mha = RotaryYatAttention(
+        embed_dim=32, num_heads=2, max_seq_len=16, use_out_proj=False
+    )
+    _ = mha(mx.random.normal(shape=(1, 4, 32)))
+    assert "out_kernel" not in mha.parameters()
+
+
+def test_module_gradient_reduces_loss():
+    def loss_fn(model, x, y):
+        return mx.mean((model(x) - y) ** 2)
+
+    mha = RotaryYatAttention(embed_dim=32, num_heads=2, max_seq_len=16)
+    x = mx.random.normal(shape=(2, 5, 32))
+    y = mx.random.normal(shape=(2, 5, 32))
+    _ = mha(x)  # build lazy params
+
+    grad_fn = mlx_nn.value_and_grad(mha, loss_fn)
+    loss, grads = grad_fn(mha, x, y)
+    assert {"q_kernel", "k_kernel", "v_kernel", "out_kernel"} <= set(grads.keys())
+
+    opt = mlx_optim.AdamW(learning_rate=1e-2)
+    opt.update(mha, grads)
+    mx.eval(mha.parameters())
+    loss_after = float(loss_fn(mha, x, y))
+    assert loss_after < float(loss)
+
+
+def test_module_causal_mask_zeroes_upper_triangle():
+    """Attention with a causal mask should respect token ordering."""
+    mha = RotaryYatAttention(embed_dim=32, num_heads=2, max_seq_len=16)
+    x = mx.random.normal(shape=(1, 6, 32))
+    causal = np.tril(np.ones((6, 6), dtype=bool))[None, None, :, :]
+    mask = mx.array(np.broadcast_to(causal, (1, 2, 6, 6)))
+    # Use the functional helpers directly to inspect attention weights.
+    q = mx.reshape(mha._linear(x, mha.q_kernel, getattr(mha, "q_bias", None)),
+                   (1, 6, 2, 16)) if mha.is_built else None
+    if q is None:
+        _ = mha(x)
+        q = mx.reshape(mha._linear(x, mha.q_kernel, getattr(mha, "q_bias", None)),
+                       (1, 6, 2, 16))
+    k = mx.reshape(mha._linear(x, mha.k_kernel, getattr(mha, "k_bias", None)),
+                   (1, 6, 2, 16))
+    w = np.array(rotary_yat_attention_weights(q, k, mha.freqs_cos, mha.freqs_sin, mask=mask))
+    upper = np.triu(np.ones_like(w[0, 0]), k=1).astype(bool)
+    assert float(np.max(np.abs(w[..., upper]))) < 1e-5

--- a/tests/test_mlx/test_squashers.py
+++ b/tests/test_mlx/test_squashers.py
@@ -1,0 +1,64 @@
+"""Tests for the MLX squashing functions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx.squashers import softermax, softer_sigmoid, soft_tanh  # noqa: E402
+
+
+def test_softermax_sums_to_one():
+    x = mx.array([1.0, 2.0, 3.0, 4.0])
+    y = np.array(softermax(x, n=1.0, epsilon=0.0))
+    assert abs(y.sum() - 1.0) < 1e-6
+
+
+def test_softermax_n_2_matches_formula():
+    x = mx.array([1.0, 2.0, 3.0])
+    y = np.array(softermax(x, n=2.0, epsilon=0.0))
+    # x² / sum(x²) = [1, 4, 9] / 14
+    expected = np.array([1.0, 4.0, 9.0]) / 14.0
+    assert np.max(np.abs(y - expected)) < 1e-6
+
+
+def test_softermax_rejects_non_positive_n():
+    with pytest.raises(ValueError):
+        softermax(mx.array([1.0, 2.0]), n=0.0)
+    with pytest.raises(ValueError):
+        softermax(mx.array([1.0, 2.0]), n=-1.0)
+
+
+def test_softer_sigmoid_range():
+    x = mx.array([0.0, 1.0, 10.0, 100.0])
+    y = np.array(softer_sigmoid(x, n=1.0))
+    assert (y >= 0).all()
+    assert (y < 1.0).all()
+    # x=0  -> 0,  x=1 -> 0.5,  x→∞ → 1.
+    assert abs(float(y[0])) < 1e-6
+    assert abs(float(y[1]) - 0.5) < 1e-6
+    assert float(y[-1]) > 0.99
+
+
+def test_soft_tanh_range():
+    x = mx.array([0.0, 1.0, 10.0, 1000.0])
+    y = np.array(soft_tanh(x, n=1.0))
+    # soft_tanh(0) = -1, soft_tanh(1) = 0, soft_tanh(∞) → 1.
+    # Closed form: (x - 1) / (x + 1), so x=1000 → 999/1001 ≈ 0.998.
+    assert abs(float(y[0]) - (-1.0)) < 1e-6
+    assert abs(float(y[1])) < 1e-6
+    assert float(y[-1]) > 0.99
+    assert (y >= -1.0).all()
+    assert (y < 1.0).all()
+
+
+def test_softer_sigmoid_rejects_non_positive_n():
+    with pytest.raises(ValueError):
+        softer_sigmoid(mx.array([1.0]), n=0.0)
+
+
+def test_soft_tanh_rejects_non_positive_n():
+    with pytest.raises(ValueError):
+        soft_tanh(mx.array([1.0]), n=-2.0)

--- a/tests/test_mlx/test_yat_math_validation.py
+++ b/tests/test_mlx/test_yat_math_validation.py
@@ -1,0 +1,157 @@
+"""Bit-by-bit (within fp32 epsilon) validation of the YAT formula.
+
+Compares the MLX layer output against a pure-numpy reference for every
+combination of bias / alpha / spherical / weight_normalized / learnable
+epsilon supported by the Tier-0 backend.
+"""
+
+from __future__ import annotations
+
+import math
+from itertools import product
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import YatNMN  # noqa: E402
+
+
+def _numpy_yat(
+    x: np.ndarray,
+    W: np.ndarray,
+    *,
+    b: np.ndarray | float | None = None,
+    alpha: float | None = None,
+    epsilon: float = 1e-5,
+    spherical: bool = False,
+    weight_normalized: bool = False,
+) -> np.ndarray:
+    """Reference YAT forward pass.
+
+    ``W`` has shape ``(features, in_features)`` to match the MLX layer's
+    ``Linear``-style storage.
+    """
+    if spherical:
+        x = x / (np.linalg.norm(x, axis=-1, keepdims=True) + 1e-8)
+        W = W / (np.linalg.norm(W, axis=-1, keepdims=True) + 1e-8)
+    if weight_normalized:
+        W = W / (np.linalg.norm(W, axis=-1, keepdims=True) + 1e-8)
+
+    dot = x @ W.T
+    if spherical:
+        dist = np.maximum(2.0 - 2.0 * dot, 0.0)
+    else:
+        x_sq = (x ** 2).sum(axis=-1, keepdims=True)
+        if weight_normalized:
+            w_sq = np.ones(W.shape[0], dtype=W.dtype)
+        else:
+            w_sq = (W ** 2).sum(axis=-1)
+        w_sq = w_sq.reshape((1,) * (dot.ndim - 1) + (W.shape[0],))
+        dist = np.maximum(x_sq + w_sq - 2 * dot, 0.0)
+
+    num = dot if b is None else dot + b
+    y = (num ** 2) / (dist + epsilon)
+    if alpha is not None:
+        y = y * alpha
+    return y
+
+
+def _extract(layer: YatNMN) -> tuple[np.ndarray, np.ndarray | float | None, float | None]:
+    W = np.array(layer.kernel)
+    if layer.use_bias:
+        if layer._constant_bias_value is not None:
+            b: np.ndarray | float | None = float(layer._constant_bias_value)
+        else:
+            b = np.array(layer.bias)
+    else:
+        b = None
+    if layer._constant_alpha_value is not None:
+        a: float | None = float(layer._constant_alpha_value)
+    elif layer.use_alpha:
+        a = float(np.array(layer.alpha)[0])
+    else:
+        a = None
+    return W, b, a
+
+
+@pytest.mark.parametrize(
+    "use_bias,use_alpha,constant_bias,constant_alpha",
+    [
+        (True, True, None, None),
+        (False, True, None, None),
+        (True, False, None, None),
+        (False, False, None, None),
+        (True, True, 0.25, None),
+        (True, True, None, True),
+        (True, True, None, 1.5),
+    ],
+)
+def test_yat_math_all_modes(use_bias, use_alpha, constant_bias, constant_alpha):
+    mx.random.seed(42)
+    layer = YatNMN(
+        features=7,
+        use_bias=use_bias,
+        constant_bias=constant_bias,
+        use_alpha=use_alpha,
+        constant_alpha=constant_alpha,
+    )
+    x = mx.random.normal(shape=(4, 5))
+    y = np.array(layer(x))
+    W, b, a = _extract(layer)
+    ref = _numpy_yat(np.array(x), W, b=b, alpha=a, epsilon=1e-5)
+    diff = np.max(np.abs(y - ref))
+    assert diff < 1e-5, f"max diff {diff} exceeds tolerance"
+
+
+@pytest.mark.parametrize("spherical,weight_normalized", list(product([False, True], repeat=2)))
+def test_yat_math_geometry_modes(spherical, weight_normalized):
+    if spherical and weight_normalized:
+        pytest.skip("spherical implies its own normalization; combination is redundant")
+    mx.random.seed(7)
+    layer = YatNMN(
+        features=6,
+        spherical=spherical,
+        weight_normalized=weight_normalized,
+    )
+    x = mx.random.normal(shape=(3, 4))
+    y = np.array(layer(x))
+    W, b, a = _extract(layer)
+    ref = _numpy_yat(
+        np.array(x), W,
+        b=b, alpha=a, epsilon=1e-5,
+        spherical=spherical, weight_normalized=weight_normalized,
+    )
+    diff = np.max(np.abs(y - ref))
+    assert diff < 1e-5, f"max diff {diff} exceeds tolerance"
+
+
+def test_yat_math_learnable_epsilon():
+    """With a learnable ε softplus-reparameterized to 1e-3 at init, the
+    forward pass should match the numpy reference at ε=1e-3."""
+    mx.random.seed(11)
+    layer = YatNMN(features=4, learnable_epsilon=True, epsilon=1e-3)
+    x = mx.random.normal(shape=(2, 3))
+    y = np.array(layer(x))
+    W, b, a = _extract(layer)
+    ref = _numpy_yat(np.array(x), W, b=b, alpha=a, epsilon=1e-3)
+    diff = np.max(np.abs(y - ref))
+    assert diff < 1e-5, f"max diff {diff} exceeds tolerance"
+
+
+def test_yat_output_non_negative_when_bias_zero():
+    """With no bias and no learnable alpha, output is a squared ratio of
+    non-negatives → strictly non-negative."""
+    mx.random.seed(3)
+    layer = YatNMN(features=5, use_bias=False, use_alpha=False)
+    x = mx.random.normal(shape=(8, 6))
+    y = np.array(layer(x))
+    assert float(np.min(y)) >= 0.0
+
+
+def test_default_constant_alpha_value():
+    """``constant_alpha=True`` → √2 exactly."""
+    layer = YatNMN(features=3, constant_alpha=True)
+    _ = layer(mx.zeros((1, 2)))
+    assert layer._constant_alpha_value == math.sqrt(2.0)

--- a/website/blog-pages/20-cross-framework-mnist.html
+++ b/website/blog-pages/20-cross-framework-mnist.html
@@ -92,9 +92,10 @@
                         <h3>The setup</h3>
 
                         <p>
-                            We trained a <em>two-hidden-layer</em> Yat MLP on MNIST in three NMN
-                            backends: <code>nmn.torch</code>, <code>nmn.nnx</code>, and
-                            <code>nmn.linen</code>. The architecture is identical across all three:
+                            We trained a <em>two-hidden-layer</em> Yat MLP on MNIST in four NMN
+                            backends: <code>nmn.torch</code>, <code>nmn.nnx</code>,
+                            <code>nmn.linen</code>, and <code>nmn.mlx</code>. The architecture is
+                            identical across all four:
                         </p>
 
                         <pre><code>Flatten(28×28) → YatNMN(256) → YatNMN(128) → Linear(10)</code></pre>
@@ -110,6 +111,7 @@
                             <li><code>src/nmn/torch/examples/vision/mnist.py</code></li>
                             <li><code>src/nmn/nnx/examples/vision/mnist.py</code></li>
                             <li><code>src/nmn/linen/examples/mnist.py</code></li>
+                            <li><code>src/nmn/mlx/examples/mnist.py</code></li>
                         </ul>
 
                         <p>
@@ -154,13 +156,21 @@
                                         <td style="padding: 0.6rem 1rem; text-align: right;"><strong>1.68</strong></td>
                                         <td style="padding: 0.6rem 1rem; text-align: right;">≈ 0.52</td>
                                     </tr>
-                                    <tr>
+                                    <tr style="border-bottom: 1px solid rgba(255,255,255,0.05);">
                                         <td style="padding: 0.6rem 1rem;">Flax Linen</td>
                                         <td style="padding: 0.6rem 1rem; text-align: right;">235,148</td>
                                         <td style="padding: 0.6rem 1rem; text-align: right;">95.28 %</td>
                                         <td style="padding: 0.6rem 1rem; text-align: right;">0.1538</td>
                                         <td style="padding: 0.6rem 1rem; text-align: right;">1.26</td>
                                         <td style="padding: 0.6rem 1rem; text-align: right;">≈ 0.38</td>
+                                    </tr>
+                                    <tr>
+                                        <td style="padding: 0.6rem 1rem;">MLX (Metal GPU)</td>
+                                        <td style="padding: 0.6rem 1rem; text-align: right;">235,148</td>
+                                        <td style="padding: 0.6rem 1rem; text-align: right;"><strong>96.28 %</strong></td>
+                                        <td style="padding: 0.6rem 1rem; text-align: right;"><strong>0.1220</strong></td>
+                                        <td style="padding: 0.6rem 1rem; text-align: right;">1.62</td>
+                                        <td style="padding: 0.6rem 1rem; text-align: right;">≈ 0.54</td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -173,22 +183,31 @@
                         <ol>
                             <li>
                                 <strong>The parameter counts are byte-identical</strong> (235,148).
-                                Three completely independent implementations agree on the model
+                                Four completely independent implementations agree on the model
                                 size — a small but real cross-framework consistency check.
                             </li>
                             <li>
-                                <strong>Final test accuracies fall in a 0.42 pp window</strong>
-                                (94.97 – 95.39). The remaining gap is the same kind of seed /
-                                shuffle-order noise you'd see comparing PyTorch to PyTorch with
-                                different seeds. There is no framework that "doesn't work" with
-                                Yat layers.
+                                <strong>Final test accuracies fall in a 1.31 pp window</strong>
+                                (94.97 – 96.28). The remaining gap is the same kind of seed /
+                                shuffle-order / device-rounding noise you'd see comparing PyTorch
+                                to PyTorch with different seeds. There is no framework that
+                                "doesn't work" with Yat layers.
                             </li>
                             <li>
-                                <strong>JAX (NNX & Linen) is ≈ 3× faster on CPU here.</strong>
-                                Same model, same data, same optimizer. The difference is the
-                                XLA JIT pipeline — Yat's element-wise + reduce structure is
+                                <strong>JAX (NNX & Linen) is ≈ 3× faster on CPU here</strong> —
+                                same model, same data, same optimizer. The difference is the
+                                XLA JIT pipeline; Yat's element-wise + reduce structure is
                                 friendly to it. On GPU/TPU the gap closes (and PyTorch's
                                 <code>torch.compile</code> recovers most of it).
+                            </li>
+                            <li>
+                                <strong>MLX on Metal lands a real receipt</strong>: 96.28 %
+                                in 1.62 s on the Apple Silicon GPU — slightly faster than the
+                                XLA-CPU runs and the best accuracy of the four. The
+                                <code>cpu</code> device run is bit-identical to the GPU run
+                                (96.28 % both ways), so MLX's <em>backend</em> isn't doing
+                                anything funny — the Yat trajectory simply lands on a slightly
+                                better local minimum at this seed. We'll take it.
                             </li>
                         </ol>
 
@@ -221,6 +240,10 @@
                                         <td style="padding: 0.5rem 1rem; text-align: right;">0.8967</td>
                                         <td style="padding: 0.5rem 1rem; text-align: right;">0.2386</td>
                                         <td style="padding: 0.5rem 1rem; text-align: right;">0.1808</td></tr>
+                                    <tr><td style="padding: 0.5rem 1rem;">MLX (Metal GPU)</td>
+                                        <td style="padding: 0.5rem 1rem; text-align: right;">0.4490</td>
+                                        <td style="padding: 0.5rem 1rem; text-align: right;">0.1630</td>
+                                        <td style="padding: 0.5rem 1rem; text-align: right;">0.1271</td></tr>
                                 </tbody>
                             </table>
                         </div>
@@ -291,6 +314,10 @@ PYTHONPATH=src python -m nmn.nnx.examples.vision.mnist \
 # Flax Linen
 PYTHONPATH=src python -m nmn.linen.examples.mnist \
     --epochs 3 --report .context/linen_mnist.json
+
+# MLX (Apple Silicon, --device gpu or cpu)
+PYTHONPATH=src python -m nmn.mlx.examples.mnist \
+    --epochs 3 --device gpu --report .context/mlx_mnist.json
 
 # TensorFlow (needs tensorflow + tensorflow-datasets)
 PYTHONPATH=src python -m nmn.tf.examples.mnist \


### PR DESCRIPTION
## Summary

Adds `nmn.mlx` — an Apple-Silicon-native NMN backend built on [MLX](https://github.com/ml-explore/mlx) — bringing the library from five frameworks (PyTorch, Flax NNX, Flax Linen, Keras 3, TensorFlow) to six. Numerical parity with the other backends is verified by the existing cross-framework integration matrix; a measured MNIST receipt on Metal GPU is included.

11 commits, each a self-contained PR-sized slice:

| # | Commit | What it adds |
| --- | --- | --- |
| 1 | `1e67852` | Scaffold + `YatNMN` + squashers + pyproject `mlx` extra |
| 2 | `58bbe85` | `YatConv{1,2,3}D` + `YatConvTranspose{1,2,3}D` (incl. grouped conv) |
| 3 | `203cdad` | `YatEmbed` + `MultiHeadYatAttention` + functional helpers |
| 4 | `3c6a51b` | MLX wired into `tests/integration/test_yat_nmn_parity.py` + `test_cross_framework.py` |
| 5 | `fdff13f` | Runnable MNIST script + `docs/guides/mlx.md` + blog post row 20 |
| 6 | `4040b07` | DropConnect on dense + conv + conv-transpose; weight-normalized conv fast path |
| 7 | `116b7d5` | `RotaryYatAttention` (RoPE + YAT) |
| 8 | `bdb5ea6` | Spherical-YAT-Performer (O(n) linear-complexity attention) |
| 9 | `5a72db8` | `CIRCULAR` / `REFLECT` / `CAUSAL` conv padding modes |
| 10 | `15b4fab` | Autoregressive KV cache for `RotaryYatAttention` |
| 11 | `e5cc6bd` | Fused `mx.fast.metal_kernel` YAT score (Tier 2 perf) with `custom_function` VJP |

## Feature parity with NNX

| Layer / helper | MLX |
| --- | :-: |
| `YatNMN` (all 10 NNX flags) | ✅ |
| `YatConv{1,2,3}D` (groups, DropConnect, weight_normalized, all padding modes) | ✅ |
| `YatConvTranspose{1,2,3}D` (DropConnect) | ✅ |
| `YatEmbed` (`__call__` + `.attend`) | ✅ |
| `MultiHeadYatAttention` | ✅ |
| `RotaryYatAttention` + autoregressive KV cache | ✅ |
| `yat_tp_attention` (Spherical-YAT-Performer) | ✅ |
| `softermax` / `softer_sigmoid` / `soft_tanh` | ✅ |
| Fused YAT score on Metal GPU | ✅ |

## Numbers (measured, seed=0)

**MNIST cross-framework comparison** (3 epochs, batch=128, lr=3e-4):

| Framework | Test acc | Total time | Device |
| --- | --- | --- | --- |
| PyTorch | 94.97 % | 4.67 s | CPU |
| Flax NNX | 95.39 % | 1.68 s | CPU |
| Flax Linen | 95.28 % | 1.26 s | CPU |
| **MLX** | **96.28 %** | **1.62 s** | Metal GPU |

MLX `--device cpu` reproduces the same 96.28 % accuracy in 2.39 s (bit-identical trajectory). Reproducible via `python -m nmn.mlx.examples.mnist --device gpu --report .context/mlx_mnist.json`.

**Cross-framework YAT parity:** `tests/integration/test_yat_nmn_parity.py` runs 24 parametric cases (`spherical × weight_normalized × learnable_epsilon × bias_mode`) and asserts MLX agrees with PyTorch / NNX / Linen on every combination, < 2e-4 rtol on CPU.

**KV cache correctness:** `tests/test_mlx/test_kv_cache.py::test_decode_matches_causal_prefill_byte_identical` confirms causal full-prefill ≡ step-by-step decode at 0.0 max diff (every position).

**Fused metal kernel:** ~12 % speedup over the eager forward at in=512, out=1024, batch=64 on M-series GPU. Autograd works via `mx.custom_function`; gradients agree with central-difference reference.

## Test summary

- **125 new MLX-specific tests** in `tests/test_mlx/` (10 files)
- Plus 24 new cases in `tests/integration/test_yat_nmn_parity.py` covering MLX
- Plus 2 pairwise tests in `tests/integration/test_cross_framework.py::TestMlxVsTorch`
- Full sweep: **217 passed / 8 skipped** across `tests/test_mlx + tests/integration`
- Existing 513 torch/nnx/linen tests still pass — zero regressions

## Packaging

- `mlx = ["mlx>=0.18.0"]` extra in `pyproject.toml`
- Kept **out of `nmn[all]`** because MLX wheels are darwin-arm64-only (Linux/Windows users get a clean install)
- Install via `pip install \"nmn[mlx]\"` on Apple Silicon

## Docs

- New `docs/guides/mlx.md` (13 sections: install → MNIST → CNN → attention → embeddings → fused kernel → DropConnect → device notes → troubleshooting)
- `README.md` and `docs/README.md` bumped to "Six frameworks" with MLX added to install / framework / layer-support tables
- `docs/migration.md` gains an MLX section + lazy-build callout
- `EXAMPLES.md` gains an MLX quick-start, runnable-script entry, and import reference
- `website/blog-pages/20-cross-framework-mnist.html` gains a fourth row with measured MLX numbers and updates the headline/analysis copy

## Test plan

- [ ] `pip install \".[mlx,test]\"` on a darwin-arm64 host
- [ ] `pytest tests/test_mlx -q` → expect 125 passed, 1 skipped
- [ ] `pytest tests/integration/test_yat_nmn_parity.py tests/integration/test_cross_framework.py -q` → expect parity holds with MLX in the mix
- [ ] `python -m nmn.mlx.examples.mnist --device gpu --report /tmp/mlx_mnist.json` → expect ≈96 % test accuracy
- [ ] On a Linux runner, confirm `nmn[all]` still installs cleanly (no MLX dep pulled in)

## Known limitations / future work

- Fused metal kernel is intentionally a simple one-thread-per-output forward — a tiled / simdgroup-matmul rewrite would give a bigger speedup but is out of scope here
- `YatConvTranspose*` is groups=1 only (an MLX restriction, not a YAT one — `mx.core.conv_transpose*d` doesn't support grouped transposed conv)
- LayerNorm-based QK normalization on `RotaryYatAttention` (the `normalize_qk` Module variant from NNX) isn't ported — the simpler L2-normalize flag in `MultiHeadYatAttention` covers the common case