### PR TITLE
feat(mlx): GOAT value-only / projection-free YAT attention

### DIFF
--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -25,6 +25,11 @@ from .performer import (
     yat_tp_features,
     yat_tp_attention,
 )
+from .goat import (
+    GoatYatAttention,
+    goat_yat_attention,
+    goat_yat_attention_weights,
+)
 from .fused import fused_yat_score, is_gpu_available
 from .squashers import softermax, softer_sigmoid, soft_tanh
 
@@ -60,6 +65,9 @@ __all__ = [
     "create_yat_tp_projection",
     "yat_tp_features",
     "yat_tp_attention",
+    "GoatYatAttention",
+    "goat_yat_attention",
+    "goat_yat_attention_weights",
     "fused_yat_score",
     "is_gpu_available",
     "softermax", "softer_sigmoid", "soft_tanh",

--- a/src/nmn/mlx/goat.py
+++ b/src/nmn/mlx/goat.py
@@ -1,0 +1,220 @@
+"""GOAT — Geometry-Only Attention Transformer (MLX backend).
+
+Value-only / projection-free YAT-kernel attention. Unlike
+:class:`~nmn.mlx.attention.MultiHeadYatAttention` (full Q/K/V projections +
+softmax), GOAT attention drops the query/key projections entirely: the YAT
+kernel
+
+.. math::
+
+    k(u, u') = \\frac{(u \\cdot u' + b)^2}{\\lVert u - u' \\rVert^2 + \\varepsilon}
+
+is evaluated on the *raw* head slices of the residual stream, and the
+attention weights are the :math:`\\ell_1`-normalised kernel (a
+Nadaraya--Watson kernel smoother) rather than a softmax. Two tiers, following
+the GOAT family:
+
+* ``variant="v"``   — GOAT-V: value-only. Only ``W_V`` (and ``W_O``) remain;
+  halves the attention-side projection count vs. standard QKV.
+* ``variant="nov"`` — GOAT-noV: projection-free. Only ``W_O`` remains; values
+  are the raw head slices and ``W_O`` recovers V's role.
+
+Per-head ``(b, eps)`` are learnable and softplus-reparameterised (strictly
+positive :math:`\\varepsilon`, non-negative ``b``), so each head has its own
+kernel sharpness/offset -- the diversity that the dropped Q/K projections
+would otherwise provide. The kernel is PSD (a Schur product of the polynomial
+and inverse-multiquadric kernels), so the layer is a finite expansion in one
+RKHS and the attention weights ARE exact attribution via the representer
+theorem -- no surrogate needed.
+
+.. warning::
+
+    The self-mask is **mandatory** for self-attention. Because
+    :math:`k(u,u) = (\\lVert u \\rVert^2 + b)^2 / \\varepsilon` is the row
+    maximum, an unmasked :math:`\\ell_1` layer collapses onto the diagonal and
+    performs no cross-token mixing. ``self_mask=True`` (the default) zeroes the
+    diagonal before normalisation.
+
+Mask convention matches the rest of ``nmn.mlx``: ``True`` = attend,
+``False`` = mask out.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+__all__ = [
+    "goat_yat_attention_weights",
+    "goat_yat_attention",
+    "GoatYatAttention",
+]
+
+
+def _yat_scores(q: mx.array, k: mx.array, b: mx.array, eps: mx.array) -> mx.array:
+    """Raw (un-normalised) YAT kernel scores.
+
+    ``q``/``k`` are ``(B, H, Lq, D)`` / ``(B, H, Lk, D)``; ``b``/``eps`` are
+    ``(H,)`` (already positive). Returns ``(B, H, Lq, Lk)``, all non-negative.
+    """
+    b = b.reshape(1, -1, 1, 1)
+    eps = eps.reshape(1, -1, 1, 1)
+    dot = q @ mx.swapaxes(k, -1, -2)                       # (B, H, Lq, Lk)
+    qn = mx.sum(q * q, axis=-1, keepdims=True)             # (B, H, Lq, 1)
+    kn = mx.sum(k * k, axis=-1, keepdims=True)             # (B, H, Lk, 1)
+    dist2 = mx.maximum(qn + mx.swapaxes(kn, -1, -2) - 2.0 * dot, 0.0)
+    return (dot + b) ** 2 / (dist2 + eps)
+
+
+def goat_yat_attention_weights(
+    q: mx.array,
+    k: mx.array,
+    b: mx.array,
+    eps: mx.array,
+    mask: Optional[mx.array] = None,
+    self_mask: bool = True,
+    floor: float = 1e-8,
+) -> mx.array:
+    """:math:`\\ell_1`-normalised YAT-kernel attention weights on raw head slices.
+
+    Args:
+        q, k: ``(B, L, H, D)`` head-split tensors (no Q/K projection — these are
+            the raw residual-stream slices).
+        b, eps: ``(H,)`` per-head kernel scalars, already strictly positive
+            (i.e. post-softplus).
+        mask: optional ``(B, H, Lq, Lk)`` (or broadcastable) boolean mask,
+            ``True`` = attend.
+        self_mask: if ``True`` (default) and the map is square, zero the
+            diagonal before normalising. **Required for self-attention.**
+        floor: numerical floor on the row sum.
+
+    Returns:
+        ``(B, H, Lq, Lk)`` row-stochastic weights.
+    """
+    qh = mx.transpose(q, (0, 2, 1, 3))                     # (B, H, Lq, D)
+    kh = mx.transpose(k, (0, 2, 1, 3))                     # (B, H, Lk, D)
+    scores = _yat_scores(qh, kh, b, eps)                   # (B, H, Lq, Lk) >= 0
+    if self_mask and scores.shape[-2] == scores.shape[-1]:
+        n = scores.shape[-1]
+        scores = scores * (1.0 - mx.eye(n, dtype=scores.dtype))[None, None]
+    if mask is not None:
+        scores = scores * mask.astype(scores.dtype)
+    return scores / (mx.sum(scores, axis=-1, keepdims=True) + floor)
+
+
+def goat_yat_attention(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    b: mx.array,
+    eps: mx.array,
+    mask: Optional[mx.array] = None,
+    self_mask: bool = True,
+) -> mx.array:
+    """Apply GOAT weights to values.
+
+    ``q``/``k``/``v`` are ``(B, L, H, D)``. Returns ``(B, Lq, H, D)``.
+    """
+    w = goat_yat_attention_weights(q, k, b, eps, mask=mask, self_mask=self_mask)
+    vh = mx.transpose(v, (0, 2, 1, 3))                     # (B, H, Lk, D)
+    out = w @ vh                                           # (B, H, Lq, D)
+    return mx.transpose(out, (0, 2, 1, 3))                 # (B, Lq, H, D)
+
+
+class GoatYatAttention(nn.Module):
+    """Multi-head GOAT self-attention (value-only or projection-free).
+
+    Args:
+        embed_dim: total embedding dimension; must be divisible by ``num_heads``.
+        num_heads: number of attention heads.
+        variant: ``"v"`` (GOAT-V, value-only) or ``"nov"`` (GOAT-noV,
+            projection-free).
+        use_out_proj: whether to apply the output projection ``W_O``.
+        use_bias: whether ``W_V`` / ``W_O`` carry a bias.
+        epsilon: initial value of the (learnable, per-head) denominator
+            constant; stored as ``softplus``-inverse so that the effective
+            ``eps`` starts here and stays positive.
+        dtype: parameter/computation dtype.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        *,
+        variant: str = "v",
+        use_out_proj: bool = True,
+        use_bias: bool = False,
+        epsilon: float = 1.0,
+        dtype: mx.Dtype = mx.float32,
+    ):
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError(
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
+            )
+        if variant not in ("v", "nov"):
+            raise ValueError(f"variant must be 'v' or 'nov', got {variant!r}")
+        if epsilon <= 0:
+            raise ValueError(f"epsilon must be positive, got {epsilon}")
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.variant = variant
+        self.use_out_proj = use_out_proj
+        self.use_bias = use_bias
+        self.dtype = dtype
+
+        # Per-head learnable (b, eps), softplus-reparameterised.
+        # b_raw = 0 -> softplus(0) = log 2; eps_raw chosen so softplus = epsilon.
+        raw_eps = math.log(math.exp(epsilon) - 1.0)
+        self.b_raw = mx.zeros((num_heads,), dtype=dtype)
+        self.eps_raw = mx.full((num_heads,), raw_eps, dtype=dtype)
+
+        scale = embed_dim ** -0.5
+        if variant == "v":
+            self.v_kernel = mx.random.normal((embed_dim, embed_dim)).astype(dtype) * scale
+            if use_bias:
+                self.v_bias = mx.zeros((embed_dim,), dtype=dtype)
+        if use_out_proj:
+            self.out_kernel = mx.random.normal((embed_dim, embed_dim)).astype(dtype) * scale
+            if use_bias:
+                self.out_bias = mx.zeros((embed_dim,), dtype=dtype)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        self_mask: bool = True,
+    ) -> mx.array:
+        if x.dtype != self.dtype:
+            x = x.astype(self.dtype)
+        B, L, _ = x.shape
+        H, D = self.num_heads, self.head_dim
+
+        # Kernel runs on the RAW head slices: query == key, no Q/K projection.
+        qk = mx.reshape(x, (B, L, H, D))
+
+        if self.variant == "v":
+            v = x @ self.v_kernel
+            if getattr(self, "v_bias", None) is not None:
+                v = v + self.v_bias
+            v = mx.reshape(v, (B, L, H, D))
+        else:  # "nov": values are the raw head slices; W_O recovers V's role.
+            v = qk
+
+        b = nn.softplus(self.b_raw)
+        eps = nn.softplus(self.eps_raw)
+
+        out = goat_yat_attention(qk, qk, v, b, eps, mask=mask, self_mask=self_mask)
+        out = mx.reshape(out, (B, L, self.embed_dim))
+
+        if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
+            out = out @ self.out_kernel
+            if getattr(self, "out_bias", None) is not None:
+                out = out + self.out_bias
+        return out

--- a/tests/test_mlx/test_goat.py
+++ b/tests/test_mlx/test_goat.py
@@ -1,0 +1,80 @@
+"""Tests for the MLX GOAT (value-only / projection-free YAT) attention."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+
+from nmn.mlx import (  # noqa: E402
+    GoatYatAttention,
+    goat_yat_attention_weights,
+)
+
+
+def _pos_scalars(h):
+    return mlx_nn.softplus(mx.zeros((h,))), mlx_nn.softplus(mx.zeros((h,)))
+
+
+@pytest.mark.parametrize("variant", ["v", "nov"])
+def test_output_shape_and_finite(variant):
+    attn = GoatYatAttention(embed_dim=8, num_heads=2, variant=variant)
+    y = attn(mx.random.normal(shape=(2, 5, 8)))
+    assert y.shape == (2, 5, 8)
+    assert bool(mx.all(mx.isfinite(y)))
+
+
+def test_weights_are_l1_row_stochastic():
+    B, L, H, D = 2, 6, 2, 4
+    q = mx.random.normal(shape=(B, L, H, D))
+    b, eps = _pos_scalars(H)
+    w = goat_yat_attention_weights(q, q, b, eps, self_mask=True)
+    assert w.shape == (B, H, L, L)
+    rows = np.array(mx.sum(w, axis=-1))
+    np.testing.assert_allclose(rows, 1.0, atol=1e-4)
+
+
+def test_self_mask_zeros_diagonal():
+    B, L, H, D = 1, 5, 1, 4
+    q = mx.random.normal(shape=(B, L, H, D))
+    b, eps = _pos_scalars(H)
+    w = np.array(goat_yat_attention_weights(q, q, b, eps, self_mask=True))[0, 0]
+    np.testing.assert_allclose(np.diagonal(w), 0.0, atol=1e-7)
+
+
+def test_unmasked_collapses_to_diagonal():
+    # k(u,u) is the row maximum, so without the self-mask the diagonal dominates
+    # every row -- the documented collapse the self-mask exists to prevent.
+    B, L, H, D = 1, 5, 1, 4
+    q = mx.random.normal(shape=(B, L, H, D))
+    b, eps = _pos_scalars(H)
+    w = np.array(goat_yat_attention_weights(q, q, b, eps, self_mask=False))[0, 0]
+    assert np.all(np.argmax(w, axis=-1) == np.arange(L))
+
+
+def test_mask_zeroes_disallowed_positions():
+    B, L, H, D = 1, 4, 1, 3
+    q = mx.random.normal(shape=(B, L, H, D))
+    b, eps = _pos_scalars(H)
+    # forbid the last key for every query (True = attend)
+    mask = mx.concatenate([mx.ones((B, H, L, L - 1)), mx.zeros((B, H, L, 1))], axis=-1)
+    w = np.array(goat_yat_attention_weights(q, q, b, eps, mask=mask, self_mask=True))[0, 0]
+    np.testing.assert_allclose(w[:, -1], 0.0, atol=1e-7)
+
+
+@pytest.mark.parametrize("variant", ["v", "nov"])
+def test_gradients_flow(variant):
+    attn = GoatYatAttention(embed_dim=8, num_heads=2, variant=variant)
+    x = mx.random.normal(shape=(2, 5, 8))
+
+    def loss_fn(model):
+        return mx.mean(model(x) ** 2)
+
+    loss, grads = mlx_nn.value_and_grad(attn, loss_fn)(attn)
+    assert bool(mx.isfinite(loss))
+    # per-head kernel scalars are trainable and receive finite gradients
+    assert "b_raw" in grads and "eps_raw" in grads
+    assert bool(mx.all(mx.isfinite(grads["b_raw"])))
+    assert bool(mx.all(mx.isfinite(grads["eps_raw"])))


### PR DESCRIPTION
## What

Adds **GOAT** (Geometry-Only Attention Transformer) attention to the MLX backend — a value-only / projection-free counterpart to the existing `MultiHeadYatAttention`.

Where `MultiHeadYatAttention` keeps full Q/K/V projections and softmax, GOAT drops the query/key projections entirely and evaluates the YAT kernel

```
k(u, u') = (u·u' + b)² / (‖u − u'‖² + ε)
```

directly on the **raw head slices**, with **per-head learnable `(b, ε)`** (softplus) and **ℓ₁ normalisation** instead of softmax (the kernel is non-negative, so ℓ₁ gives a Nadaraya–Watson kernel smoother — no wasteful log→exp round-trip).

Two tiers:
- `variant="v"` — **GOAT-V**: value-only (`W_V` + `W_O`).
- `variant="nov"` — **GOAT-noV**: projection-free (`W_O` only); values are the raw head slices and `W_O` recovers V's role.

## Why

- **Parameter-lean & cache-light**: no Q/K projections; GOAT-noV has no attention-side KV state at all.
- **Interpretable by construction**: the kernel is PSD (Schur product of the polynomial and IMQ kernels), so the layer is a finite expansion in one RKHS and the attention weights *are* exact attribution via the representer theorem — no surrogate.
- **Per-head `(b, ε)`** give each head its own kernel geometry, recovering the diversity the dropped Q/K projections would otherwise provide.

## Self-mask (important)

`k(u,u) = (‖u‖² + b)² / ε` is the row maximum, so an unmasked ℓ₁ layer collapses onto the diagonal and does **no cross-token mixing**. `self_mask=True` (default) zeroes the diagonal before normalising. The mask convention matches the rest of `nmn.mlx` (`True` = attend).

## Contents

- `src/nmn/mlx/goat.py` — `GoatYatAttention` (`nn.Module`) plus functional `goat_yat_attention` / `goat_yat_attention_weights`.
- Exported from `nmn.mlx`.
- `tests/test_mlx/test_goat.py` — output shape (both variants), ℓ₁ row-stochasticity, self-mask diagonal zeroing, the unmasked-collapse property, padding-mask, and gradient flow to the per-head scalars. **8 passed locally.**

## Notes / follow-ups

- MLX only for now; the nnx/tf/keras backends can get a matching `GoatYatAttention` in a follow-up.
- Self-attention module (single input); the functional helpers accept distinct `q`/`k` for cross-attention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)