### PR TITLE
feat: bias-aware MAY/RAY linear-attention feature maps + YatNMN lazy mode (all frameworks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,46 @@ Flax NNX ↔ Flax Linen      │ < 1e-7       │ ✅
 
 Run yourself: `pytest tests/integration/test_cross_framework_consistency.py -v`.
 
+### Bias-aware linear-attention feature maps (MAY / RAY)
+
+Linearized spherical-Yat attention approximates the kernel
+`κ(s) = (s + b)² / ((2 + ε) − 2s)` (with `s = q̂·k̂`) by a feature map `φ` so that
+`φ(q)·φ(k) ≈ κ`, giving **O(n)** attention. Three feature maps ship across all
+frameworks (`create_*_projection` + `*_features` + `*_yat_attention`):
+
+| Feature map | Module (per framework) | Bias `b` | Best regime |
+| ----------- | ---------------------- | :------: | ----------- |
+| **SLAY** (anchor) | `spherical_yat_performer` / `performer` | `b = 0` only | bias-free kernel |
+| **MAY** (Random Maclaurin) | `maclaurin_yat` / `may` / `performer_yat` | **any `b`** | `b > 0` — near-exact |
+| **RAY** (radial) | `radial_yat` / `ray` / `performer_yat` | **any `b`** | sharp-`ε` route |
+
+Trained Yat-attention learns a per-head bias `b > 0`, which SLAY's `b = 0` anchors
+cannot represent. **MAY** is bias-aware and near-exact there. Benchmark (cosine
+similarity of linearized vs exact attention output, `d=64`, `N=512`, matched
+`F=256`, `ε = median sq-distance`, reproduced by `tests/scripts/benchmark_may_ray.py`):
+
+```
+   b  │  MAY   │  SLAY      b  │  MAY   │  SLAY
+ ─────┼────────┼──────    ─────┼────────┼──────
+ 0.00 │  0.20  │  0.52     1.00 │  0.89  │  0.84
+ 0.25 │  0.52  │  0.66     2.00 │  0.97  │  0.86
+ 0.50 │  0.74  │  0.78     4.00 │  0.99  │  0.87   ← SLAY floors, MAY → exact
+```
+
+SLAY wins only at its `b = 0` design point; for the `b > 0` deployment regime MAY
+beats it and keeps improving with the feature budget. On NNX the attention layer
+takes a selector: `performer_kind="slay" | "maclaurin" | "radial"` (default `slay`).
+MAY/RAY features are sign-indefinite — see the module docstrings for the caveat.
+
+### Lazy YatNMN training (freeze kernel)
+
+`YatNMN(..., lazy=True)` (alias `freeze_kernel=True`) freezes **only the kernel**
+(feature directions) while keeping **`bias`, `alpha`, and `epsilon` trainable** — a
+cheap-adaptation / α-ε-probing regime. The freeze uses each backend's idiomatic
+mechanism (NNX `FrozenParam` excluded from `nnx.state(model, nnx.Param)`, torch
+`requires_grad=False`, mlx `freeze`, Keras/TF `trainable=False`, linen
+`stop_gradient`). Defaults are unchanged (`lazy=False`).
+
 ---
 
 ## The math, in one minute

--- a/src/nmn/keras/__init__.py
+++ b/src/nmn/keras/__init__.py
@@ -10,6 +10,15 @@ from .attention import (
     yat_attention_normalized,
 )
 from .squashers import softermax, softer_sigmoid, soft_tanh
+from .performer_yat import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
 
 try:
     from .conv import (
@@ -39,4 +48,12 @@ __all__ = [
     "yat_attention_normalized",
     # Squashers
     "softermax", "softer_sigmoid", "soft_tanh",
+    # Performer (MAY / RAY bias-aware linear-attention feature maps)
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
 ] + _conv_all

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -58,6 +58,8 @@ class YatNMN(Layer):
         learnable_epsilon=False,
         spherical=False,
         weight_normalized=False,
+        lazy=False,
+        freeze_kernel=None,
         kernel_initializer="glorot_normal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -76,6 +78,14 @@ class YatNMN(Layer):
         self.positive_init = positive_init
         self.spherical = spherical
         self.weight_normalized = weight_normalized
+
+        # Lazy mode (issue #37): freeze ONLY the kernel (its feature directions),
+        # while bias, alpha, and learnable epsilon stay trainable. `freeze_kernel`
+        # is an alias; if either is truthy the kernel becomes non-trainable.
+        if freeze_kernel is None:
+            freeze_kernel = lazy
+        self.lazy = bool(lazy or freeze_kernel)
+        self.freeze_kernel = self.lazy
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -109,13 +119,16 @@ class YatNMN(Layer):
     def build(self, input_shape):
         input_dim = input_shape[-1]
 
+        # In lazy mode the kernel is frozen: trainable=False excludes it from
+        # the optimizer/gradient updates entirely (not merely zero-grad). Bias,
+        # alpha, and epsilon below stay trainable=True.
         self.kernel = self.add_weight(
             name="kernel",
             shape=(input_dim, self.units),
             initializer=self.kernel_initializer,
             regularizer=self.kernel_regularizer,
             constraint=self.kernel_constraint,
-            trainable=True,
+            trainable=not self.lazy,
         )
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
@@ -240,6 +253,8 @@ class YatNMN(Layer):
             "learnable_epsilon": self.learnable_epsilon,
             "spherical": self.spherical,
             "weight_normalized": self.weight_normalized,
+            "lazy": self.lazy,
+            "freeze_kernel": self.freeze_kernel,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),

--- a/src/nmn/keras/performer_yat.py
+++ b/src/nmn/keras/performer_yat.py
@@ -201,8 +201,9 @@ def maclaurin_features(
     proj = ops.einsum("...d,mld->...ml", x, omegas)
 
     # mask[m, l] = l < N_m  →  (M, nmax); neutralize unused factors with 1.0.
-    l = ops.arange(nmax)
-    mask = ops.expand_dims(l, 0) < ops.expand_dims(degrees, 1)   # (M, nmax)
+    # Cast both sides to int32 so the comparison never mixes int32/int64.
+    l = ops.cast(ops.arange(nmax), "int32")
+    mask = ops.expand_dims(l, 0) < ops.cast(ops.expand_dims(degrees, 1), "int32")
     mask = ops.cast(mask, "bool")
     proj = ops.where(mask, proj, ops.ones_like(proj))
 

--- a/src/nmn/keras/performer_yat.py
+++ b/src/nmn/keras/performer_yat.py
@@ -1,0 +1,427 @@
+"""Bias-aware linear-attention feature maps for spherical YAT (Keras).
+
+This module implements two **bias-aware** random feature maps that linearize
+spherical YAT attention, plus a generic linear-attention readout that consumes
+them. It is the Keras counterpart of the nnx ``spherical_yat_performer`` and the
+mlx ``performer`` modules, but unlike those (which approximate the *bias-free*
+``b = 0`` kernel via the anchor / SLAY method), the maps here carry the
+per-head bias ``b`` directly.
+
+Spherical YAT kernel
+--------------------
+For L2-normalized query/key (``||q̂|| = ||k̂|| = 1``) with ``s = q̂·k̂``::
+
+    kappa(s) = (s + b)^2 / (C - 2 s),   C = 2 + eps
+
+where ``b`` is the per-head bias (deployment regime is ``b > 0``) and ``eps``
+is the YAT epsilon. In benchmarks ``eps`` is set to the *median squared
+distance* between normalized q and k (not ``1e-5``) — that is the regime where
+the Maclaurin map (MAY) shines.
+
+MAY — Random Maclaurin features (headline method)
+-------------------------------------------------
+The Maclaurin coefficients of ``kappa`` on the sphere are all non-negative for
+``b >= 0``::
+
+    beta_n = (1/C) (2/C)^n                                # coeffs of 1/(C - 2 s)
+    a_n    = beta_{n-2} + 2 b beta_{n-1} + b^2 beta_n     # (beta_{-1}=beta_{-2}=0)
+
+Truncating at ``nmax`` and writing ``Z = sum_n a_n``, ``p_n = a_n / Z``, the
+randomized estimator draws ``M`` degrees ``N_r ~ Categorical(p)`` and, for each,
+``N_r`` Rademacher vectors ``omega in {-1, +1}^d``. The feature is the product
+over the drawn Rademacher projections::
+
+    phi_r(x̂) = sqrt(Z / M) * prod_{l < N_r} (omega[r, l] · x̂)
+
+with degree-0 draws contributing the constant feature ``sqrt(Z / M)`` (this is
+exactly what lets MAY attend *diffusely* — the ``b = 0`` anchor method cannot).
+The estimator is **unbiased**: ``E[phi(q̂)·phi(k̂)] = kappa(q̂·k̂)``.
+
+RAY — sketched degree-2 modulation × radial RFF (secondary method)
+------------------------------------------------------------------
+Augmenting ``z = [x̂, sqrt(b)]`` gives ``z_q·z_k = s + b`` and
+``||z_q - z_k||^2 = ||q̂ - k̂||^2``, so::
+
+    kappa = (z_q·z_k)^2 · 1 / (eps + ||z_q - z_k||^2)
+
+a product of two PSD kernels. ``(z_q·z_k)^2`` is sketched by two independent
+random projections; ``1/(eps + r^2)`` is approximated by Gauss-Laguerre
+quadrature over the exponential-integral representation, each node giving a
+Gaussian RBF realized as a random Fourier feature. RAY targets the hard
+sharp-``eps`` regime and is expected to underperform MAY (comparable to SLAY).
+
+Sign-indefinite caveat
+----------------------
+Both MAY and RAY features are **sign-indefinite**: odd-degree Rademacher
+products (MAY) and cosine RFFs (RAY) can be negative, so the linear-attention
+denominator can in principle go non-positive. Do **not** add an epsilon to the
+features themselves — that biases the (unbiased) estimator. A small epsilon is
+added only to the *denominator* for division stability. Empirically the maps are
+well-conditioned at ``b > 0``.
+
+All projections are sampled once at construction with NumPy (so they are fixed
+and shared by q and k); the per-token feature maps and the attention readout use
+``keras.src.ops`` and therefore run on whatever Keras backend is active.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional
+
+import numpy as np
+from keras.src import ops
+
+__all__ = [
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+]
+
+
+# --------------------------------------------------------------------------
+# Shared helpers
+# --------------------------------------------------------------------------
+def _normalize(x, epsilon: float = 1e-6):
+    """L2-normalize over the last axis (the spherical assumption)."""
+    norm = ops.sqrt(ops.sum(ops.square(x), axis=-1, keepdims=True) + epsilon)
+    return x / norm
+
+
+def maclaurin_coeffs(b: float, eps: float, nmax: int) -> np.ndarray:
+    """Maclaurin coefficients ``a_n`` of ``kappa`` on the sphere.
+
+    ``a_n = beta_{n-2} + 2 b beta_{n-1} + b^2 beta_n`` with
+    ``beta_n = (1/C)(2/C)^n`` and ``C = 2 + eps``. All entries are ``>= 0`` for
+    ``b >= 0`` (this is what makes the categorical sampling well-defined).
+
+    Returns:
+        ``a`` of shape ``(nmax + 1,)``.
+    """
+    C = 2.0 + eps
+    n = np.arange(nmax + 1)
+    beta = (1.0 / C) * (2.0 / C) ** n
+    a = b * b * beta.copy()
+    a[1:] += 2.0 * b * beta[:-1]
+    a[2:] += beta[:-2]
+    return a
+
+
+# --------------------------------------------------------------------------
+# MAY — Random Maclaurin features
+# --------------------------------------------------------------------------
+def create_maclaurin_projection(
+    head_dim: int,
+    num_features: int = 256,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    nmax: int = 40,
+    seed: Optional[int] = None,
+    dtype: str = "float32",
+) -> Dict[str, Any]:
+    """Precompute the fixed projection for MAY (Random Maclaurin) features.
+
+    Args:
+        head_dim: Per-head dimension ``d``.
+        num_features: ``M`` — number of Maclaurin features produced per token.
+        bias: Per-head bias (deployment regime ``bias > 0``). The map is bias-aware.
+        epsilon: YAT epsilon (``C = 2 + epsilon``). Set to the median squared
+            distance between normalized q/k for the benchmark regime.
+        nmax: Maclaurin truncation order (default 40).
+        seed: Optional integer seed for deterministic projections.
+        dtype: Float dtype string for the emitted feature arrays.
+
+    Returns:
+        Dict with ``omegas`` ``(M, nmax, d)`` Rademacher tensor, ``degrees``
+        ``(M,)`` integer degrees ``N_r``, scalar ``Z``, and the integers
+        ``num_features`` (``M``) and ``nmax``.
+    """
+    rng = np.random.default_rng(seed)
+    a = maclaurin_coeffs(bias, epsilon, nmax)
+    Z = float(a.sum())
+    p = a / Z
+    # Degrees N_r ~ Categorical(a_n / Z); degree 0 → constant feature.
+    degrees = rng.choice(len(a), size=num_features, p=p).astype(np.int64)
+    # Rademacher vectors: (M, nmax, d); only the first N_r are actually used.
+    omegas = rng.choice([-1.0, 1.0], size=(num_features, nmax, head_dim))
+
+    return {
+        "omegas": ops.convert_to_tensor(omegas.astype(dtype)),   # (M, nmax, d)
+        "degrees": ops.convert_to_tensor(degrees),               # (M,)
+        "Z": Z,
+        "num_features": num_features,
+        "nmax": nmax,
+        "head_dim": head_dim,
+        "b": float(bias),
+        "epsilon": epsilon,
+    }
+
+
+def maclaurin_features(
+    x,
+    params: Dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+):
+    """Compute MAY features ``phi(x) in R^M`` for every ``(..., d)`` token.
+
+    Faithful to the verified NumPy reference::
+
+        proj[..., r, l] = omega[r, l] · x̂
+        mask[r, l]      = (l < N_r)
+        proj            = where(mask, proj, 1.0)          # neutralize l >= N_r
+        phi_r(x̂)        = sqrt(Z / M) * prod_l proj[..., r, l]
+
+    Args:
+        x: ``(..., d)`` (e.g. ``(B, T, H, d)``); normalized to the unit sphere.
+        params: Output of :func:`create_maclaurin_projection`.
+        normalize: L2-normalize ``x`` first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., M)``. **Sign-indefinite** — do not add an
+        epsilon to these (it would bias the unbiased estimator).
+    """
+    if normalize:
+        x = _normalize(x, epsilon)
+
+    omegas = params["omegas"]          # (M, nmax, d)
+    degrees = params["degrees"]        # (M,)
+    M = params["num_features"]
+    nmax = params["nmax"]
+    Z = params["Z"]
+
+    x = ops.cast(x, omegas.dtype)
+
+    # proj[..., m, l] = sum_d x[..., d] * omega[m, l, d]  →  (..., M, nmax)
+    proj = ops.einsum("...d,mld->...ml", x, omegas)
+
+    # mask[m, l] = l < N_m  →  (M, nmax); neutralize unused factors with 1.0.
+    l = ops.arange(nmax)
+    mask = ops.expand_dims(l, 0) < ops.expand_dims(degrees, 1)   # (M, nmax)
+    mask = ops.cast(mask, "bool")
+    proj = ops.where(mask, proj, ops.ones_like(proj))
+
+    # Product over the nmax (factor) axis → (..., M).
+    feat = ops.prod(proj, axis=-1)
+    scale = math.sqrt(Z / M)
+    return feat * scale
+
+
+# --------------------------------------------------------------------------
+# RAY — sketched degree-2 modulation × radial RFF
+# --------------------------------------------------------------------------
+def create_radial_projection(
+    head_dim: int,
+    sketch_m: int = 128,
+    num_radial: int = 8,
+    radial_dim: int = 64,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    seed: Optional[int] = None,
+    dtype: str = "float32",
+) -> Dict[str, Any]:
+    """Precompute the fixed projection for RAY (radial) features.
+
+    Builds the degree-2 sketch (two independent Gaussian projections that
+    approximate ``(z_q·z_k)^2``) and the radial RFF (Gauss-Laguerre over the
+    exponential-integral representation of ``1/(eps + r^2)``).
+
+    Args:
+        head_dim: Per-head dimension ``d``. The augmented dim is ``d + 1``.
+        sketch_m: Width ``m`` of the degree-2 sketch.
+        num_radial: Number of Gauss-Laguerre nodes.
+        radial_dim: RFF width per node.
+        bias: Per-head bias; folded into the augmented vector ``z = [x̂, sqrt(bias)]``.
+        epsilon: YAT epsilon (the ``r^2`` shift inside ``1/(eps + r^2)``).
+        seed: Optional integer seed.
+        dtype: Float dtype string for the emitted arrays.
+
+    Returns:
+        Dict with ``W1`` ``(m, d+1)``, ``W2`` ``(m, d+1)``,
+        ``omegas`` ``(num_radial, radial_dim, d+1)``,
+        ``phases`` ``(num_radial, radial_dim)``, ``coef`` ``(num_radial,)``,
+        plus scalars ``b``, ``sketch_m``, ``radial_dim``, ``num_radial``.
+    """
+    rng = np.random.default_rng(seed)
+    da = head_dim + 1  # augmented z = [x̂, sqrt(b)]
+
+    # Degree-2 sketch: two independent projections → approximates (z·z')^2.
+    W1 = rng.standard_normal((sketch_m, da))
+    W2 = rng.standard_normal((sketch_m, da))
+
+    # Radial RFF for 1/(eps + r^2) via 1/(eps+r^2) = ∫ e^{-t(eps+r^2)} dt,
+    # Gauss-Laguerre over tau with the substitution t = tau / eps.
+    tau, wq = np.polynomial.laguerre.laggauss(num_radial)
+    t_nodes = tau / epsilon                 # t_j = tau_j / eps
+    coef = (1.0 / epsilon) * wq             # (1/eps) w_j
+    omegas, phases = [], []
+    for tj in t_nodes:
+        omegas.append(rng.standard_normal((radial_dim, da)) * np.sqrt(2.0 * tj))
+        phases.append(rng.uniform(0.0, 2.0 * np.pi, radial_dim))
+
+    return {
+        "W1": ops.convert_to_tensor(W1.astype(dtype)),
+        "W2": ops.convert_to_tensor(W2.astype(dtype)),
+        "omegas": ops.convert_to_tensor(np.stack(omegas).astype(dtype)),
+        "phases": ops.convert_to_tensor(np.stack(phases).astype(dtype)),
+        "coef": ops.convert_to_tensor(coef.astype(dtype)),
+        "b": float(bias),
+        "sketch_m": sketch_m,
+        "radial_dim": radial_dim,
+        "num_radial": num_radial,
+        "head_dim": head_dim,
+        "epsilon": epsilon,
+    }
+
+
+def radial_features(
+    x,
+    params: Dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+):
+    """Compute RAY features ``phi(x)`` for every ``(..., d)`` token.
+
+    Faithful to the verified NumPy reference: augment ``z = [x̂, sqrt(b)]``,
+    sketch ``psi(z)`` for ``(z·z')^2``, build per-node radial RFFs, and return
+    the tensor product ``psi(z) ⊗ phi_rad(z)`` flattened to the last axis.
+
+    Args:
+        x: ``(..., d)``; normalized to the unit sphere.
+        params: Output of :func:`create_radial_projection`.
+        normalize: L2-normalize ``x`` first.
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., sketch_m * num_radial * radial_dim)``. Also
+        **sign-indefinite** (cosine RFFs can be negative).
+    """
+    if normalize:
+        x = _normalize(x, epsilon)
+
+    W1 = params["W1"]
+    W2 = params["W2"]
+    omegas = params["omegas"]      # (num_radial, radial_dim, d+1)
+    phases = params["phases"]      # (num_radial, radial_dim)
+    coef = params["coef"]          # (num_radial,)
+    sketch_m = params["sketch_m"]
+    radial_dim = params["radial_dim"]
+    num_radial = params["num_radial"]
+    b = params["b"]
+
+    x = ops.cast(x, W1.dtype)
+    sqrt_b = math.sqrt(b)
+
+    # z = [x̂, sqrt(b)] → (..., d+1). Build the sqrt(b) pad from x so it carries
+    # the same (dynamic) leading shape without manual shape juggling.
+    pad = ops.zeros_like(x[..., :1]) + sqrt_b              # (..., 1) filled with sqrt(b)
+    z = ops.concatenate([x, pad], axis=-1)
+
+    # Degree-2 sketch psi(z): (..., sketch_m), approximates (z·z')^2.
+    psi = (ops.matmul(z, ops.transpose(W1)) * ops.matmul(z, ops.transpose(W2)))
+    psi = psi / math.sqrt(sketch_m)
+
+    # Radial RFF per node: (..., num_radial, radial_dim).
+    # proj[..., j, c] = sum_e z[..., e] * omega[j, c, e]
+    proj = ops.einsum("...e,jce->...jc", z, omegas)
+    proj = proj + phases                                   # broadcast (num_radial, radial_dim)
+    rff = math.sqrt(2.0 / radial_dim) * ops.cos(proj)      # (..., num_radial, radial_dim)
+    sqrt_coef = ops.sqrt(ops.maximum(coef, 0.0))           # (num_radial,)
+    rff = rff * ops.reshape(sqrt_coef, (num_radial, 1))    # scale each node
+
+    # Flatten the (num_radial, radial_dim) tail → phi_rad (..., R*radial_dim).
+    # ops.shape(...) returns a tuple of (possibly dynamic) dims; keep the leading
+    # dims as-is and collapse the trailing two into a single Python int.
+    rad_total = num_radial * radial_dim
+    lead = tuple(ops.shape(rff)[:-2])
+    phi_rad = ops.reshape(rff, lead + (rad_total,))
+
+    # Tensor product psi ⊗ phi_rad → (..., sketch_m, rad_total) → flatten.
+    out = ops.expand_dims(psi, -1) * ops.expand_dims(phi_rad, -2)
+    lead_out = tuple(ops.shape(out)[:-2])
+    return ops.reshape(out, lead_out + (sketch_m * rad_total,))
+
+
+# --------------------------------------------------------------------------
+# Linear-attention readout (feature-map-agnostic)
+# --------------------------------------------------------------------------
+def _linear_attention(q_feat, k_feat, value, causal: bool, epsilon: float):
+    """Generic linear attention from feature maps.
+
+    q_feat: ``(B, Q, H, F)``; k_feat: ``(B, K, H, F)``; value: ``(B, K, H, dv)``.
+    Returns ``(B, Q, H, dv)``. A small epsilon is added to the *denominator*
+    only (never to the features — that would bias the estimator).
+    """
+    value = ops.cast(value, q_feat.dtype)
+
+    if causal:
+        # kv[b, k, h, f, d] = k_feat[b, k, h, f] * value[b, k, h, d]
+        kv = ops.einsum("bkhf,bkhd->bkhfd", k_feat, value)
+        kv_cum = ops.cumsum(kv, axis=1)
+        k_cum = ops.cumsum(k_feat, axis=1)
+        num = ops.einsum("bqhf,bqhfd->bqhd", q_feat, kv_cum)
+        den = ops.einsum("bqhf,bqhf->bqh", q_feat, k_cum)
+        den = ops.expand_dims(den, -1) + epsilon
+        return num / den
+
+    # Non-causal: O(n) via the associativity trick.
+    kv = ops.einsum("bkhf,bkhd->bhfd", k_feat, value)
+    num = ops.einsum("bqhf,bhfd->bqhd", q_feat, kv)
+    k_sum = ops.sum(k_feat, axis=1)
+    den = ops.einsum("bqhf,bhf->bqh", q_feat, k_sum)
+    den = ops.expand_dims(den, -1) + epsilon
+    return num / den
+
+
+def maclaurin_yat_attention(
+    query,
+    key,
+    value,
+    params: Dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-9,
+    normalize: bool = True,
+):
+    """Linear-complexity spherical YAT attention via MAY features.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, dv)``.
+        params: Output of :func:`create_maclaurin_projection`.
+        causal: If ``True``, use prefix sums (each query sees keys up to its
+            own position).
+        epsilon: Stability constant added to the denominator only.
+        normalize: L2-normalize q/k first (the spherical assumption).
+
+    Returns:
+        ``(B, Q, H, dv)``.
+    """
+    q_feat = maclaurin_features(query, params, normalize=normalize)
+    k_feat = maclaurin_features(key, params, normalize=normalize)
+    return _linear_attention(q_feat, k_feat, value, causal, epsilon)
+
+
+def radial_yat_attention(
+    query,
+    key,
+    value,
+    params: Dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-9,
+    normalize: bool = True,
+):
+    """Linear-complexity spherical YAT attention via RAY features.
+
+    Same signature as :func:`maclaurin_yat_attention`, using radial features.
+    RAY is the weaker method (sharp-``eps`` regime); expect it to underperform
+    MAY and be comparable to the bias-free anchor (SLAY) baseline.
+    """
+    q_feat = radial_features(query, params, normalize=normalize)
+    k_feat = radial_features(key, params, normalize=normalize)
+    return _linear_attention(q_feat, k_feat, value, causal, epsilon)

--- a/src/nmn/linen/__init__.py
+++ b/src/nmn/linen/__init__.py
@@ -10,6 +10,17 @@ from .attention import (
     yat_attention_normalized,
 )
 from .squashers import softermax, softer_sigmoid, soft_tanh
+from .performer_yat import (
+    spherical_kappa,
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+    linear_attention,
+)
 
 try:
     from .conv import (
@@ -39,5 +50,15 @@ __all__ = [
     "yat_attention_normalized",
     # Squashers
     "softermax", "softer_sigmoid", "soft_tanh",
+    # Performer / linear-attention feature maps (MAY + RAY)
+    "spherical_kappa",
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+    "linear_attention",
 ] + _conv_all
 

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -42,6 +42,44 @@ class YatNMN(Module):
         norm at forward time. This optimization avoids recomputing kernel norms
         in YAT distance calculation since they are guaranteed to be 1.0
         (default: False).
+      lazy: if True, run in "lazy" mode where ONLY the ``kernel`` is frozen
+        (its feature directions do not receive gradients); ``bias``, ``alpha``
+        and the learnable ``epsilon`` remain trainable (default: False). Alias:
+        ``freeze_kernel``. See the freezing note below.
+      freeze_kernel: alias for ``lazy``; if either is True the kernel is frozen.
+
+    Freezing the kernel (lazy mode)
+    -------------------------------
+    Linen parameters are functional: there is no per-variable "trainable" flag
+    to remove the kernel from the optimizer. Two complementary mechanisms are
+    provided / recommended:
+
+    1. **In-layer (this module):** when ``lazy=True`` the kernel is read through
+       ``jax.lax.stop_gradient`` in ``__call__``, so no gradient flows into it.
+       The ``bias`` is NOT wrapped — it stays fully trainable, along with
+       ``alpha`` and the learnable ``epsilon``. This guarantees correctness even
+       if the caller forgets the optimizer-level mask below.
+
+    2. **Optimizer-level (recommended for true exclusion):** use ``optax``
+       ``multi_transform`` with a param-label tree that maps the ``kernel`` leaf
+       to a frozen transform and everything else to your real optimizer, so the
+       frozen kernel is excluded from the optimizer state entirely::
+
+           import optax
+           from flax.traverse_util import path_aware_map
+
+           def label_fn(params):
+               return path_aware_map(
+                   lambda path, _: "frozen" if path[-1] == "kernel" else "trainable",
+                   params,
+               )
+
+           tx = optax.multi_transform(
+               {"trainable": optax.adam(1e-3), "frozen": optax.set_to_zero()},
+               label_fn,
+           )
+
+       ``optax.set_to_zero()`` keeps the frozen kernel exactly constant.
     """
     features: int
     use_bias: bool = True
@@ -59,6 +97,8 @@ class YatNMN(Module):
     learnable_epsilon: bool = False
     spherical: bool = False
     weight_normalized: bool = False
+    lazy: bool = False
+    freeze_kernel: bool = False
     dot_general: DotGeneralT | None = None
     dot_general_cls: Any = None
     return_weights: bool = False
@@ -82,6 +122,14 @@ class YatNMN(Module):
             (self.features, jnp.shape(inputs)[-1]),
             self.param_dtype,
         )
+
+        # Lazy mode: freeze ONLY the kernel feature directions. Linen has no
+        # per-variable trainable flag, so we stop gradient on the kernel read
+        # here (bias/alpha/epsilon are intentionally NOT wrapped and stay
+        # trainable). For true exclusion from the optimizer state, also use the
+        # optax multi_transform pattern documented in the class docstring.
+        if self.lazy or self.freeze_kernel:
+            kernel = jax.lax.stop_gradient(kernel)
 
         # Apply positive init
         if self.positive_init:

--- a/src/nmn/linen/performer_yat.py
+++ b/src/nmn/linen/performer_yat.py
@@ -1,0 +1,463 @@
+"""Bias-aware linear-attention feature maps for spherical YAT (Flax Linen).
+
+This module provides **MAY** (Random Maclaurin) and **RAY** (radial) feature
+maps that linearize the spherical YAT attention kernel, together with a generic
+linear-attention readout. They are the Linen-framework counterpart of the nnx
+``spherical_yat_performer`` (SLAY / anchor) and the mlx ``performer`` modules,
+but unlike SLAY they are **bias-aware**.
+
+The kernel
+----------
+On unit vectors (``s = q̂·k̂`` with ``||q̂|| = ||k̂|| = 1``):
+
+    kappa(s) = (s + b)^2 / (C - 2 s),    C = 2 + eps
+
+where ``b`` is the per-head bias (the deployment regime is ``b > 0``) and
+``eps`` is the YAT epsilon. In benchmarks ``eps`` is set to the **median squared
+distance** between the normalized q and k (NOT 1e-5); that is the regime where
+MAY shines.
+
+The existing **SLAY** (anchor) method approximates only the ``b = 0`` kernel and
+cannot carry the bias. **MAY** and **RAY** approximate the full ``(s + b)^2``
+numerator, so they remain accurate as ``b`` grows. At ``b >= 1`` MAY clearly
+beats SLAY.
+
+MAY — Random Maclaurin features (headline method)
+-------------------------------------------------
+The Maclaurin coefficients of ``kappa`` on the sphere are all non-negative for
+``b >= 0``::
+
+    beta_n = (1/C) (2/C)^n                               # coeffs of 1/(C - 2 s)
+    a_n    = beta_{n-2} + 2 b beta_{n-1} + b^2 beta_n     # (beta_{-1}=beta_{-2}=0)
+
+Truncating at ``nmax`` and writing ``Z = sum_n a_n``, ``p_n = a_n / Z``, the
+Random-Maclaurin estimator samples a degree ``N_r ~ Categorical(p)`` per
+feature and forms a product of ``N_r`` Rademacher projections::
+
+    phi_r(x̂) = sqrt(Z / M) * prod_{l < N_r} (omega[r, l] · x̂)
+
+Degree-0 draws yield the **constant** feature, which is exactly what lets MAY
+attend diffusely (SLAY's ``b = 0`` design cannot). The estimator is unbiased::
+
+    E[phi(q̂) · phi(k̂)] = kappa(q̂ · k̂)
+
+**Caveat (sign-indefinite):** MAY features can be negative (odd-degree products),
+so the linear-attention denominator can in principle go non-positive. Do NOT add
+an epsilon to the *features* (that biases the estimator); add a small epsilon
+only to the *denominator* for division stability. Empirically well-conditioned
+for ``b > 0``.
+
+RAY — sketched degree-2 modulation x radial RFF (secondary method)
+------------------------------------------------------------------
+Augment ``z = [x̂, sqrt(b)]`` in R^{d+1} so that ``z_q·z_k = s + b`` and
+``||z_q - z_k||^2 = ||q̂ - k̂||^2``. Then ``kappa = (z_q·z_k)^2 / (eps + ||z_q -
+z_k||^2)`` is a product of two PSD kernels, sketched as:
+
+* a degree-2 sketch ``psi(z)`` with ``E[psi(z_q)·psi(z_k)] = (z_q·z_k)^2``;
+* a radial RFF for ``1/(eps + r^2)`` via Gauss-Laguerre quadrature of the
+  exponential-integral representation ``1/(eps+r^2) = ∫_0^∞ e^{-t(eps+r^2)} dt``.
+
+The RAY feature is the tensor product ``psi(z) ⊗ phi_rad(z)``, and is also
+sign-indefinite. RAY is the weaker method (the sharp-eps regime is hard); it is
+expected to underperform MAY and be comparable-ish to SLAY.
+
+Linear-attention readout
+-------------------------
+Given ``phi_q [.., Q, H, F]``, ``phi_k [.., K, H, F]``, ``v [.., K, H, dv]``::
+
+    kv  = sum_k phi_k ⊗ v          # [.., H, F, dv]
+    num = phi_q · kv               # [.., Q, H, dv]
+    den = phi_q · sum_k phi_k      # [.., Q, H]
+    out = num / (den + eps_div)
+
+Causal attention uses prefix sums. All projection constructors are plain
+``create_*_projection(key, ...)`` functions returning a parameter dict; the
+feature maps and the attention readout are pure ``jax``/``jnp`` functions.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+
+__all__ = [
+    "spherical_kappa",
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+    "linear_attention",
+]
+
+
+# --------------------------------------------------------------------------
+# Exact kernel (for reference / testing)
+# --------------------------------------------------------------------------
+def spherical_kappa(s: Array, b: float, eps: float = 1e-5) -> Array:
+    """Exact spherical-YAT kernel ``kappa(s) = (s + b)^2 / (C - 2 s)``.
+
+    Args:
+        s: Cosine similarity ``q̂·k̂`` of unit vectors.
+        b: Per-head bias.
+        eps: YAT epsilon (``C = 2 + eps``).
+
+    Returns:
+        ``kappa(s)`` with the same shape as ``s``.
+    """
+    C = 2.0 + eps
+    return (s + b) ** 2 / (C - 2.0 * s)
+
+
+def _normalize(x: Array, eps: float = 1e-6) -> Array:
+    """L2-normalize along the last axis."""
+    return x / jnp.sqrt(jnp.sum(x * x, axis=-1, keepdims=True) + eps)
+
+
+# --------------------------------------------------------------------------
+# Maclaurin coefficients
+# --------------------------------------------------------------------------
+def maclaurin_coeffs(b: float, eps: float, nmax: int) -> Array:
+    """Maclaurin coefficients of ``kappa`` on the sphere.
+
+    ``a_n = beta_{n-2} + 2 b beta_{n-1} + b^2 beta_n`` with
+    ``beta_n = (1/C)(2/C)^n`` and ``beta_{-1} = beta_{-2} = 0``. All entries are
+    non-negative for ``b >= 0``.
+
+    Args:
+        b: Per-head bias.
+        eps: YAT epsilon (``C = 2 + eps``).
+        nmax: Highest Maclaurin degree to retain (returns ``nmax + 1`` coeffs).
+
+    Returns:
+        ``a`` of shape ``[nmax + 1]``.
+    """
+    C = 2.0 + eps
+    n = jnp.arange(nmax + 1)
+    beta = (1.0 / C) * (2.0 / C) ** n
+    a = b * b * beta
+    # a[1:] += 2 b beta[:-1]
+    a = a.at[1:].add(2.0 * b * beta[:-1])
+    # a[2:] += beta[:-2]
+    a = a.at[2:].add(beta[:-2])
+    return a  # [nmax + 1], all >= 0 for b >= 0
+
+
+# --------------------------------------------------------------------------
+# MAY — Random Maclaurin features
+# --------------------------------------------------------------------------
+def create_maclaurin_projection(
+    key: Array,
+    head_dim: int,
+    num_features: int = 256,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    nmax: int = 40,
+    dtype: Any = jnp.float32,
+) -> dict[str, Any]:
+    """Build a (fixed) Random-Maclaurin projection shared by q and k.
+
+    Args:
+        key: JAX PRNG key.
+        head_dim: Per-head dimension ``d``.
+        num_features: ``M`` — number of output features.
+        bias: Per-head bias used to build the Maclaurin coefficients.
+        epsilon: YAT epsilon (``C = 2 + epsilon``).
+        nmax: Maclaurin truncation degree (default 40).
+        dtype: dtype for the stored Rademacher tensor.
+
+    Returns:
+        Dict with ``omegas`` ``[M, nmax, d]`` (Rademacher), ``degrees`` ``[M]``
+        (sampled ``N_r``), the scalar normalizer ``Z``, and the integers ``M``,
+        ``nmax``, ``head_dim``.
+    """
+    a = maclaurin_coeffs(bias, epsilon, nmax)
+    Z = jnp.sum(a)
+    p = a / Z
+
+    k_deg, k_omega = jax.random.split(key)
+    # N_r ~ Categorical(p), r = 1..M
+    degrees = jax.random.choice(
+        k_deg, a.shape[0], shape=(num_features,), p=p
+    )
+    # Rademacher vectors: [M, nmax, d]; only the first N_r are used per feature.
+    omegas = jnp.where(
+        jax.random.bernoulli(k_omega, 0.5, (num_features, nmax, head_dim)),
+        1.0,
+        -1.0,
+    ).astype(dtype)
+
+    return {
+        "omegas": omegas,          # (M, nmax, d)
+        "degrees": degrees,        # (M,)
+        "Z": Z,                    # scalar
+        "M": num_features,
+        "nmax": nmax,
+        "head_dim": head_dim,
+    }
+
+
+def maclaurin_features(
+    x: Array,
+    params: dict[str, Any],
+    normalize: bool = True,
+    eps: float = 1e-6,
+) -> Array:
+    """Random-Maclaurin feature map ``phi(x) ∈ R^M``.
+
+    Args:
+        x: ``(..., d)`` (e.g. ``(..., seq, heads, d)``).
+        params: Output of :func:`create_maclaurin_projection`.
+        normalize: L2-normalize ``x`` to the unit sphere first.
+        eps: Stability constant for the normalization denominator.
+
+    Returns:
+        Features ``(..., M)``. May be negative (sign-indefinite); do NOT add an
+        epsilon to these features (it biases the estimator).
+    """
+    if normalize:
+        x = _normalize(x, eps)
+
+    omegas = params["omegas"]          # (M, nmax, d)
+    degrees = params["degrees"]        # (M,)
+    Z = params["Z"]
+    M = params["M"]
+    nmax = omegas.shape[1]
+
+    # proj[..., m, l] = omega[m, l] · x̂
+    proj = jnp.einsum("...d,mld->...ml", x, omegas)   # (..., M, nmax)
+    l = jnp.arange(nmax)                               # (nmax,)
+    mask = l[None, :] < degrees[:, None]               # (M, nmax)
+    # neutralize unused factors (l >= N_r) by setting them to 1.0
+    proj = jnp.where(mask, proj, 1.0)
+    feat = jnp.prod(proj, axis=-1)                     # (..., M)
+    return jnp.sqrt(Z / M) * feat
+
+
+# --------------------------------------------------------------------------
+# RAY — sketched degree-2 modulation x radial RFF
+# --------------------------------------------------------------------------
+def _laggauss(n: int) -> tuple[Array, Array]:
+    """Gauss-Laguerre nodes/weights (computed in NumPy, returned as arrays)."""
+    import numpy as np
+
+    nodes, weights = np.polynomial.laguerre.laggauss(n)
+    return jnp.asarray(nodes), jnp.asarray(weights)
+
+
+def create_radial_projection(
+    key: Array,
+    head_dim: int,
+    sketch_m: int = 128,
+    num_radial: int = 8,
+    radial_dim: int = 64,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    dtype: Any = jnp.float32,
+) -> dict[str, Any]:
+    """Build a RAY projection (degree-2 sketch x radial RFF).
+
+    Augments ``z = [x̂, sqrt(bias)]`` so that ``z_q·z_k = s + bias`` and
+    ``||z_q - z_k||^2 = ||q̂ - k̂||^2``.
+
+    Args:
+        key: JAX PRNG key.
+        head_dim: Per-head dimension ``d`` (augmented to ``d + 1``).
+        sketch_m: Width ``m`` of the degree-2 sketch.
+        num_radial: Number of Gauss-Laguerre nodes for the radial RFF.
+        radial_dim: RFF features per radial node.
+        bias: Per-head bias (enters the augmentation).
+        epsilon: YAT epsilon (radial-kernel scale).
+        dtype: dtype for stored arrays.
+
+    Returns:
+        Dict with ``W1``, ``W2`` ``[m, d+1]``, ``omegas`` ``[num_radial,
+        radial_dim, d+1]``, ``phases`` ``[num_radial, radial_dim]``, ``coef``
+        ``[num_radial]``, plus ``bias``, ``sketch_m``, ``radial_dim``,
+        ``num_radial``, ``head_dim``.
+    """
+    da = head_dim + 1   # augmented z = [x̂, sqrt(bias)]
+    k_w1, k_w2, k_om, k_ph = jax.random.split(key, 4)
+
+    # degree-2 sketch: two independent projections -> approximates (z·z')^2
+    W1 = jax.random.normal(k_w1, (sketch_m, da), dtype=dtype)
+    W2 = jax.random.normal(k_w2, (sketch_m, da), dtype=dtype)
+
+    # radial RFF for 1/(eps + r^2) via Gauss-Laguerre over
+    # 1/(eps + r^2) = ∫ e^{-t(eps + r^2)} dt, substitute t = tau / eps.
+    tau, wq = _laggauss(num_radial)
+    t_nodes = tau / epsilon              # t_j = tau_j / epsilon
+    coef = (1.0 / epsilon) * wq          # (1/epsilon) w_j
+
+    # omega_j ~ N(0, 2 t_j I) ; phase ~ U(0, 2 pi)
+    base = jax.random.normal(k_om, (num_radial, radial_dim, da), dtype=dtype)
+    scale = jnp.sqrt(2.0 * t_nodes).astype(dtype)[:, None, None]
+    omegas = base * scale
+    phases = jax.random.uniform(
+        k_ph, (num_radial, radial_dim), dtype=dtype, minval=0.0, maxval=2.0 * math.pi
+    )
+
+    return {
+        "W1": W1,                           # (m, d+1)
+        "W2": W2,                           # (m, d+1)
+        "omegas": omegas,                   # (num_radial, radial_dim, d+1)
+        "phases": phases,                   # (num_radial, radial_dim)
+        "coef": coef.astype(dtype),         # (num_radial,)
+        "bias": float(bias),
+        "sketch_m": sketch_m,
+        "radial_dim": radial_dim,
+        "num_radial": num_radial,
+        "head_dim": head_dim,
+    }
+
+
+def radial_features(
+    x: Array,
+    params: dict[str, Any],
+    normalize: bool = True,
+    eps: float = 1e-6,
+) -> Array:
+    """RAY feature map ``phi(x) = psi(z) ⊗ phi_rad(z)``.
+
+    Args:
+        x: ``(..., d)``.
+        params: Output of :func:`create_radial_projection`.
+        normalize: L2-normalize ``x`` first.
+        eps: Stability constant for the normalization denominator.
+
+    Returns:
+        Features ``(..., sketch_m * num_radial * radial_dim)``. Sign-indefinite.
+    """
+    if normalize:
+        x = _normalize(x, eps)
+
+    bias = params["bias"]
+    sketch_m = params["sketch_m"]
+    radial_dim = params["radial_dim"]
+    num_radial = params["num_radial"]
+    W1, W2 = params["W1"], params["W2"]
+    omegas, phases, coef = params["omegas"], params["phases"], params["coef"]
+
+    # augment z = [x̂, sqrt(bias)]
+    sqrt_b = jnp.full(x.shape[:-1] + (1,), math.sqrt(bias), dtype=x.dtype)
+    z = jnp.concatenate([x, sqrt_b], axis=-1)            # (..., d+1)
+
+    # degree-2 sketch psi(z): (..., sketch_m), approximates (z·z')^2
+    proj1 = jnp.einsum("...a,ma->...m", z, W1)
+    proj2 = jnp.einsum("...a,ma->...m", z, W2)
+    psi = proj1 * proj2 / math.sqrt(sketch_m)            # (..., m)
+
+    # radial RFF per node: (..., num_radial, radial_dim)
+    proj = jnp.einsum("...a,jra->...jr", z, omegas) + phases
+    rff = jnp.sqrt(2.0 / radial_dim) * jnp.cos(proj)     # (..., num_radial, radial_dim)
+    sqrt_coef = jnp.sqrt(jnp.maximum(coef, 0.0))         # (num_radial,)
+    rff = rff * sqrt_coef[:, None]                       # broadcast over radial_dim
+    phi_rad = rff.reshape(x.shape[:-1] + (num_radial * radial_dim,))
+
+    # tensor product psi (x) phi_rad -> (..., sketch_m * radial_total)
+    out = jnp.einsum("...s,...r->...sr", psi, phi_rad)
+    return out.reshape(x.shape[:-1] + (sketch_m * num_radial * radial_dim,))
+
+
+# --------------------------------------------------------------------------
+# Linear-attention readout (feature-map agnostic)
+# --------------------------------------------------------------------------
+def linear_attention(
+    phi_q: Array,
+    phi_k: Array,
+    value: Array,
+    causal: bool = False,
+    eps_div: float = 1e-6,
+) -> Array:
+    """Generic linear-attention readout from feature maps.
+
+    Args:
+        phi_q: ``(B, Q, H, F)`` query features.
+        phi_k: ``(B, K, H, F)`` key features.
+        value: ``(B, K, H, dv)``.
+        causal: If True, use prefix sums so each query only sees keys up to its
+            own position.
+        eps_div: Small epsilon added to the *denominator* only (do not add to
+            the features — that would bias sign-indefinite MAY/RAY estimators).
+
+    Returns:
+        ``(B, Q, H, dv)``.
+    """
+    if causal:
+        # kv[b, k, h, f, d] = phi_k[b, k, h, f] * value[b, k, h, d]
+        kv = jnp.einsum("bkhf,bkhd->bkhfd", phi_k, value)
+        kv_cum = jnp.cumsum(kv, axis=1)
+        k_cum = jnp.cumsum(phi_k, axis=1)
+
+        num = jnp.einsum("bqhf,bqhfd->bqhd", phi_q, kv_cum)
+        den = jnp.einsum("bqhf,bqhf->bqh", phi_q, k_cum)
+        return num / (den[..., None] + eps_div)
+
+    kv = jnp.einsum("bkhf,bkhd->bhfd", phi_k, value)
+    num = jnp.einsum("bqhf,bhfd->bqhd", phi_q, kv)
+
+    k_sum = jnp.sum(phi_k, axis=1)
+    den = jnp.einsum("bqhf,bhf->bqh", phi_q, k_sum)
+    return num / (den[..., None] + eps_div)
+
+
+# --------------------------------------------------------------------------
+# Convenience attention wrappers
+# --------------------------------------------------------------------------
+def maclaurin_yat_attention(
+    query: Array,
+    key: Array,
+    value: Array,
+    params: dict[str, Any],
+    causal: bool = False,
+    eps_div: float = 1e-6,
+) -> Array:
+    """Linear-complexity bias-aware YAT attention via MAY features.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, dv)``.
+        params: Output of :func:`create_maclaurin_projection`.
+        causal: Causal masking via prefix sums.
+        eps_div: Denominator stability constant.
+
+    Returns:
+        ``(B, Q, H, dv)``.
+    """
+    phi_q = maclaurin_features(query, params, normalize=True)
+    phi_k = maclaurin_features(key, params, normalize=True)
+    return linear_attention(phi_q, phi_k, value, causal=causal, eps_div=eps_div)
+
+
+def radial_yat_attention(
+    query: Array,
+    key: Array,
+    value: Array,
+    params: dict[str, Any],
+    causal: bool = False,
+    eps_div: float = 1e-6,
+) -> Array:
+    """Linear-complexity bias-aware YAT attention via RAY features.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, dv)``.
+        params: Output of :func:`create_radial_projection`.
+        causal: Causal masking via prefix sums.
+        eps_div: Denominator stability constant.
+
+    Returns:
+        ``(B, Q, H, dv)``.
+    """
+    phi_q = radial_features(query, params, normalize=True)
+    phi_k = radial_features(key, params, normalize=True)
+    return linear_attention(phi_q, phi_k, value, causal=causal, eps_div=eps_div)

--- a/src/nmn/mlx/__init__.py
+++ b/src/nmn/mlx/__init__.py
@@ -25,6 +25,17 @@ from .performer import (
     yat_tp_features,
     yat_tp_attention,
 )
+from .may import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+)
+from .ray import (
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
 from .goat import (
     GoatYatAttention,
     goat_yat_attention,
@@ -65,6 +76,13 @@ __all__ = [
     "create_yat_tp_projection",
     "yat_tp_features",
     "yat_tp_attention",
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
     "GoatYatAttention",
     "goat_yat_attention",
     "goat_yat_attention_weights",

--- a/src/nmn/mlx/may.py
+++ b/src/nmn/mlx/may.py
@@ -1,0 +1,235 @@
+"""MAY — Random Maclaurin features for *bias-aware* spherical YAT attention (MLX).
+
+The spherical YAT kernel on unit vectors ``s = q̂·k̂`` (``‖q̂‖ = ‖k̂‖ = 1``) is
+
+    kappa(s) = (s + b)² / (C − 2 s),    C = 2 + ε
+
+where ``b`` is the per-head bias (the deployment regime is ``b > 0``) and ``ε``
+is the YAT epsilon. In benchmarks ``ε`` is set to the **median squared distance**
+between normalized ``q`` and ``k`` (NOT ``1e-5``) — that is the regime where MAY
+shines.
+
+The existing **SLAY** anchor method (:mod:`nmn.mlx.performer`) only approximates
+the ``b = 0`` kernel; it structurally cannot carry the bias. **MAY** is
+**bias-aware**: it expands ``kappa`` in a Maclaurin series and draws Random
+Maclaurin features whose expected inner product reproduces ``kappa`` *including*
+the ``b``-dependent terms.
+
+Maclaurin expansion (all coefficients non-negative for ``b ≥ 0``)::
+
+    beta_n = (1/C) (2/C)^n                              # coeffs of 1/(C − 2s)
+    a_n    = beta_{n-2} + 2 b beta_{n-1} + b² beta_n     # (beta_{-1}=beta_{-2}=0)
+
+Truncate at ``nmax`` (default 40), let ``Z = Σ_n a_n`` and ``p_n = a_n / Z``.
+The Random Maclaurin construction samples ``M`` degrees ``N_r ~ Categorical(p)``
+and, for each, ``N_r`` Rademacher vectors ``ω ∈ {−1,+1}^d``. The feature is the
+product of the corresponding ``ω·x̂`` factors scaled by ``√(Z/M)``::
+
+    phi_r(x̂) = √(Z/M) · Π_{l < N_r} (ω_{r,l} · x̂)
+
+so ``phi(x)`` has exactly ``M`` features and
+``E[phi(q̂)·phi(k̂)] = kappa(q̂·k̂)``. Degree-0 draws give a constant feature —
+this is what lets MAY attend diffusely (SLAY's ``b = 0`` cannot).
+
+**Caveat (sign-indefinite).** MAY features are sign-indefinite: odd-degree
+products can be negative, so the linear-attention denominator can in principle go
+non-positive. We do **not** add an epsilon to the features themselves (that would
+bias the unbiased estimator); a small epsilon is added only to the attention
+denominator for division stability. Empirically the construction is
+well-conditioned at ``b > 0``.
+
+Mirrors the signature style of :mod:`nmn.mlx.performer` (the SLAY file):
+numpy-seeded ``mx.array`` parameters, no jax key. The exact attention reference
+is :func:`nmn.mlx.attention.yat_attention_normalized`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import mlx.core as mx
+import numpy as np
+
+
+__all__ = [
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+]
+
+
+def maclaurin_coeffs(b: float, epsilon: float, nmax: int) -> np.ndarray:
+    """Maclaurin coefficients of ``kappa`` on the sphere.
+
+    ``a_n = beta_{n-2} + 2 b beta_{n-1} + b² beta_n`` with
+    ``beta_n = (1/C)(2/C)^n`` and ``C = 2 + epsilon``. All entries are ``≥ 0``
+    for ``b ≥ 0``.
+
+    Args:
+        b: Per-head bias.
+        epsilon: YAT epsilon (``C = 2 + epsilon``).
+        nmax: Truncation degree (returns ``nmax + 1`` coefficients).
+
+    Returns:
+        ``np.ndarray`` of shape ``(nmax + 1,)``.
+    """
+    C = 2.0 + epsilon
+    n = np.arange(nmax + 1)
+    beta = (1.0 / C) * (2.0 / C) ** n
+    a = (b * b) * beta.copy()
+    a[1:] += 2.0 * b * beta[:-1]
+    a[2:] += beta[:-2]
+    return a  # (nmax + 1,), all >= 0 for b >= 0
+
+
+def create_maclaurin_projection(
+    head_dim: int,
+    num_features: int = 256,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    nmax: int = 40,
+    dtype: mx.Dtype = mx.float32,
+    seed: Optional[int] = None,
+) -> dict[str, Any]:
+    """Precompute the (fixed) Random Maclaurin projection shared by q and k.
+
+    Args:
+        head_dim: Per-head dimension ``d``.
+        num_features: ``M`` — number of output features (one per random draw).
+        bias: Per-head bias ``b`` baked into the Maclaurin coefficients. The
+            deployment regime is ``b > 0`` (where MAY beats SLAY).
+        epsilon: YAT epsilon (``C = 2 + epsilon``). In benchmarks set this to
+            the median squared distance between normalized q and k.
+        nmax: Maclaurin truncation degree (default 40).
+        dtype: MLX dtype for the precomputed arrays.
+        seed: Optional integer seed for deterministic projections.
+
+    Returns:
+        Dict with the Rademacher tensor ``omegas`` ``(M, nmax, d)``, the integer
+        ``degrees`` ``(M,)``, the partition constant ``Z``, and the bookkeeping
+        integers ``head_dim``, ``num_features`` (``M``), ``nmax``.
+    """
+    rng = np.random.default_rng(seed)
+
+    a = maclaurin_coeffs(bias, epsilon, nmax)
+    Z = float(a.sum())
+    p = a / a.sum()
+
+    # Degrees N_r ~ Categorical(p), r = 1..M.
+    degrees_np = rng.choice(len(a), size=num_features, p=p).astype(np.int32)
+
+    # Dense Rademacher tensor: only the first N_r rows are used per feature.
+    omegas_np = rng.choice(
+        np.array([-1.0, 1.0], dtype=np.float32),
+        size=(num_features, nmax, head_dim),
+    ).astype(np.float32)
+
+    return {
+        "omegas": mx.array(omegas_np).astype(dtype),   # (M, nmax, d)
+        "degrees": mx.array(degrees_np),               # (M,) int32
+        "Z": Z,
+        "head_dim": head_dim,
+        "num_features": num_features,
+        "nmax": nmax,
+    }
+
+
+def maclaurin_features(
+    x: mx.array,
+    params: dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> mx.array:
+    """Compute the Random Maclaurin feature ``phi(x) ∈ ℝ^M`` per token.
+
+    ``phi_r(x̂) = √(Z/M) · Π_{l < N_r} (ω_{r,l} · x̂)``. Factors with ``l ≥ N_r``
+    are neutralized to ``1`` (so they drop out of the product). Degree-0 draws
+    yield the constant feature ``√(Z/M)``.
+
+    Args:
+        x: ``(..., seq_len, num_heads, head_dim)``.
+        params: Output of :func:`create_maclaurin_projection`.
+        normalize: L2-normalize inputs first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., seq_len, num_heads, M)``. Sign-indefinite.
+    """
+    if normalize:
+        x_norm = mx.sqrt(mx.sum(x * x, axis=-1, keepdims=True) + epsilon)
+        x = x / x_norm
+
+    omegas = params["omegas"]        # (M, nmax, d)
+    degrees = params["degrees"]      # (M,)
+    Z = params["Z"]
+    M = params["num_features"]
+    nmax = params["nmax"]
+
+    # proj[..., r, l] = ω_{r,l} · x̂  →  (..., M, nmax)
+    proj = mx.einsum("...d,mld->...ml", x, omegas)
+
+    # mask[r, l] = (l < N_r)  →  neutralize unused factors to 1.
+    l = mx.arange(nmax).reshape((1, nmax))                 # (1, nmax)
+    mask = l < degrees.reshape((M, 1))                     # (M, nmax) bool
+    proj = mx.where(mask, proj, mx.array(1.0, dtype=proj.dtype))
+
+    feat = mx.prod(proj, axis=-1)                          # (..., M)
+    return math.sqrt(Z / M) * feat
+
+
+def maclaurin_yat_attention(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    params: dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> mx.array:
+    """Linear-complexity *bias-aware* YAT attention via MAY features.
+
+    Linear-attention readout (feature-map-agnostic, mirrors the SLAY
+    ``yat_tp_attention``): ``out = (phi_q · Σ_k phi_k ⊗ v) / (phi_q · Σ_k phi_k)``.
+    A small ``epsilon`` is added only to the denominator (NOT to the features) —
+    MAY features are sign-indefinite, so the denominator is stabilized rather
+    than the unbiased estimator perturbed.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, v_dim)``.
+        params: Output of :func:`create_maclaurin_projection`.
+        causal: If ``True``, use prefix sums so each query only sees keys up to
+            its own position.
+        epsilon: Denominator stability constant.
+
+    Returns:
+        ``(B, Q, H, v_dim)``.
+    """
+    if query.dtype != value.dtype:
+        value = value.astype(query.dtype)
+    if key.dtype != query.dtype:
+        key = key.astype(query.dtype)
+
+    q_feat = maclaurin_features(query, params, normalize=True)
+    k_feat = maclaurin_features(key, params, normalize=True)
+
+    if causal:
+        kv = mx.einsum("bkhm,bkhd->bkhmd", k_feat, value)
+        kv_cum = mx.cumsum(kv, axis=1)
+        k_cum = mx.cumsum(k_feat, axis=1)
+
+        num = mx.einsum("bqhm,bqhmd->bqhd", q_feat, kv_cum)
+        den = mx.einsum("bqhm,bqhm->bqh", q_feat, k_cum)
+        den = den[..., None] + epsilon
+        return num / den
+
+    # Non-causal: O(n) via the associativity trick.
+    kv = mx.einsum("bkhm,bkhd->bhmd", k_feat, value)
+    num = mx.einsum("bqhm,bhmd->bqhd", q_feat, kv)
+
+    k_sum = mx.sum(k_feat, axis=1)
+    den = mx.einsum("bqhm,bhm->bqh", q_feat, k_sum)
+    den = den[..., None] + epsilon
+    return num / den

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -57,6 +57,14 @@ class YatNMN(nn.Module):
             distance term as it is known to be 1.
         return_weights: If ``True``, ``__call__`` returns
             ``(output, kernel)`` instead of just ``output``.
+        lazy: If ``True``, freeze ONLY the ``kernel`` (the feature directions)
+            so it is excluded from :meth:`trainable_parameters` and the
+            optimizer never updates it. The ``bias``, ``alpha`` and learnable
+            ``epsilon`` remain fully trainable. Implemented via mlx's
+            ``Module.freeze(keys=["kernel"])`` (the idiomatic per-variable
+            freeze), not stop-gradient. ``freeze_kernel`` is an accepted alias.
+            Default ``False`` (fully backward compatible).
+        freeze_kernel: Alias for ``lazy``.
 
     Example::
 
@@ -85,12 +93,17 @@ class YatNMN(nn.Module):
         spherical: bool = False,
         weight_normalized: bool = False,
         return_weights: bool = False,
+        lazy: bool = False,
+        freeze_kernel: Optional[bool] = None,
     ) -> None:
         super().__init__()
         if epsilon <= 0:
             raise ValueError(f"epsilon must be positive, got {epsilon}")
         if not 0.0 <= drop_rate < 1.0:
             raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
+
+        # ``freeze_kernel`` is an alias for ``lazy``; either enables lazy mode.
+        self.lazy = bool(lazy) or bool(freeze_kernel)
 
         self.features = features
         self.dtype = dtype
@@ -159,6 +172,12 @@ class YatNMN(nn.Module):
             self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
 
         self.is_built = True
+
+        # Lazy mode: freeze ONLY the kernel so it is excluded from
+        # ``trainable_parameters()`` (the optimizer never updates it). The
+        # bias, alpha and learnable epsilon stay trainable.
+        if self.lazy:
+            self.freeze(keys=["kernel"], recurse=False)
 
     # -----------------------------------------------------------------
     # Forward

--- a/src/nmn/mlx/ray.py
+++ b/src/nmn/mlx/ray.py
@@ -1,0 +1,224 @@
+"""RAY — sketched degree-2 modulation × radial RFF for spherical YAT (MLX).
+
+A secondary, bias-aware feature map for the spherical YAT kernel
+
+    kappa(s) = (s + b)² / (C − 2 s),    C = 2 + ε.
+
+RAY factorizes ``kappa`` as a **product of two PSD kernels** by augmenting the
+unit input ``x̂`` with the bias coordinate::
+
+    z = [x̂, √b] ∈ ℝ^{d+1}   ⇒   z_q·z_k = s + b,   ‖z_q − z_k‖² = ‖q̂ − k̂‖²
+
+so that ``kappa = (z_q·z_k)² · 1/(ε + ‖z_q − z_k‖²)``.
+
+* **Degree-2 sketch** ``psi(z)`` approximates ``(z_q·z_k)²`` with two independent
+  Gaussian projections ``W1, W2 ∈ ℝ^{m×(d+1)}``::
+
+      psi_i(z) = (W1_i·z)(W2_i·z) / √m   ⇒   E[psi(z_q)·psi(z_k)] = (z_q·z_k)².
+
+* **Radial RFF** approximates ``1/(ε + r²)`` via the exponential-integral
+  representation ``1/(ε + r²) = ∫₀^∞ e^{−t(ε + r²)} dt``, discretized by
+  Gauss-Laguerre over ``τ`` (substituting ``t = τ/ε``): nodes ``t_j = τ_j/ε``,
+  coefficients ``coef_j = (1/ε) w_j``. For each node ``e^{−t_j r²}`` is a Gaussian
+  RBF kernel, approximated by random Fourier features
+  ``ω_j ~ N(0, 2 t_j I)``, ``phase ~ U(0, 2π)``,
+  ``rff_j(z) = √(2/D) cos(ω_j·z + phase)`` scaled by ``√coef_j``.
+
+The **RAY feature** is the tensor product ``psi(z) ⊗ phi_rad(z)``. Like MAY it is
+**sign-indefinite** (the degree-2 sketch and the RFFs can be negative), so a small
+epsilon is added only to the attention denominator, never to the features.
+
+RAY is the weaker method: the sharp-epsilon regime is genuinely hard, so it is
+expected to underperform MAY and land comparable-ish to SLAY. It is implemented
+faithfully; it is not expected to win.
+
+Mirrors the signature style of :mod:`nmn.mlx.performer` (numpy-seeded
+``mx.array`` parameters, no jax key). Exact reference:
+:func:`nmn.mlx.attention.yat_attention_normalized`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+import mlx.core as mx
+import numpy as np
+
+
+__all__ = [
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+]
+
+
+def create_radial_projection(
+    head_dim: int,
+    sketch_m: int = 8,
+    num_radial: int = 4,
+    radial_dim: int = 8,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    dtype: mx.Dtype = mx.float32,
+    seed: Optional[int] = None,
+) -> dict[str, Any]:
+    """Precompute the (fixed) RAY projection shared by q and k.
+
+    Args:
+        head_dim: Per-head dimension ``d`` (the augmented dim is ``d + 1``).
+        sketch_m: ``m`` — width of the degree-2 sketch for ``(z_q·z_k)²``.
+        num_radial: Number of Gauss-Laguerre nodes for the radial integral.
+        radial_dim: ``D`` — RFF features per radial node.
+        bias: Per-head bias ``b`` (augmented coordinate ``√b``). Deployment
+            regime is ``b > 0``.
+        epsilon: YAT epsilon (the sharp ``1/(ε + r²)`` scale). In benchmarks set
+            to the median squared distance between normalized q and k.
+        dtype: MLX dtype for the precomputed arrays.
+        seed: Optional integer seed for deterministic projections.
+
+    Returns:
+        Dict with ``W1``/``W2`` ``(m, d+1)``, the stacked radial ``omegas``
+        ``(num_radial, D, d+1)``, ``phases`` ``(num_radial, D)``, the Laguerre
+        ``coef`` ``(num_radial,)``, plus bookkeeping (``bias``, ``sketch_m``,
+        ``radial_dim``, ``num_radial``). The output feature dim is
+        ``sketch_m · num_radial · radial_dim``.
+    """
+    rng = np.random.default_rng(seed)
+    da = head_dim + 1  # augmented z = [x̂, √b]
+
+    # Degree-2 sketch: two independent projections approximate (z·z')².
+    W1 = rng.standard_normal((sketch_m, da)).astype(np.float32)
+    W2 = rng.standard_normal((sketch_m, da)).astype(np.float32)
+
+    # Radial RFF for 1/(ε + r²) via Gauss-Laguerre over the exponential-integral
+    # representation 1/(ε + r²) = ∫ e^{−t(ε + r²)} dt.
+    tau, wq = np.polynomial.laguerre.laggauss(num_radial)
+    t_nodes = tau / epsilon                      # t_j = τ_j / ε
+    coef = (1.0 / epsilon) * wq                  # (1/ε) w_j
+
+    omegas, phases = [], []
+    for tj in t_nodes:
+        omegas.append(
+            rng.standard_normal((radial_dim, da)).astype(np.float32)
+            * np.sqrt(2.0 * tj)
+        )
+        phases.append(rng.uniform(0.0, 2.0 * np.pi, radial_dim).astype(np.float32))
+
+    return {
+        "W1": mx.array(W1).astype(dtype),                       # (m, d+1)
+        "W2": mx.array(W2).astype(dtype),                       # (m, d+1)
+        "omegas": mx.array(np.stack(omegas)).astype(dtype),     # (num_radial, D, d+1)
+        "phases": mx.array(np.stack(phases)).astype(dtype),     # (num_radial, D)
+        "coef": mx.array(coef.astype(np.float32)).astype(dtype),  # (num_radial,)
+        "bias": float(bias),
+        "head_dim": head_dim,
+        "sketch_m": sketch_m,
+        "radial_dim": radial_dim,
+        "num_radial": num_radial,
+    }
+
+
+def radial_features(
+    x: mx.array,
+    params: dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> mx.array:
+    """Compute the RAY feature ``psi(z) ⊗ phi_rad(z)`` per token.
+
+    Args:
+        x: ``(..., seq_len, num_heads, head_dim)``.
+        params: Output of :func:`create_radial_projection`.
+        normalize: L2-normalize inputs first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., seq_len, num_heads, sketch_m · num_radial ·
+        radial_dim)``. Sign-indefinite.
+    """
+    if normalize:
+        x_norm = mx.sqrt(mx.sum(x * x, axis=-1, keepdims=True) + epsilon)
+        x = x / x_norm
+
+    W1 = params["W1"]
+    W2 = params["W2"]
+    omegas = params["omegas"]        # (num_radial, D, d+1)
+    phases = params["phases"]        # (num_radial, D)
+    coef = params["coef"]            # (num_radial,)
+    b = params["bias"]
+    m = params["sketch_m"]
+    D = params["radial_dim"]
+    num_radial = params["num_radial"]
+
+    # Augment z = [x̂, √b] → (..., d+1).
+    sqrt_b = mx.full(x.shape[:-1] + (1,), math.sqrt(b), dtype=x.dtype)
+    z = mx.concatenate([x, sqrt_b], axis=-1)
+
+    # Degree-2 sketch psi(z): (..., m), approximates (z·z')².
+    psi = (mx.einsum("...d,md->...m", z, W1)
+           * mx.einsum("...d,md->...m", z, W2)) / math.sqrt(m)
+
+    # Radial RFF per node: (..., num_radial, D).
+    proj = mx.einsum("...d,jrd->...jr", z, omegas) + phases   # (..., num_radial, D)
+    rff = math.sqrt(2.0 / D) * mx.cos(proj)
+    scale = mx.sqrt(mx.maximum(coef, 0.0)).reshape((num_radial, 1))
+    rff = rff * scale                                          # (..., num_radial, D)
+    leading = rff.shape[:-2]
+    phi_rad = mx.reshape(rff, leading + (num_radial * D,))     # (..., num_radial*D)
+
+    # Tensor product psi ⊗ phi_rad → (..., m * num_radial * D).
+    out = psi[..., :, None] * phi_rad[..., None, :]            # (..., m, R*D)
+    return mx.reshape(out, leading + (m * num_radial * D,))
+
+
+def radial_yat_attention(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    params: dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> mx.array:
+    """Linear-complexity *bias-aware* YAT attention via RAY features.
+
+    Same linear-attention readout as :func:`nmn.mlx.may.maclaurin_yat_attention`
+    and the SLAY ``yat_tp_attention``; a small ``epsilon`` is added only to the
+    denominator (RAY features are sign-indefinite).
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, v_dim)``.
+        params: Output of :func:`create_radial_projection`.
+        causal: If ``True``, use prefix sums for causal masking.
+        epsilon: Denominator stability constant.
+
+    Returns:
+        ``(B, Q, H, v_dim)``.
+    """
+    if query.dtype != value.dtype:
+        value = value.astype(query.dtype)
+    if key.dtype != query.dtype:
+        key = key.astype(query.dtype)
+
+    q_feat = radial_features(query, params, normalize=True)
+    k_feat = radial_features(key, params, normalize=True)
+
+    if causal:
+        kv = mx.einsum("bkhm,bkhd->bkhmd", k_feat, value)
+        kv_cum = mx.cumsum(kv, axis=1)
+        k_cum = mx.cumsum(k_feat, axis=1)
+
+        num = mx.einsum("bqhm,bqhmd->bqhd", q_feat, kv_cum)
+        den = mx.einsum("bqhm,bqhm->bqh", q_feat, k_cum)
+        den = den[..., None] + epsilon
+        return num / den
+
+    kv = mx.einsum("bkhm,bkhd->bhmd", k_feat, value)
+    num = mx.einsum("bqhm,bhmd->bqhd", q_feat, kv)
+
+    k_sum = mx.sum(k_feat, axis=1)
+    den = mx.einsum("bqhm,bhm->bqh", q_feat, k_sum)
+    den = den[..., None] + epsilon
+    return num / den

--- a/src/nmn/nnx/__init__.py
+++ b/src/nmn/nnx/__init__.py
@@ -65,7 +65,7 @@ Quick Start
 # Core YAT Layers
 # =============================================================================
 
-from nmn.nnx.layers import YatNMN, Embed
+from nmn.nnx.layers import YatNMN, Embed, FrozenParam
 
 
 # =============================================================================
@@ -124,6 +124,17 @@ from nmn.nnx.layers import (
     create_yat_tp_projection,
 )
 
+# MAY / RAY bias-aware linear-attention feature maps
+from nmn.nnx.layers import (
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    maclaurin_coeffs,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
+
 # Standard Dot-Product Attention
 from nmn.nnx.layers import (
     dot_product_attention,
@@ -177,6 +188,7 @@ __all__ = [
     # Core Layers
     # -------------------------------------------------------------------------
     "YatNMN",
+    "FrozenParam",
     "Embed",
     "YatEmbed",  # alias of Embed for cross-framework consistency
 
@@ -231,7 +243,16 @@ __all__ = [
     "yat_tp_attention",
     "yat_tp_features",
     "create_yat_tp_projection",
-    
+
+    # MAY / RAY bias-aware feature maps
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "maclaurin_coeffs",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+
     # Standard Attention
     "dot_product_attention",
     "dot_product_attention_weights",

--- a/src/nmn/nnx/layers/__init__.py
+++ b/src/nmn/nnx/layers/__init__.py
@@ -11,7 +11,7 @@ This module contains all YAT (You Are There) layer implementations and related c
 # Core YAT Layers
 # =============================================================================
 
-from nmn.nnx.layers.nmn import YatNMN
+from nmn.nnx.layers.nmn import YatNMN, FrozenParam
 from nmn.nnx.layers.embed import Embed
 
 
@@ -71,6 +71,17 @@ from nmn.nnx.layers.attention import (
     create_yat_tp_projection,
 )
 
+# MAY / RAY bias-aware linear-attention feature maps
+from nmn.nnx.layers.attention import (
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    maclaurin_coeffs,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
+
 # Standard Dot-Product Attention
 from nmn.nnx.layers.attention import (
     dot_product_attention,
@@ -106,8 +117,9 @@ __all__ = [
     # Core Layers
     # -------------------------------------------------------------------------
     "YatNMN",
+    "FrozenParam",
     "Embed",
-    
+
     # -------------------------------------------------------------------------
     # Convolution Layers
     # -------------------------------------------------------------------------
@@ -149,7 +161,16 @@ __all__ = [
     "yat_tp_attention",
     "yat_tp_features",
     "create_yat_tp_projection",
-    
+
+    # MAY / RAY bias-aware feature maps
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "maclaurin_coeffs",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+
     # Standard Attention
     "dot_product_attention",
     "dot_product_attention_weights",

--- a/src/nmn/nnx/layers/attention/__init__.py
+++ b/src/nmn/nnx/layers/attention/__init__.py
@@ -97,6 +97,21 @@ from .spherical_yat_performer import (
     create_yat_tp_projection,
 )
 
+# MAY — Random Maclaurin features (bias-aware linear YAT attention)
+from .maclaurin_yat import (
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    maclaurin_coeffs,
+)
+
+# RAY — sketched degree-2 modulation × radial RFF (bias-aware)
+from .radial_yat import (
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
+
 # Standard Dot-Product Attention
 from .dot_product import (
     dot_product_attention,
@@ -139,6 +154,15 @@ __all__ = [
     "yat_tp_attention",
     "yat_tp_features",
     "create_yat_tp_projection",
+    # MAY — Random Maclaurin features
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "maclaurin_coeffs",
+    # RAY — radial features
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
     # Standard Attention
     "dot_product_attention",
     "dot_product_attention_weights",

--- a/src/nmn/nnx/layers/attention/maclaurin_yat.py
+++ b/src/nmn/nnx/layers/attention/maclaurin_yat.py
@@ -1,0 +1,291 @@
+"""MAY — Random Maclaurin features for spherical Yat-attention (bias-aware).
+
+This module implements the **MAY** ("Maclaurin Yat") linear-attention feature
+map, a bias-aware unbiased estimator of the spherical Yat kernel.
+
+Kernel
+------
+On unit vectors (s = q̂·k̂, with ‖q̂‖ = ‖k̂‖ = 1) the spherical Yat kernel is
+
+    kappa(s) = (s + b)² / (C - 2 s),    C = 2 + eps
+
+where ``b`` is the per-head bias (deployment regime **b > 0**) and ``eps`` is
+the Yat epsilon. In benchmarks ``eps`` is set to the *median squared distance*
+between normalized q and k (NOT 1e-5) — this is the regime where MAY shines.
+
+Why MAY (vs. SLAY)
+------------------
+The existing **SLAY** anchor performer
+(:mod:`nmn.nnx.layers.attention.spherical_yat_performer`) approximates only the
+**b = 0** kernel ``s² / (C - 2 s)``; it structurally *cannot* carry the bias
+term. MAY/RAY are **bias-aware**: they approximate the full ``(s + b)²``
+numerator, so at ``b >= 1`` MAY clearly beats SLAY.
+
+Random Maclaurin construction
+-----------------------------
+Expand ``kappa`` as a power series in ``s`` on the sphere. The geometric base
+``1 / (C - 2 s)`` has coefficients
+
+    beta_n = (1/C) (2/C)^n            (all > 0)
+
+Multiplying by ``(s + b)² = s² + 2 b s + b²`` shifts indices:
+
+    a_n = beta_{n-2} + 2 b beta_{n-1} + b² beta_n     (beta_{-1}=beta_{-2}=0)
+
+so ``a_n >= 0`` for all ``b >= 0``. Truncate at ``nmax`` (default 40), let
+``Z = sum_n a_n`` and ``p_n = a_n / Z``.
+
+The Random Maclaurin map draws, per feature r = 1..M, a degree
+``N_r ~ Categorical(p)`` and ``N_r`` Rademacher vectors ``omega ∈ {-1,+1}^d``,
+then forms the product of projections:
+
+    proj[n, r, l] = omega[r, l] · x̂                  ([..., M, nmax])
+    mask[r, l]    = (l < N_r)                          (neutralize unused factors)
+    phi_r(x̂)      = sqrt(Z / M) * prod_l where(mask, proj, 1.0)
+
+Degree-0 draws produce the **constant feature** — this is exactly what lets MAY
+attend diffusely (SLAY's ``b = 0`` design cannot).
+
+Guarantee
+---------
+``E[phi(q̂)·phi(k̂)] = kappa(q̂·k̂)`` (an *unbiased* estimator). The pointwise
+inner product therefore tracks ``kappa`` (rising with ``s``), and more features
+raise the cosine similarity to exact attention.
+
+Sign-indefinite caveat
+----------------------
+MAY features are **sign-indefinite**: odd-degree products can be negative, so
+the linear-attention denominator can in principle go non-positive. Do **NOT**
+add an epsilon to the *features* (that biases the estimator). Add a small
+epsilon only to the *denominator* for division stability. Empirically the map
+is well-conditioned at ``b > 0``.
+
+Public API (mirrors the SLAY file's signature style):
+    create_maclaurin_projection(key, head_dim, ...) -> dict
+    maclaurin_features(x, params) -> Array
+    maclaurin_yat_attention(q, k, v, params, causal=...) -> Array
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import random, lax
+from flax.nnx.nn.dtypes import promote_dtype
+from flax.typing import Dtype, PrecisionLike
+from jax import Array
+
+
+def maclaurin_coeffs(b: float, epsilon: float, nmax: int) -> np.ndarray:
+    """Maclaurin coefficients ``a_n`` of ``kappa(s) = (s+b)²/(C-2s)``.
+
+    ``a_n = beta_{n-2} + 2 b beta_{n-1} + b² beta_n`` with
+    ``beta_n = (1/C)(2/C)^n`` and ``C = 2 + eps``. All ``a_n >= 0`` for
+    ``b >= 0``.
+
+    Args:
+        b: Per-head bias.
+        epsilon: Yat epsilon (``C = 2 + epsilon``).
+        nmax: Truncation order (returns ``nmax + 1`` coefficients).
+
+    Returns:
+        NumPy array ``a`` of shape ``[nmax + 1]``, all non-negative for b >= 0.
+    """
+    C = 2.0 + epsilon
+    n = np.arange(nmax + 1)
+    beta = (1.0 / C) * (2.0 / C) ** n
+    a = (b * b) * beta.copy()
+    a[1:] += 2.0 * b * beta[:-1]
+    a[2:] += beta[:-2]
+    return a  # [nmax+1]
+
+
+def create_maclaurin_projection(
+    key: Array,
+    head_dim: int,
+    num_features: int = 256,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    nmax: int = 40,
+    dtype: Dtype = jnp.float32,
+) -> dict:
+    """Create parameters for MAY (Random Maclaurin) Yat features.
+
+    The projection is fixed at construction and shared by q and k. We sample
+    ``num_features`` degrees ``N_r ~ Categorical(a_n / Z)`` and, for each, a
+    dense ``[num_features, nmax, head_dim]`` Rademacher tensor. Only the first
+    ``N_r`` Rademacher rows are used per feature (the rest are masked out in
+    :func:`maclaurin_features`).
+
+    Args:
+        key: JAX random key.
+        head_dim: Dimension of each attention head ``d``.
+        num_features: Number of output features ``M`` (the feature budget).
+        bias: Per-head bias ``b`` (deployment regime ``b > 0``).
+        epsilon: Yat epsilon (``C = 2 + epsilon``). For benchmarks set this to
+            the median squared distance between normalized q and k.
+        nmax: Maclaurin truncation order (default 40).
+        dtype: Data type.
+
+    Returns:
+        Dictionary with projection parameters:
+            ``omegas``  — Rademacher tensor ``[M, nmax, d]`` in {-1, +1}.
+            ``degrees`` — integer degrees ``[M]`` (the sampled ``N_r``).
+            ``Z``       — normalization constant ``sum_n a_n`` (scalar).
+            ``num_features``, ``nmax``, ``head_dim``, ``bias``, ``epsilon``.
+    """
+    a = maclaurin_coeffs(bias, epsilon, nmax)
+    Z = float(a.sum())
+    p = a / a.sum()
+
+    key, deg_key, rad_key = random.split(key, 3)
+    # Sample degrees N_r ~ Categorical(p) via Gumbel-free categorical.
+    degrees = random.choice(
+        deg_key, len(a), shape=(num_features,), p=jnp.asarray(p, dtype=jnp.float32)
+    ).astype(jnp.int32)
+    # Rademacher vectors: [M, nmax, d] in {-1, +1}.
+    omegas = jnp.where(
+        random.bernoulli(rad_key, 0.5, (num_features, nmax, head_dim)),
+        jnp.array(1.0, dtype=dtype),
+        jnp.array(-1.0, dtype=dtype),
+    )
+
+    return {
+        'omegas': omegas,              # [M, nmax, d]
+        'degrees': degrees,            # [M]
+        'Z': jnp.asarray(Z, dtype=dtype),
+        'num_features': num_features,
+        'nmax': nmax,
+        'head_dim': head_dim,
+        'bias': bias,
+        'epsilon': epsilon,
+    }
+
+
+def maclaurin_features(
+    x: Array,
+    params: dict,
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> Array:
+    """Compute MAY (Random Maclaurin) features.
+
+    For each feature r:
+
+        proj[..., r, l] = omega[r, l] · x̂
+        phi_r(x̂)        = sqrt(Z / M) * prod_{l < N_r} proj[..., r, l]
+
+    where factors with ``l >= N_r`` are neutralized to 1.0 (degree-0 features
+    therefore produce the constant ``sqrt(Z / M)``). The result has exactly
+    ``M`` features.
+
+    Args:
+        x: Input tensor ``[..., head_dim]`` (e.g. ``[..., seq, heads, d]``).
+        params: Parameters from :func:`create_maclaurin_projection`.
+        normalize: If True, L2-normalize ``x`` to unit norm first.
+        epsilon: Stability constant for the normalization.
+
+    Returns:
+        Feature tensor ``[..., M]``.
+    """
+    if normalize:
+        x = x / jnp.sqrt(jnp.sum(x ** 2, axis=-1, keepdims=True) + epsilon)
+
+    omegas = params['omegas']          # [M, nmax, d]
+    degrees = params['degrees']        # [M]
+    Z = params['Z']
+    M = params['num_features']
+
+    x = x.astype(omegas.dtype)
+    # proj[..., m, l] = sum_d x[..., d] * omega[m, l, d]
+    proj = jnp.einsum("...d,mld->...ml", x, omegas)   # [..., M, nmax]
+
+    nmax = omegas.shape[1]
+    l = jnp.arange(nmax)                               # [nmax]
+    mask = l[None, :] < degrees[:, None]               # [M, nmax]
+    proj = jnp.where(mask, proj, jnp.array(1.0, dtype=proj.dtype))  # neutralize l>=N_r
+
+    feat = jnp.prod(proj, axis=-1)                     # [..., M]  product over factors
+    scale = jnp.sqrt(Z / M).astype(feat.dtype)
+    return scale * feat
+
+
+def _linear_readout(
+    q_feat: Array,
+    k_feat: Array,
+    value: Array,
+    causal: bool,
+    epsilon: float,
+    precision: PrecisionLike,
+) -> Array:
+    """Feature-map-agnostic linear-attention readout.
+
+    Given phi_q ``[.., Q, H, F]``, phi_k ``[.., K, H, F]``, v ``[.., K, H, dv]``:
+
+        kv  = sum_k phi_k ⊗ v          [.., H, F, dv]
+        num = phi_q · kv               [.., Q, H, dv]
+        den = phi_q · sum_k phi_k      [.., Q, H]
+        out = num / (den + eps_div)
+
+    NOTE: the features are sign-indefinite, so a small epsilon is added only to
+    the **denominator** (never to the features) for division stability.
+    """
+    if causal:
+        kv = jnp.einsum("...khm,...khd->...khmd", k_feat, value, precision=precision)
+        kv_cum = jnp.cumsum(kv, axis=-4)
+        k_cum = jnp.cumsum(k_feat, axis=-3)
+
+        num = jnp.einsum("...qhm,...qhmd->...qhd", q_feat, kv_cum, precision=precision)
+        den = jnp.einsum("...qhm,...qhm->...qh", q_feat, k_cum, precision=precision)
+        den = den[..., None]
+    else:
+        kv = jnp.einsum("...khm,...khd->...hmd", k_feat, value, precision=precision)
+        num = jnp.einsum("...qhm,...hmd->...qhd", q_feat, kv, precision=precision)
+
+        k_sum = jnp.sum(k_feat, axis=-3)
+        den = jnp.einsum("...qhm,...hm->...qh", q_feat, k_sum, precision=precision)
+        den = den[..., None]
+
+    # Stabilize the denominator without biasing the (sign-indefinite) estimator:
+    # push |den| away from zero while preserving its sign.
+    den = den + jnp.sign(den) * epsilon + (den == 0) * epsilon
+    return num / den
+
+
+def maclaurin_yat_attention(
+    query: Array,
+    key: Array,
+    value: Array,
+    params: dict,
+    causal: bool = False,
+    epsilon: float = 1e-6,
+    precision: PrecisionLike = None,
+    gradient_scaling: bool = True,
+) -> Array:
+    """Compute spherical Yat attention using MAY (Random Maclaurin) features.
+
+    Uses the unbiased estimator ``E[phi(q̂)·phi(k̂)] = kappa(q̂·k̂)`` to perform
+    O(n) linear attention via associativity reordering. The features carry the
+    bias term ``b``, so this is faithful for the deployment regime ``b > 0``
+    (where SLAY's bias-free approximation fails).
+
+    Args:
+        query: ``[..., q_length, num_heads, head_dim]``.
+        key: ``[..., kv_length, num_heads, head_dim]``.
+        value: ``[..., kv_length, num_heads, v_dim]``.
+        params: Parameters from :func:`create_maclaurin_projection`.
+        causal: If True, use causal attention via prefix sums.
+        epsilon: Denominator stability constant (added to the denominator only).
+        precision: JAX precision.
+        gradient_scaling: Unused, kept for API compatibility with SLAY.
+
+    Returns:
+        Output ``[..., q_length, num_heads, v_dim]``.
+    """
+    query, key, value = promote_dtype((query, key, value), dtype=None)
+
+    q_feat = maclaurin_features(query, params, normalize=True)
+    k_feat = maclaurin_features(key, params, normalize=True)
+
+    return _linear_readout(q_feat, k_feat, value, causal, epsilon, precision)

--- a/src/nmn/nnx/layers/attention/radial_yat.py
+++ b/src/nmn/nnx/layers/attention/radial_yat.py
@@ -1,0 +1,216 @@
+"""RAY — sketched degree-2 modulation × radial RFF for spherical Yat-attention.
+
+This module implements the **RAY** ("Radial Yat") linear-attention feature map,
+a secondary bias-aware estimator of the spherical Yat kernel.
+
+Kernel and augmentation
+-----------------------
+On unit vectors (s = q̂·k̂) the spherical Yat kernel is
+
+    kappa(s) = (s + b)² / (C - 2 s),    C = 2 + eps.
+
+Augment ``z = [x̂, sqrt(b)] ∈ R^{d+1}`` so that
+
+    z_q · z_k     = s + b
+    ‖z_q - z_k‖²  = ‖q̂ - k̂‖² = 2(1 - s)
+
+and therefore
+
+    kappa = (z_q · z_k)² · 1 / (eps + ‖z_q - z_k‖²)
+
+is a **product of two PSD kernels**. RAY approximates each factor:
+
+1. Degree-2 sketch ``psi(z)``: two independent random projections
+   ``W1, W2 ∈ R^{m×(d+1)}`` give ``psi_i(z) = (W1_i·z)(W2_i·z)/sqrt(m)`` with
+   ``E[psi(z_q)·psi(z_k)] = (z_q·z_k)²``.
+2. Radial RFF for ``1/(eps + r²)`` via the exponential-integral identity
+   ``1/(eps + r²) = ∫_0^∞ e^{-t(eps + r²)} dt``. Gauss-Laguerre over ``tau``
+   (substituting ``t = tau/eps``) gives nodes ``t_j = tau_j/eps`` and coeffs
+   ``coeff_j = (1/eps) w_j``. For node ``j``, ``e^{-t_j r²}`` is a Gaussian RBF
+   kernel, approximated by random Fourier features
+   ``omega_j ~ N(0, 2 t_j I)``, ``phase ~ U(0, 2pi)``,
+   ``rff_j(z) = sqrt(2/D) cos(omega_j·z + phase)`` scaled by ``sqrt(coeff_j)``.
+
+The **RAY feature** is the tensor product ``psi(z) ⊗ phi_rad(z)``.
+
+Bias-aware, sign-indefinite, weaker than MAY
+--------------------------------------------
+RAY carries the bias through the augmentation, so it is bias-aware. Like MAY it
+is **sign-indefinite** (the degree-2 sketch can be negative), so add an epsilon
+only to the linear-attention *denominator*, never to the features. RAY is the
+weaker method: the sharp-eps regime is hard, so it is expected to underperform
+MAY and be comparable-ish to SLAY. Implement it correctly; don't expect it to
+win.
+
+Public API (mirrors the SLAY / MAY signature style):
+    create_radial_projection(key, head_dim, ...) -> dict
+    radial_features(x, params) -> Array
+    radial_yat_attention(q, k, v, params, causal=...) -> Array
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import random
+from flax.nnx.nn.dtypes import promote_dtype
+from flax.typing import Dtype, PrecisionLike
+from jax import Array
+
+from .maclaurin_yat import _linear_readout
+
+
+def create_radial_projection(
+    key: Array,
+    head_dim: int,
+    sketch_m: int = 128,
+    num_radial: int = 8,
+    radial_dim: int = 64,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    dtype: Dtype = jnp.float32,
+) -> dict:
+    """Create parameters for RAY (radial) Yat features.
+
+    Builds the degree-2 sketch projections and the radial RFF (Gauss-Laguerre)
+    parameters. The total feature dimension is ``sketch_m * num_radial *
+    radial_dim``.
+
+    Args:
+        key: JAX random key.
+        head_dim: Dimension of each attention head ``d`` (augmented to ``d+1``).
+        sketch_m: Number of degree-2 sketch features ``m``.
+        num_radial: Number of Gauss-Laguerre radial nodes.
+        radial_dim: Number of random Fourier features ``D`` per radial node.
+        bias: Per-head bias ``b`` (used in the augmentation ``sqrt(b)``).
+        epsilon: Yat epsilon. For benchmarks set to the median squared distance
+            between normalized q and k.
+        dtype: Data type.
+
+    Returns:
+        Dictionary with projection parameters:
+            ``W1``, ``W2`` — degree-2 sketch projections ``[m, d+1]``.
+            ``omegas``     — radial RFF frequencies ``[num_radial, D, d+1]``.
+            ``phases``     — radial RFF phases ``[num_radial, D]``.
+            ``coef``       — radial quadrature coefficients ``[num_radial]``.
+            ``bias``, ``sketch_m``, ``radial_dim``, ``num_radial``, ``head_dim``.
+    """
+    da = head_dim + 1  # augmented z = [x_hat, sqrt(b)]
+
+    key, k1, k2 = random.split(key, 3)
+    W1 = random.normal(k1, (sketch_m, da), dtype=dtype)
+    W2 = random.normal(k2, (sketch_m, da), dtype=dtype)
+
+    # Radial RFF via Gauss-Laguerre over the exponential-integral representation
+    # 1/(eps + r^2) = int_0^inf e^{-t(eps + r^2)} dt.
+    tau, wq = np.polynomial.laguerre.laggauss(num_radial)
+    t_nodes = tau / epsilon                 # t_j = tau_j / eps
+    coef = (1.0 / epsilon) * wq             # (1/eps) w_j
+
+    omegas_list, phases_list = [], []
+    for tj in t_nodes:
+        key, ko, kp = random.split(key, 3)
+        omegas_list.append(
+            random.normal(ko, (radial_dim, da), dtype=dtype) * jnp.sqrt(2.0 * tj).astype(dtype)
+        )
+        phases_list.append(
+            random.uniform(kp, (radial_dim,), dtype=dtype, minval=0.0, maxval=2.0 * np.pi)
+        )
+
+    return {
+        'W1': W1,
+        'W2': W2,
+        'omegas': jnp.stack(omegas_list),     # [num_radial, D, d+1]
+        'phases': jnp.stack(phases_list),     # [num_radial, D]
+        'coef': jnp.asarray(coef, dtype=dtype),
+        'bias': bias,
+        'sketch_m': sketch_m,
+        'radial_dim': radial_dim,
+        'num_radial': num_radial,
+        'head_dim': head_dim,
+        'epsilon': epsilon,
+    }
+
+
+def radial_features(
+    x: Array,
+    params: dict,
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> Array:
+    """Compute RAY (radial) features as the tensor product psi(z) ⊗ phi_rad(z).
+
+    Args:
+        x: Input tensor ``[..., head_dim]`` (e.g. ``[..., seq, heads, d]``).
+        params: Parameters from :func:`create_radial_projection`.
+        normalize: If True, L2-normalize ``x`` to unit norm first.
+        epsilon: Stability constant for the normalization.
+
+    Returns:
+        Feature tensor ``[..., sketch_m * num_radial * radial_dim]``.
+    """
+    if normalize:
+        x = x / jnp.sqrt(jnp.sum(x ** 2, axis=-1, keepdims=True) + epsilon)
+
+    W1 = params['W1']
+    dtype = W1.dtype
+    x = x.astype(dtype)
+
+    # Augment z = [x_hat, sqrt(b)]: append a constant sqrt(b) channel.
+    sqrt_b = jnp.sqrt(jnp.array(params['bias'], dtype=dtype))
+    pad = jnp.broadcast_to(sqrt_b, x.shape[:-1] + (1,))
+    z = jnp.concatenate([x, pad], axis=-1)          # [..., d+1]
+
+    sketch_m = params['sketch_m']
+    radial_dim = params['radial_dim']
+
+    # Degree-2 sketch psi(z): [..., sketch_m], E[psi·psi'] = (z·z')^2.
+    p1 = jnp.einsum("...a,ma->...m", z, W1)
+    p2 = jnp.einsum("...a,ma->...m", z, params['W2'])
+    psi = (p1 * p2) / jnp.sqrt(jnp.array(sketch_m, dtype=dtype))   # [..., m]
+
+    # Radial RFF per node: [..., num_radial, D].
+    proj = jnp.einsum("...a,jDa->...jD", z, params['omegas'])      # [..., num_radial, D]
+    proj = proj + params['phases']                                # broadcast [num_radial, D]
+    rff = jnp.sqrt(jnp.array(2.0 / radial_dim, dtype=dtype)) * jnp.cos(proj)
+    coef = jnp.sqrt(jnp.maximum(params['coef'], 0.0))             # [num_radial]
+    rff = rff * coef[:, None]                                      # scale each node
+    phi_rad = rff.reshape(rff.shape[:-2] + (params['num_radial'] * radial_dim,))
+
+    # Tensor product psi ⊗ phi_rad -> [..., sketch_m * num_radial * radial_dim].
+    out = jnp.einsum("...s,...r->...sr", psi, phi_rad)
+    return out.reshape(out.shape[:-2] + (psi.shape[-1] * phi_rad.shape[-1],))
+
+
+def radial_yat_attention(
+    query: Array,
+    key: Array,
+    value: Array,
+    params: dict,
+    causal: bool = False,
+    epsilon: float = 1e-6,
+    precision: PrecisionLike = None,
+    gradient_scaling: bool = True,
+) -> Array:
+    """Compute spherical Yat attention using RAY (radial) features.
+
+    Args:
+        query: ``[..., q_length, num_heads, head_dim]``.
+        key: ``[..., kv_length, num_heads, head_dim]``.
+        value: ``[..., kv_length, num_heads, v_dim]``.
+        params: Parameters from :func:`create_radial_projection`.
+        causal: If True, use causal attention via prefix sums.
+        epsilon: Denominator stability constant (added to the denominator only).
+        precision: JAX precision.
+        gradient_scaling: Unused, kept for API compatibility with SLAY.
+
+    Returns:
+        Output ``[..., q_length, num_heads, v_dim]``.
+    """
+    query, key, value = promote_dtype((query, key, value), dtype=None)
+
+    q_feat = radial_features(query, params, normalize=True)
+    k_feat = radial_features(key, params, normalize=True)
+
+    return _linear_readout(q_feat, k_feat, value, causal, epsilon, precision)

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -56,6 +56,14 @@ from .spherical_yat_performer import (
     yat_tp_attention,
     create_yat_tp_projection,
 )
+from .maclaurin_yat import (
+    create_maclaurin_projection,
+    maclaurin_yat_attention,
+)
+from .radial_yat import (
+    create_radial_projection,
+    radial_yat_attention,
+)
 from .multi_head import DEFAULT_CONSTANT_ALPHA
 from .masks import combine_masks
 from nmn.nnx.layers.squashers import softermax
@@ -430,9 +438,16 @@ class RotaryYatAttention(Module):
         use_softermax: bool = False,
         power: float = 1.0,
         use_performer: bool = False,
+        performer_kind: str = "slay",
         num_anchor_features: int = 16,
         num_prf_features: int = 8,
         num_quad_nodes: int = 1,
+        performer_num_features: int = 256,
+        performer_bias: float = 1.0,
+        performer_nmax: int = 40,
+        performer_sketch_m: int = 128,
+        performer_num_radial: int = 8,
+        performer_radial_dim: int = 64,
         causal: bool = False,
         performer_normalize: bool = True,
         use_alpha: bool = True,
@@ -486,6 +501,12 @@ class RotaryYatAttention(Module):
         self.use_softermax = use_softermax
         self.power = power
         self.use_performer = use_performer
+        if performer_kind not in ("slay", "maclaurin", "radial"):
+            raise ValueError(
+                f"performer_kind must be one of 'slay', 'maclaurin', 'radial', "
+                f"got {performer_kind!r}."
+            )
+        self.performer_kind = performer_kind
         self.causal = causal
         self.performer_normalize = performer_normalize
 
@@ -537,27 +558,73 @@ class RotaryYatAttention(Module):
         self.perf_anchors: nnx.Cache | None
         self.perf_quad_nodes: nnx.Cache | None
         self.perf_quad_weights: nnx.Cache | None
+        # Generic store for non-slay performer params (maclaurin / radial).
+        # The frozen projection arrays live under nnx.Cache so they are excluded
+        # from nnx.Param state; non-array scalars are kept as static meta.
+        _perf_cache: dict[str, nnx.Cache] = {}
+        _perf_meta: dict = {}
         if use_performer:
             self.num_anchor_features = num_anchor_features
             self.num_prf_features_per_node = num_prf_features
             self.num_scales = num_quad_nodes
             self.num_features_per_scale = num_prf_features
-            self.num_features = num_quad_nodes * num_anchor_features * num_prf_features
 
-            params = create_yat_tp_projection(
-                rngs.params(),
-                self.head_dim,
-                num_prf_features=num_prf_features,
-                num_quad_nodes=num_quad_nodes,
-                num_anchor_features=num_anchor_features,
-                dtype=param_dtype,
-            )
+            if performer_kind == "slay":
+                self.num_features = num_quad_nodes * num_anchor_features * num_prf_features
 
-            self.perf_projections = nnx.Cache(params['projections'])
-            self.perf_anchors = nnx.Cache(params['anchors'])
-            self.perf_quad_nodes = nnx.Cache(params['quad_nodes'])
-            self.perf_quad_weights = nnx.Cache(params['quad_weights'])
-            self.perf_head_dim = params['head_dim']
+                params = create_yat_tp_projection(
+                    rngs.params(),
+                    self.head_dim,
+                    num_prf_features=num_prf_features,
+                    num_quad_nodes=num_quad_nodes,
+                    num_anchor_features=num_anchor_features,
+                    dtype=param_dtype,
+                )
+
+                self.perf_projections = nnx.Cache(params['projections'])
+                self.perf_anchors = nnx.Cache(params['anchors'])
+                self.perf_quad_nodes = nnx.Cache(params['quad_nodes'])
+                self.perf_quad_weights = nnx.Cache(params['quad_weights'])
+                self.perf_head_dim = params['head_dim']
+            else:
+                # MAY / RAY: store the whole param dict generically.
+                self.perf_projections = None
+                self.perf_anchors = None
+                self.perf_quad_nodes = None
+                self.perf_quad_weights = None
+                self.perf_head_dim = self.head_dim
+
+                if performer_kind == "maclaurin":
+                    params = create_maclaurin_projection(
+                        rngs.params(),
+                        self.head_dim,
+                        num_features=performer_num_features,
+                        bias=performer_bias,
+                        epsilon=epsilon,
+                        nmax=performer_nmax,
+                        dtype=param_dtype,
+                    )
+                    self.num_features = performer_num_features
+                else:  # radial
+                    params = create_radial_projection(
+                        rngs.params(),
+                        self.head_dim,
+                        sketch_m=performer_sketch_m,
+                        num_radial=performer_num_radial,
+                        radial_dim=performer_radial_dim,
+                        bias=performer_bias,
+                        epsilon=epsilon,
+                        dtype=param_dtype,
+                    )
+                    self.num_features = (
+                        performer_sketch_m * performer_num_radial * performer_radial_dim
+                    )
+
+                for k, val in params.items():
+                    if isinstance(val, (jnp.ndarray, jax.Array)):
+                        _perf_cache[k] = nnx.Cache(val)
+                    else:
+                        _perf_meta[k] = val
         else:
             self.num_features = None
             self.num_scales = None
@@ -567,6 +634,10 @@ class RotaryYatAttention(Module):
             self.perf_quad_nodes = None
             self.perf_quad_weights = None
             self.perf_head_dim = None
+
+        # Wrap the generic performer cache as nnx data (arrays) + static meta.
+        self._perf_cache = nnx.data(_perf_cache)
+        self._perf_meta = _perf_meta
 
         # Q, K, V projections
         linear_kwargs = dict(
@@ -722,9 +793,9 @@ class RotaryYatAttention(Module):
                 alpha_value = self.alpha[...]
 
         # Apply Rotary YAT attention
-        if self.use_performer:
-            # Performer mode: O(n) complexity
-            
+        if self.use_performer and self.performer_kind == "slay":
+            # Performer mode (SLAY anchor approximation): O(n) complexity
+
             # Reconstruct params dict
             performer_params = {
                 'projections': jax.device_put(self.perf_projections[...]),
@@ -736,7 +807,7 @@ class RotaryYatAttention(Module):
                 'num_anchor_features': self.num_anchor_features,
                 'num_scales': self.num_scales,
             }
-            
+
             output = rotary_yat_performer_attention(
                 q,
                 k,
@@ -758,6 +829,39 @@ class RotaryYatAttention(Module):
                 normalize_inputs=self.performer_normalize,
                 alpha=alpha_value,
             )
+        elif self.use_performer:
+            # MAY / RAY performer: bias-aware Random Maclaurin / radial features.
+            # Apply RoPE then dispatch to the matching linear-attention readout.
+            q_rot = apply_rotary_emb(q, freqs_cos, freqs_sin, position_offset)
+            k_rot = apply_rotary_emb(k, freqs_cos, freqs_sin, position_offset)
+
+            # Rebuild the param dict from the generic cache + meta store.
+            performer_params = {
+                k_: jax.device_put(c[...]) for k_, c in self._perf_cache.items()
+            }
+            performer_params.update(self._perf_meta)
+
+            if self.performer_kind == "maclaurin":
+                output = maclaurin_yat_attention(
+                    q_rot, k_rot, v, performer_params,
+                    causal=self.causal,
+                    precision=self.precision,
+                )
+            else:  # radial
+                output = radial_yat_attention(
+                    q_rot, k_rot, v, performer_params,
+                    causal=self.causal,
+                    precision=self.precision,
+                )
+
+            # Apply learnable alpha scaling (matches the SLAY path behavior).
+            if alpha_value is not None:
+                output = output * jnp.asarray(alpha_value, dtype=output.dtype)
+
+            if not deterministic and self.dropout_rate > 0.0:
+                keep_prob = 1.0 - self.dropout_rate
+                keep = random.bernoulli(dropout_rng, keep_prob, output.shape)
+                output = output * keep / keep_prob
         else:
             # Standard O(n²) attention
             output = rotary_yat_attention(

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -29,6 +29,21 @@ default_kernel_init = initializers.xavier_normal()
 default_bias_init = initializers.zeros_init()
 default_alpha_init = initializers.ones_init()
 
+
+class FrozenParam(nnx.Variable):
+  """A frozen (non-trainable) parameter variable.
+
+  Used by :class:`YatNMN` in *lazy* mode (issue #37) to hold the kernel so that
+  it is naturally excluded from ``nnx.state(model, nnx.Param)`` — and therefore
+  from the optimizer/gradient — while ``bias``, ``alpha`` and the learnable
+  ``epsilon`` remain ordinary :class:`flax.nnx.Param` and stay trainable.
+
+  This is the idiomatic NNX mechanism (preferred over ``jax.lax.stop_gradient``):
+  the kernel is excluded by *variable type* from the trainable state, not merely
+  zero-gradient. ``nnx.state(model, FrozenParam)`` recovers the frozen kernel.
+  """
+  pass
+
 class YatNMN(Module):
   """A YAT linear transformation applied over the last dimension of the input.
 
@@ -138,8 +153,27 @@ class YatNMN(Module):
     tie_kernel_bank: bool = False,
     kernel_bank_size: tp.Optional[int] = None,
     kernel_bank_id: str = 'default',
+    lazy: bool = False,
+    freeze_kernel: tp.Optional[bool] = None,
     rngs: rnglib.Rngs,
   ):
+
+    # ── Lazy mode (issue #37): freeze ONLY the kernel ───────────────────────
+    # `freeze_kernel` is an alias for `lazy`. When enabled, the kernel is stored
+    # under FrozenParam (a non-Param nnx.Variable) so it is excluded from
+    # nnx.state(model, nnx.Param) — and hence from the optimizer/grad — while
+    # bias, alpha and the learnable epsilon stay ordinary nnx.Param (trainable).
+    if freeze_kernel is not None:
+      lazy = bool(freeze_kernel)
+    self.lazy = lazy
+    self.freeze_kernel = lazy
+    if lazy and tie_kernel_bank:
+      raise ValueError(
+        "lazy/freeze_kernel is not supported together with tie_kernel_bank: "
+        "a shared kernel bank cannot be frozen per-instance."
+      )
+    # Pick the variable type used to wrap the kernel.
+    _kernel_var = FrozenParam if lazy else nnx.Param
 
     self._tie_kernel_bank = tie_kernel_bank
     self._kernel_slice = slice(None)
@@ -200,7 +234,9 @@ class YatNMN(Module):
       kernel_val = kernel_init(kernel_key, (in_features, out_features), param_dtype)
       if positive_init:
         kernel_val = jnp.abs(kernel_val)
-      self.kernel = nnx.Param(kernel_val)
+      # In lazy mode the kernel is a FrozenParam (excluded from trainable state);
+      # otherwise a normal trainable nnx.Param.
+      self.kernel = _kernel_var(kernel_val)
     self.bias: nnx.Param[jax.Array] | None
     self._constant_bias_value: tp.Optional[float] = None
     if constant_bias is not None and constant_bias is not False:

--- a/src/nmn/tf/__init__.py
+++ b/src/nmn/tf/__init__.py
@@ -10,6 +10,15 @@ from .attention import (
     yat_attention_normalized,
 )
 from .squashers import softermax, softer_sigmoid, soft_tanh
+from .performer_yat import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
 
 try:
     from .conv import (
@@ -39,4 +48,12 @@ __all__ = [
     "yat_attention_normalized",
     # Squashers
     "softermax", "softer_sigmoid", "soft_tanh",
+    # Performer feature maps (MAY / RAY)
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
 ] + _conv_all

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -37,6 +37,14 @@ class YatNMN(tf.Module):
         learnable_epsilon: If ``True``, epsilon becomes a learnable parameter
             passed through softplus to guarantee strict positivity
             (default: ``False``).
+        lazy: If ``True``, freeze ONLY the kernel (the feature directions): the
+            kernel ``tf.Variable`` is created with ``trainable=False`` so it is
+            excluded from gradients/optimizer updates. The ``bias``, ``alpha``,
+            and learnable ``epsilon`` remain trainable. Composes with
+            ``use_bias`` / ``use_alpha`` / ``learnable_epsilon``. Defaults to
+            ``False`` (fully backward compatible). ``freeze_kernel`` is an alias.
+        freeze_kernel: Alias for ``lazy``. If either is ``True`` the kernel is
+            frozen.
         spherical: If ``True``, normalize inputs and each kernel row (neuron)
             to unit norm before computing the YAT formula (default: ``False``).
         weight_normalized: If ``True``, normalize each kernel row (neuron) to
@@ -69,6 +77,8 @@ class YatNMN(tf.Module):
         spherical: bool = False,
         weight_normalized: bool = False,
         return_weights: bool = False,
+        lazy: bool = False,
+        freeze_kernel: bool = False,
         name: Optional[str] = None
     ):
         super().__init__(name=name)
@@ -78,6 +88,8 @@ class YatNMN(tf.Module):
             raise ValueError(f"epsilon must be positive, got {epsilon}")
         self.epsilon = epsilon
         self.learnable_epsilon = learnable_epsilon
+        # Lazy mode: freeze ONLY the kernel (bias/alpha/epsilon stay trainable).
+        self.lazy = bool(lazy or freeze_kernel)
         self.spherical = spherical
         self.weight_normalized = weight_normalized
         self.return_weights = return_weights
@@ -131,9 +143,13 @@ class YatNMN(tf.Module):
         initial_kernel = tf.random.normal(kernel_shape, stddev=std, dtype=self.dtype)
         if self.positive_init:
             initial_kernel = tf.abs(initial_kernel)
+        # In lazy mode the kernel feature directions are frozen: creating the
+        # Variable with trainable=False excludes it from gradients/optimizer
+        # (it will not appear in self.trainable_variables). bias/alpha/epsilon
+        # below stay trainable.
         self.kernel = tf.Variable(
             initial_kernel,
-            trainable=True,
+            trainable=not self.lazy,
             name='kernel',
             dtype=self.dtype
         )

--- a/src/nmn/tf/performer_yat.py
+++ b/src/nmn/tf/performer_yat.py
@@ -186,7 +186,8 @@ def maclaurin_features(
 
     # mask[m, l] = l < N_m  -> (M, nmax); neutralize unused factors to 1.0
     l = tf.range(nmax, dtype=tf.int32)                       # [nmax]
-    mask = tf.expand_dims(l, 0) < tf.expand_dims(degrees, 1)  # [M, nmax]
+    # Cast degrees to int32 too so the comparison never mixes int32/int64.
+    mask = tf.expand_dims(l, 0) < tf.cast(tf.expand_dims(degrees, 1), tf.int32)  # [M, nmax]
     mask = tf.reshape(mask, [1] * (len(proj.shape) - 2) + [M, nmax])
     proj = tf.where(mask, proj, tf.ones_like(proj))
 

--- a/src/nmn/tf/performer_yat.py
+++ b/src/nmn/tf/performer_yat.py
@@ -1,0 +1,403 @@
+"""MAY (Random Maclaurin) and RAY (radial) linear-attention feature maps for
+spherical YAT attention in TensorFlow.
+
+Spherical YAT kernel on unit vectors ``s = q̂·k̂`` (``||q̂|| = ||k̂|| = 1``)::
+
+    kappa(s) = (s + b)^2 / (C - 2 s),   C = 2 + eps
+
+where ``b`` is the per-head bias (deployment regime ``b > 0``) and ``eps`` is the
+YAT epsilon. The exact reference for the underlying quadratic attention is
+:func:`nmn.tf.attention.yat_attention_normalized`.
+
+This module provides two **bias-aware** feature maps that linearize the kernel,
+both reusing a generic linear-attention readout
+(``num = phi_q · (phi_kᵀ v)``, ``den = phi_q · sum_k phi_k``):
+
+MAY -- Random Maclaurin features (the headline method)
+    Expands ``kappa`` in a Maclaurin series on the sphere. With the geometric
+    coefficients ``beta_n = (1/C)(2/C)^n`` of ``1/(C - 2 s)``, the kernel
+    coefficients are
+
+        a_n = beta_{n-2} + 2 b beta_{n-1} + b^2 beta_n   (beta_{-1}=beta_{-2}=0)
+
+    which are all ``>= 0`` for ``b >= 0``. Sampling degrees ``N_r ~ a_n / Z``
+    (``Z = sum_n a_n``) and forming products of ``N_r`` Rademacher projections
+    yields an **unbiased** estimator: ``E[phi(q̂)·phi(k̂)] = kappa(q̂·k̂)``.
+    Degree-0 draws produce a constant feature, which is exactly what lets MAY
+    carry the bias and attend diffusely -- something the bias-free SLAY anchor
+    method (which only approximates the ``b = 0`` kernel) cannot do.
+
+RAY -- sketched degree-2 modulation × radial RFF (secondary method)
+    Augments ``z = [x̂, sqrt(b)]`` so ``z_q·z_k = s + b`` and
+    ``||z_q - z_k||^2 = ||q̂ - k̂||^2``. Then
+    ``kappa = (z_q·z_k)^2 · 1/(eps + ||z_q - z_k||^2)`` -- a product of two PSD
+    kernels approximated by a degree-2 polynomial sketch and a radial random
+    Fourier feature (Gauss-Laguerre over the exponential-integral
+    representation of ``1/(eps + r^2)``). RAY is the weaker method (the sharp-eps
+    regime is hard); expect it to be comparable-ish to SLAY and to underperform
+    MAY.
+
+**Caveat (sign-indefinite features).** Both MAY and RAY features are
+sign-indefinite -- odd-degree Rademacher products can be negative -- so the
+linear-attention denominator can in principle go non-positive. Do NOT add an
+epsilon to the *features* (that biases the estimator); a small epsilon is added
+only to the *denominator* for division stability. Empirically well-conditioned
+for ``b > 0``.
+
+The random projections are drawn once with NumPy (seeded for determinism) and
+stored as TensorFlow constants, so the feature maps themselves are pure TF ops.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional
+
+import numpy as np
+import tensorflow as tf
+
+
+__all__ = [
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+]
+
+
+# --------------------------------------------------------------------------
+# Shared helpers
+# --------------------------------------------------------------------------
+def _normalize(x: tf.Tensor, epsilon: float = 1e-6) -> tf.Tensor:
+    """L2-normalizes the last axis (the spherical assumption)."""
+    norm = tf.sqrt(tf.reduce_sum(tf.square(x), axis=-1, keepdims=True) + epsilon)
+    return x / norm
+
+
+def maclaurin_coeffs(b: float, eps: float, nmax: int) -> np.ndarray:
+    """Maclaurin coefficients of ``kappa`` on the sphere.
+
+    ``a_n = beta_{n-2} + 2 b beta_{n-1} + b^2 beta_n`` with
+    ``beta_n = (1/C)(2/C)^n`` (the coefficients of ``1/(C - 2 s)``), all
+    ``>= 0`` for ``b >= 0``.
+
+    Args:
+        b: Per-head bias.
+        eps: YAT epsilon (``C = 2 + eps``).
+        nmax: Truncation degree.
+
+    Returns:
+        NumPy array ``a`` of shape ``[nmax + 1]``.
+    """
+    C = 2.0 + eps
+    n = np.arange(nmax + 1)
+    beta = (1.0 / C) * (2.0 / C) ** n
+    a = b * b * beta.copy()
+    a[1:] += 2.0 * b * beta[:-1]
+    a[2:] += beta[:-2]
+    return a  # [nmax + 1], all >= 0 for b >= 0
+
+
+# --------------------------------------------------------------------------
+# MAY -- Random Maclaurin features
+# --------------------------------------------------------------------------
+def create_maclaurin_projection(
+    head_dim: int,
+    num_features: int = 256,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    nmax: int = 40,
+    dtype: tf.DType = tf.float32,
+    seed: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Precompute the fixed projection for MAY (Random Maclaurin) features.
+
+    A degree ``N_r ~ Categorical(a_n / Z)`` is sampled for each of the ``M``
+    output features, and ``nmax`` Rademacher vectors are drawn per feature (only
+    the first ``N_r`` are used). The projection is shared by queries and keys.
+
+    Args:
+        head_dim: Per-head input dimension ``d``.
+        num_features: ``M`` -- the number of output features.
+        bias: Per-head bias (deployment regime ``bias > 0``).
+        epsilon: YAT epsilon (``C = 2 + epsilon``).
+        nmax: Maclaurin truncation degree (default 40).
+        dtype: TF dtype for the stored tensors.
+        seed: Optional integer seed for deterministic projections.
+
+    Returns:
+        Dict with ``omegas`` ``[M, nmax, d]`` (Rademacher), ``degrees`` ``[M]``
+        (int32), the scalar ``Z``, and the integers ``num_features`` / ``nmax``.
+    """
+    rng = np.random.default_rng(seed)
+    a = maclaurin_coeffs(bias, epsilon, nmax)
+    Z = float(a.sum())
+    p = a / a.sum()
+
+    degrees = rng.choice(len(a), size=num_features, p=p).astype(np.int32)  # [M]
+    omegas = rng.choice([-1.0, 1.0], size=(num_features, nmax, head_dim))   # [M, nmax, d]
+
+    return {
+        "omegas": tf.constant(omegas, dtype=dtype),       # [M, nmax, d]
+        "degrees": tf.constant(degrees, dtype=tf.int32),  # [M]
+        "Z": Z,
+        "num_features": num_features,
+        "nmax": nmax,
+    }
+
+
+def maclaurin_features(
+    x: tf.Tensor,
+    params: Dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> tf.Tensor:
+    """Compute MAY features ``phi(x) ∈ ℝ^M`` for each token.
+
+    ``phi_r(x̂) = sqrt(Z / M) * prod_{l < N_r} (omega[r, l] · x̂)``. Unused
+    factors (``l >= N_r``) are neutralized to 1.0 so degree-0 draws give the
+    constant feature.
+
+    Args:
+        x: ``(..., d)`` (typically ``(B, L, H, d)``).
+        params: Output of :func:`create_maclaurin_projection`.
+        normalize: L2-normalize ``x`` first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., M)``.
+    """
+    if normalize:
+        x = _normalize(x, epsilon)
+
+    omegas = params["omegas"]          # [M, nmax, d]
+    degrees = params["degrees"]        # [M]
+    M = params["num_features"]
+    nmax = params["nmax"]
+    Z = params["Z"]
+
+    x = tf.cast(x, omegas.dtype)
+
+    # proj[..., m, l] = sum_d x[..., d] * omegas[m, l, d]  -> (..., M, nmax)
+    proj = tf.einsum("...d,mld->...ml", x, omegas)
+
+    # mask[m, l] = l < N_m  -> (M, nmax); neutralize unused factors to 1.0
+    l = tf.range(nmax, dtype=tf.int32)                       # [nmax]
+    mask = tf.expand_dims(l, 0) < tf.expand_dims(degrees, 1)  # [M, nmax]
+    mask = tf.reshape(mask, [1] * (len(proj.shape) - 2) + [M, nmax])
+    proj = tf.where(mask, proj, tf.ones_like(proj))
+
+    feat = tf.reduce_prod(proj, axis=-1)                     # (..., M)
+    scale = tf.cast(math.sqrt(Z / float(M)), feat.dtype)
+    return scale * feat
+
+
+def maclaurin_yat_attention(
+    query: tf.Tensor,
+    key: tf.Tensor,
+    value: tf.Tensor,
+    params: Dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> tf.Tensor:
+    """Linear-complexity spherical-YAT attention via MAY features.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, v_dim)``.
+        params: Output of :func:`create_maclaurin_projection`.
+        causal: If ``True``, use prefix sums (each query sees keys up to its
+            own position).
+        epsilon: Denominator stability constant (added to the *denominator*
+            only -- never to the features).
+
+    Returns:
+        ``(B, Q, H, v_dim)``.
+    """
+    q_feat = maclaurin_features(query, params, normalize=True, epsilon=epsilon)
+    k_feat = maclaurin_features(key, params, normalize=True, epsilon=epsilon)
+    return _linear_attention(q_feat, k_feat, value, causal=causal, epsilon=epsilon)
+
+
+# --------------------------------------------------------------------------
+# RAY -- sketched degree-2 modulation × radial RFF
+# --------------------------------------------------------------------------
+def create_radial_projection(
+    head_dim: int,
+    sketch_m: int = 128,
+    num_radial: int = 8,
+    radial_dim: int = 64,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    dtype: tf.DType = tf.float32,
+    seed: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Precompute the fixed projection for RAY (radial) features.
+
+    Two random projections ``W1, W2`` sketch the degree-2 modulation
+    ``(z_q·z_k)^2``; a Gauss-Laguerre radial RFF approximates
+    ``1/(eps + ||z_q - z_k||^2)`` over the exponential-integral representation.
+
+    Args:
+        head_dim: Per-head input dimension ``d`` (augmented to ``d + 1``).
+        sketch_m: ``m`` -- degree-2 sketch width.
+        num_radial: Number of Gauss-Laguerre nodes.
+        radial_dim: RFF features per node.
+        bias: Per-head bias (used to augment ``z = [x̂, sqrt(bias)]``).
+        epsilon: YAT epsilon.
+        dtype: TF dtype for the stored tensors.
+        seed: Optional integer seed.
+
+    Returns:
+        Dict with ``W1``/``W2`` ``[m, d+1]``, ``omegas`` ``[num_radial, radial_dim, d+1]``,
+        ``phases`` ``[num_radial, radial_dim]``, ``coef`` ``[num_radial]``, plus
+        scalars/integers ``b``, ``sketch_m``, ``radial_dim``, ``num_radial``.
+    """
+    rng = np.random.default_rng(seed)
+    da = head_dim + 1  # augmented z = [x̂, sqrt(bias)]
+
+    # degree-2 sketch: two independent projections -> approximates (z·z')^2
+    W1 = rng.standard_normal((sketch_m, da))
+    W2 = rng.standard_normal((sketch_m, da))
+
+    # radial RFF for 1/(eps + ||z - z'||^2) via Gauss-Laguerre over the
+    # exponential-integral representation 1/(eps + r^2) = ∫ e^{-t(eps + r^2)} dt.
+    tau, wq = np.polynomial.laguerre.laggauss(num_radial)
+    t_nodes = tau / epsilon              # t_j = tau_j / epsilon
+    coef = (1.0 / epsilon) * wq          # (1/epsilon) w_j
+
+    omegas, phases = [], []
+    for tj in t_nodes:
+        omegas.append(rng.standard_normal((radial_dim, da)) * np.sqrt(2.0 * tj))
+        phases.append(rng.uniform(0, 2 * np.pi, radial_dim))
+
+    return {
+        "W1": tf.constant(W1, dtype=dtype),                 # [m, d+1]
+        "W2": tf.constant(W2, dtype=dtype),                 # [m, d+1]
+        "omegas": tf.constant(np.stack(omegas), dtype=dtype),   # [num_radial, radial_dim, d+1]
+        "phases": tf.constant(np.stack(phases), dtype=dtype),   # [num_radial, radial_dim]
+        "coef": tf.constant(coef, dtype=dtype),             # [num_radial]
+        "b": float(bias),
+        "sketch_m": sketch_m,
+        "radial_dim": radial_dim,
+        "num_radial": num_radial,
+    }
+
+
+def radial_features(
+    x: tf.Tensor,
+    params: Dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> tf.Tensor:
+    """Compute RAY features for each token: ``psi(z) ⊗ phi_rad(z)``.
+
+    Args:
+        x: ``(..., d)``.
+        params: Output of :func:`create_radial_projection`.
+        normalize: L2-normalize ``x`` first.
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., sketch_m * num_radial * radial_dim)``.
+    """
+    if normalize:
+        x = _normalize(x, epsilon)
+
+    W1 = params["W1"]
+    x = tf.cast(x, W1.dtype)
+    W2 = params["W2"]
+    omegas = params["omegas"]          # [num_radial, radial_dim, d+1]
+    phases = params["phases"]          # [num_radial, radial_dim]
+    coef = params["coef"]              # [num_radial]
+    sketch_m = params["sketch_m"]
+    radial_dim = params["radial_dim"]
+    num_radial = params["num_radial"]
+
+    leading = tf.shape(x)[:-1]
+
+    # Augment z = [x̂, sqrt(b)]  -> (..., d+1)
+    sqrt_b = tf.cast(math.sqrt(params["b"]), x.dtype)
+    pad_shape = tf.concat([leading, [1]], axis=0)
+    z = tf.concat([x, tf.fill(pad_shape, sqrt_b)], axis=-1)
+
+    # degree-2 sketch psi(z): (..., sketch_m), approximates (z·z')^2
+    psi = (
+        tf.einsum("...d,md->...m", z, W1)
+        * tf.einsum("...d,md->...m", z, W2)
+        / tf.cast(math.sqrt(float(sketch_m)), z.dtype)
+    )
+
+    # radial RFF per node: (..., num_radial, radial_dim)
+    proj = tf.einsum("...d,jrd->...jr", z, omegas) + phases
+    rff = tf.cast(math.sqrt(2.0 / float(radial_dim)), z.dtype) * tf.cos(proj)
+    sqrt_coef = tf.sqrt(tf.maximum(coef, 0.0))                  # [num_radial]
+    rff = rff * tf.reshape(sqrt_coef, [num_radial, 1])
+    # phi_rad: flatten (num_radial, radial_dim) -> (..., num_radial * radial_dim)
+    rff_shape = tf.concat([leading, [num_radial * radial_dim]], axis=0)
+    phi_rad = tf.reshape(rff, rff_shape)
+
+    # tensor product psi ⊗ phi_rad -> (..., sketch_m * num_radial * radial_dim)
+    out = tf.einsum("...s,...r->...sr", psi, phi_rad)
+    out_shape = tf.concat([leading, [sketch_m * num_radial * radial_dim]], axis=0)
+    return tf.reshape(out, out_shape)
+
+
+def radial_yat_attention(
+    query: tf.Tensor,
+    key: tf.Tensor,
+    value: tf.Tensor,
+    params: Dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> tf.Tensor:
+    """Linear-complexity spherical-YAT attention via RAY (radial) features.
+
+    Args mirror :func:`maclaurin_yat_attention`. RAY is the weaker method;
+    expect it to underperform MAY.
+    """
+    q_feat = radial_features(query, params, normalize=True, epsilon=epsilon)
+    k_feat = radial_features(key, params, normalize=True, epsilon=epsilon)
+    return _linear_attention(q_feat, k_feat, value, causal=causal, epsilon=epsilon)
+
+
+# --------------------------------------------------------------------------
+# Generic linear-attention readout (feature-map-agnostic)
+# --------------------------------------------------------------------------
+def _linear_attention(
+    q_feat: tf.Tensor,
+    k_feat: tf.Tensor,
+    value: tf.Tensor,
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> tf.Tensor:
+    """Linear-attention readout from feature maps.
+
+    ``q_feat`` / ``k_feat``: ``(B, *, H, F)``; ``value``: ``(B, K, H, dv)``.
+    A small ``epsilon`` is added to the *denominator* only.
+    """
+    value = tf.cast(value, q_feat.dtype)
+
+    if causal:
+        # kv[b, k, h, f, d] = k_feat[b, k, h, f] * value[b, k, h, d]
+        kv = tf.einsum("bkhf,bkhd->bkhfd", k_feat, value)
+        kv_cum = tf.cumsum(kv, axis=1)
+        k_cum = tf.cumsum(k_feat, axis=1)
+
+        num = tf.einsum("bqhf,bqhfd->bqhd", q_feat, kv_cum)
+        den = tf.einsum("bqhf,bqhf->bqh", q_feat, k_cum)
+        den = den[..., None] + epsilon
+        return num / den
+
+    # Non-causal: O(n) via the associativity trick.
+    kv = tf.einsum("bkhf,bkhd->bhfd", k_feat, value)
+    num = tf.einsum("bqhf,bhfd->bqhd", q_feat, kv)
+
+    k_sum = tf.reduce_sum(k_feat, axis=1)                  # (B, H, F)
+    den = tf.einsum("bqhf,bhf->bqh", q_feat, k_sum)
+    den = den[..., None] + epsilon
+    return num / den

--- a/src/nmn/torch/__init__.py
+++ b/src/nmn/torch/__init__.py
@@ -14,7 +14,15 @@ from .layers import (
 from .nmn import YatNMN
 
 # Import attention
-from .attention import MultiHeadYatAttention
+from .attention import (
+    MultiHeadYatAttention,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
 
 # Import embedding
 from .embed import YatEmbed
@@ -35,6 +43,13 @@ __all__ = [
     "YatNMN",
     # YAT Attention
     "MultiHeadYatAttention",
+    # MAY / RAY linear-attention feature maps
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
     # YAT Embedding
     "YatEmbed",
     # Squashers

--- a/src/nmn/torch/attention/__init__.py
+++ b/src/nmn/torch/attention/__init__.py
@@ -6,6 +6,10 @@ Provides:
 - yat_attention_normalized: Optimized YAT for unit-normed Q/K
 - normalize_qk: Normalize Q, K to unit vectors
 - MultiHeadYatAttention: Multi-head attention module using YAT
+- MAY (create_maclaurin_projection / maclaurin_features / maclaurin_yat_attention):
+  bias-aware Random Maclaurin linear-attention feature map
+- RAY (create_radial_projection / radial_features / radial_yat_attention):
+  bias-aware sketched degree-2 × radial-RFF linear-attention feature map
 """
 
 from .yat_attention import (
@@ -17,6 +21,17 @@ from .yat_attention import (
 
 from .multi_head import MultiHeadYatAttention, DEFAULT_CONSTANT_ALPHA
 
+from .performer_yat import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+    linear_attention_readout,
+)
+
 __all__ = [
     "yat_attention",
     "yat_attention_weights",
@@ -24,4 +39,13 @@ __all__ = [
     "normalize_qk",
     "MultiHeadYatAttention",
     "DEFAULT_CONSTANT_ALPHA",
+    # MAY / RAY linear-attention feature maps (issue #36)
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+    "linear_attention_readout",
 ]

--- a/src/nmn/torch/attention/performer_yat.py
+++ b/src/nmn/torch/attention/performer_yat.py
@@ -1,0 +1,442 @@
+"""Bias-aware linear-attention feature maps for spherical YAT (PyTorch).
+
+This module implements two **unbiased** random-feature maps that linearize
+the spherical YAT attention kernel, so that attention runs in ``O(seq_len)``
+via the standard ``Σ_k φ(k) vᵀ`` reordering trick.
+
+Kernel (on unit vectors ``s = q̂·k̂``, with ``‖q̂‖ = ‖k̂‖ = 1``):
+
+    kappa(s) = (s + b)² / (C − 2 s),     C = 2 + eps
+
+where ``b`` is the per-head **bias** (the deployment regime is ``b > 0``) and
+``eps`` is the YAT epsilon (in the benchmark set to the *median squared
+distance* between normalized q/k, not ``1e-5``).
+
+Contrast with **SLAY** (the anchor/performer method in other backends): SLAY
+approximates only the ``b = 0`` kernel and therefore **cannot carry the bias**.
+The two maps here are **bias-aware**:
+
+* **MAY** — Random Maclaurin features (the headline method). Expands ``kappa``
+  in its Maclaurin series on the sphere and samples monomials. The degree-0
+  draw produces a constant feature, which is exactly what lets MAY attend
+  diffusely; SLAY's ``b = 0`` design cannot. ``E[φ(q̂)·φ(k̂)] = kappa(q̂·k̂)``.
+* **RAY** — sketched degree-2 modulation ⊗ radial RFF. Writes ``kappa`` as a
+  product of two PSD kernels and sketches each. Correct but weaker (the
+  sharp-eps regime is hard); expected to be comparable-ish to SLAY, not to win.
+
+Maclaurin coefficients (all ``≥ 0`` for ``b ≥ 0``):
+
+    beta_n = (1/C) (2/C)^n                               # coeffs of 1/(C − 2 s)
+    a_n    = beta_{n-2} + 2 b beta_{n-1} + b² beta_n      # beta_{-1}=beta_{-2}=0
+
+so ``kappa(s) = Σ_n a_n sⁿ``.
+
+Sign-indefinite caveat (documented per the spec): MAY/RAY features are
+**sign-indefinite** — odd-degree monomial products can be negative, so the
+linear-attention denominator can in principle go non-positive. We do **not**
+add an epsilon to the *features* (that would bias the estimator); we add a
+small epsilon only to the *denominator* for division stability. Empirically
+the estimator is well-conditioned at ``b > 0``.
+
+Public API (mirrors the SLAY/performer style in other backends):
+
+* ``create_maclaurin_projection(...)`` / ``maclaurin_features(x, params)`` /
+  ``maclaurin_yat_attention(q, k, v, params, causal=...)``
+* ``create_radial_projection(...)`` / ``radial_features(x, params)`` /
+  ``radial_yat_attention(q, k, v, params, causal=...)``
+
+The exact (quadratic) reference these approximate is
+:func:`nmn.torch.attention.yat_attention.yat_attention_normalized`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+from torch import Tensor
+
+
+__all__ = [
+    "maclaurin_coeffs",
+    "create_maclaurin_projection",
+    "maclaurin_features",
+    "maclaurin_yat_attention",
+    "create_radial_projection",
+    "radial_features",
+    "radial_yat_attention",
+    "linear_attention_readout",
+]
+
+
+# --------------------------------------------------------------------------
+# Shared helpers
+# --------------------------------------------------------------------------
+def _normalize(x: Tensor, epsilon: float = 1e-6) -> Tensor:
+    """L2-normalize along the last axis (the spherical assumption)."""
+    norm = torch.sqrt(torch.sum(x * x, dim=-1, keepdim=True) + epsilon)
+    return x / norm
+
+
+def maclaurin_coeffs(b: float, eps: float, nmax: int) -> np.ndarray:
+    """Maclaurin coefficients ``a_n`` of ``kappa`` on the unit sphere.
+
+    ``a_n = beta_{n-2} + 2 b beta_{n-1} + b² beta_n`` with
+    ``beta_n = (1/C)(2/C)^n`` and ``C = 2 + eps``. All ``a_n ≥ 0`` for
+    ``b ≥ 0``, so they define a valid (unnormalized) categorical distribution
+    over monomial degrees.
+
+    Args:
+        b: Per-head bias.
+        eps: YAT epsilon (``C = 2 + eps``).
+        nmax: Maximum monomial degree (inclusive). Returns ``nmax + 1`` coeffs.
+
+    Returns:
+        ``np.ndarray`` of shape ``(nmax + 1,)``.
+    """
+    C = 2.0 + eps
+    n = np.arange(nmax + 1)
+    beta = (1.0 / C) * (2.0 / C) ** n
+    a = (b * b) * beta.copy()
+    a[1:] += 2.0 * b * beta[:-1]
+    a[2:] += beta[:-2]
+    return a  # [nmax+1], all >= 0 for b >= 0
+
+
+# --------------------------------------------------------------------------
+# MAY — Random Maclaurin features
+# --------------------------------------------------------------------------
+def create_maclaurin_projection(
+    head_dim: int,
+    num_features: int = 256,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    nmax: int = 40,
+    seed: Optional[int] = None,
+    dtype: torch.dtype = torch.float32,
+    device: Optional[torch.device] = None,
+) -> Dict[str, Any]:
+    """Precompute the (fixed) MAY projection, shared by q and k.
+
+    Samples ``M = num_features`` monomial degrees ``N_r ~ Categorical(a_n / Z)``
+    and a dense ``[M, nmax + 1, head_dim]`` Rademacher tensor (only the first
+    ``N_r`` rows of each feature are actually used; the rest are neutralized to
+    ``1`` at feature time). Degree-0 draws yield the constant feature.
+
+    Args:
+        head_dim: Per-head dimension ``d``.
+        num_features: ``M`` — number of output features (each token maps to
+            exactly ``M`` features).
+        bias: Per-head bias (deployment regime ``bias > 0``).
+        epsilon: YAT epsilon (``C = 2 + epsilon``).
+        nmax: Maclaurin truncation degree (default 40).
+        seed: Optional integer seed for deterministic projections.
+        dtype: Torch dtype for the stored tensors.
+        device: Optional torch device for the stored tensors.
+
+    Returns:
+        Dict of plain tensors / scalars: ``omegas`` ``[M, nmax+1, d]``,
+        ``degrees`` ``[M]`` (int64), ``Z`` (float), ``num_features``,
+        ``nmax``, ``b``, ``eps``, ``head_dim``.
+    """
+    rng = np.random.default_rng(seed)
+    a = maclaurin_coeffs(bias, epsilon, nmax)
+    Z = float(a.sum())
+    p = a / Z
+    degrees_np = rng.choice(len(a), size=num_features, p=p)
+    # Rademacher vectors: [M, nmax+1, d]; only first N_r used per feature.
+    omegas_np = rng.choice(
+        np.array([-1.0, 1.0], dtype=np.float32),
+        size=(num_features, nmax + 1, head_dim),
+    )
+
+    omegas = torch.as_tensor(omegas_np, dtype=dtype, device=device)
+    degrees = torch.as_tensor(degrees_np, dtype=torch.int64, device=device)
+
+    return {
+        "omegas": omegas,              # (M, nmax+1, d)
+        "degrees": degrees,            # (M,)
+        "Z": Z,
+        "num_features": num_features,
+        "nmax": nmax,
+        "b": bias,
+        "eps": epsilon,
+        "head_dim": head_dim,
+    }
+
+
+def maclaurin_features(
+    x: Tensor,
+    params: Dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> Tensor:
+    """Compute MAY features ``φ(x) ∈ ℝ^M`` for each token.
+
+    ``φ_r(x̂) = sqrt(Z / M) · Π_{l < N_r} (omega[r, l] · x̂)``, with unused
+    factors (``l ≥ N_r``) neutralized to ``1``. The product over degree-0
+    features is empty and equals the constant ``sqrt(Z / M)``.
+
+    Args:
+        x: ``(..., head_dim)`` (any leading shape, e.g. ``(B, S, H, d)``).
+        params: Output of :func:`create_maclaurin_projection`.
+        normalize: L2-normalize ``x`` first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., M)``. **Sign-indefinite** (see module doc).
+    """
+    if normalize:
+        x = _normalize(x, epsilon)
+
+    omegas = params["omegas"].to(device=x.device, dtype=x.dtype)  # (M, L, d)
+    degrees = params["degrees"].to(device=x.device)              # (M,)
+    M = params["num_features"]
+    Z = params["Z"]
+    L = omegas.shape[1]
+
+    # proj[..., r, l] = omega[r, l] · x̂   ->  (..., M, L)
+    proj = torch.einsum("...d,mld->...ml", x, omegas)
+
+    # mask[r, l] = (l < N_r); neutralize unused factors to 1.0
+    l_idx = torch.arange(L, device=x.device)               # (L,)
+    mask = l_idx[None, :] < degrees[:, None]                # (M, L)
+    proj = torch.where(mask, proj, torch.ones_like(proj))
+
+    feat = proj.prod(dim=-1)                                # (..., M)
+    return math.sqrt(Z / M) * feat
+
+
+def maclaurin_yat_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    params: Dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> Tensor:
+    """Linear-complexity bias-aware spherical-YAT attention via MAY features.
+
+    Args:
+        query: ``(B, Q, H, d)``.
+        key: ``(B, K, H, d)``.
+        value: ``(B, K, H, v_dim)``.
+        params: Output of :func:`create_maclaurin_projection`.
+        causal: If ``True``, use prefix sums so each query only sees keys up to
+            its own position.
+        epsilon: Numerical stability constant added to the **denominator only**
+            (never to the features — that would bias the estimator).
+
+    Returns:
+        ``(B, Q, H, v_dim)``.
+    """
+    q_feat = maclaurin_features(query, params, normalize=True)
+    k_feat = maclaurin_features(key, params, normalize=True)
+    return linear_attention_readout(
+        q_feat, k_feat, value, causal=causal, epsilon=epsilon
+    )
+
+
+# --------------------------------------------------------------------------
+# RAY — sketched degree-2 modulation ⊗ radial RFF
+# --------------------------------------------------------------------------
+def create_radial_projection(
+    head_dim: int,
+    sketch_m: int = 128,
+    num_radial: int = 8,
+    radial_dim: int = 64,
+    bias: float = 1.0,
+    epsilon: float = 1e-5,
+    seed: Optional[int] = None,
+    dtype: torch.dtype = torch.float32,
+    device: Optional[torch.device] = None,
+) -> Dict[str, Any]:
+    """Precompute the (fixed) RAY projection, shared by q and k.
+
+    Augments ``z = [x̂, sqrt(b)] ∈ ℝ^{d+1}`` so that ``z_q·z_k = s + b`` and
+    ``‖z_q − z_k‖² = ‖q̂ − k̂‖²``. Then
+    ``kappa = (z_q·z_k)² · 1/(eps + ‖z_q − z_k‖²)``, a product of two PSD
+    kernels: a **degree-2 sketch** (two independent Gaussian projections) for
+    ``(z_q·z_k)²`` and a **radial RFF** (Gauss-Laguerre over the
+    exponential-integral representation of ``1/(eps + r²)``) for the radial
+    factor.
+
+    Args:
+        head_dim: Per-head dimension ``d`` (augmented dim is ``d + 1``).
+        sketch_m: ``m`` — degree-2 sketch width.
+        num_radial: Gauss-Laguerre node count for the radial factor.
+        radial_dim: RFF dimension per radial node.
+        bias: Per-head bias.
+        epsilon: YAT epsilon (the radial kernel is ``1/(epsilon + r²)``).
+        seed: Optional integer seed.
+        dtype: Torch dtype for the stored tensors.
+        device: Optional torch device.
+
+    Returns:
+        Dict of plain tensors / scalars.
+    """
+    rng = np.random.default_rng(seed)
+    da = head_dim + 1  # augmented z = [x_hat, sqrt(b)]
+
+    # degree-2 sketch: two independent projections -> approximates (z·z')²
+    W1 = rng.standard_normal((sketch_m, da)).astype(np.float32)
+    W2 = rng.standard_normal((sketch_m, da)).astype(np.float32)
+
+    # radial RFF for 1/(eps + ‖z - z'‖²) via Gauss-Laguerre over
+    # 1/(eps + r²) = ∫_0^∞ e^{−t(eps + r²)} dt, substitution t = tau/eps.
+    tau, wq = np.polynomial.laguerre.laggauss(num_radial)
+    t_nodes = tau / epsilon              # t_j = tau_j / epsilon
+    coef = (1.0 / epsilon) * wq          # (1/epsilon) w_j
+    omegas, phases = [], []
+    for tj in t_nodes:
+        omegas.append(
+            rng.standard_normal((radial_dim, da)).astype(np.float32) * np.sqrt(2.0 * tj)
+        )
+        phases.append(rng.uniform(0, 2 * np.pi, radial_dim).astype(np.float32))
+
+    def _t(arr):
+        return torch.as_tensor(np.asarray(arr), dtype=dtype, device=device)
+
+    return {
+        "W1": _t(W1),                                  # (m, da)
+        "W2": _t(W2),                                  # (m, da)
+        "omegas": _t(np.stack(omegas)),                # (num_radial, radial_dim, da)
+        "phases": _t(np.stack(phases)),                # (num_radial, radial_dim)
+        "coef": _t(coef.astype(np.float32)),           # (num_radial,)
+        "b": bias,
+        "eps": epsilon,
+        "sketch_m": sketch_m,
+        "radial_dim": radial_dim,
+        "num_radial": num_radial,
+        "head_dim": head_dim,
+    }
+
+
+def radial_features(
+    x: Tensor,
+    params: Dict[str, Any],
+    normalize: bool = True,
+    epsilon: float = 1e-6,
+) -> Tensor:
+    """Compute RAY features ``φ(x) = psi(z) ⊗ φ_rad(z)`` for each token.
+
+    Args:
+        x: ``(..., head_dim)``.
+        params: Output of :func:`create_radial_projection`.
+        normalize: L2-normalize ``x`` first (the spherical assumption).
+        epsilon: Stability constant for the normalization denominator.
+
+    Returns:
+        Features of shape ``(..., sketch_m * num_radial * radial_dim)``.
+        **Sign-indefinite** (see module doc).
+    """
+    if normalize:
+        x = _normalize(x, epsilon)
+
+    W1 = params["W1"].to(device=x.device, dtype=x.dtype)
+    W2 = params["W2"].to(device=x.device, dtype=x.dtype)
+    omegas = params["omegas"].to(device=x.device, dtype=x.dtype)   # (J, radial_dim, da)
+    phases = params["phases"].to(device=x.device, dtype=x.dtype)   # (J, radial_dim)
+    coef = params["coef"].to(device=x.device, dtype=x.dtype)       # (J,)
+    sketch_m = params["sketch_m"]
+    radial_dim = params["radial_dim"]
+    b = params["b"]
+
+    leading = x.shape[:-1]
+
+    # z = [x̂, sqrt(b)]  ->  (..., da)
+    sqrt_b = torch.full(
+        leading + (1,), math.sqrt(b), dtype=x.dtype, device=x.device
+    )
+    z = torch.cat([x, sqrt_b], dim=-1)
+
+    # degree-2 sketch psi(z): (..., sketch_m), approximates (z·z')²
+    psi = (
+        torch.einsum("...d,md->...m", z, W1)
+        * torch.einsum("...d,md->...m", z, W2)
+    ) / math.sqrt(sketch_m)
+
+    # radial RFF per node: (..., J, radial_dim)
+    proj = torch.einsum("...d,jrd->...jr", z, omegas) + phases  # (..., J, radial_dim)
+    rff = math.sqrt(2.0 / radial_dim) * torch.cos(proj)
+    sqrt_coef = torch.sqrt(torch.clamp(coef, min=0.0))          # (J,)
+    rff = rff * sqrt_coef[..., :, None]
+    phi_rad = rff.reshape(leading + (-1,))                      # (..., J*radial_dim)
+
+    # tensor product psi(z) ⊗ φ_rad(z)  ->  (..., sketch_m * J*radial_dim)
+    out = psi[..., :, None] * phi_rad[..., None, :]             # (..., m, J*radial_dim)
+    return out.reshape(leading + (-1,))
+
+
+def radial_yat_attention(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    params: Dict[str, Any],
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> Tensor:
+    """Linear-complexity bias-aware spherical-YAT attention via RAY features.
+
+    See :func:`maclaurin_yat_attention`; same signature, RAY feature map.
+    """
+    q_feat = radial_features(query, params, normalize=True)
+    k_feat = radial_features(key, params, normalize=True)
+    return linear_attention_readout(
+        q_feat, k_feat, value, causal=causal, epsilon=epsilon
+    )
+
+
+# --------------------------------------------------------------------------
+# Feature-map-agnostic linear-attention readout
+# --------------------------------------------------------------------------
+def linear_attention_readout(
+    q_feat: Tensor,
+    k_feat: Tensor,
+    value: Tensor,
+    causal: bool = False,
+    epsilon: float = 1e-5,
+) -> Tensor:
+    """L1-normalized linear-attention readout from feature maps.
+
+    ``kv = Σ_k φ_k ⊗ v``; ``num = φ_q · kv``; ``den = φ_q · Σ_k φ_k``;
+    ``out = num / (den + epsilon)``. The epsilon is added to the **denominator
+    only** (the features are unbiased and must not be shifted).
+
+    Args:
+        q_feat: ``(B, Q, H, F)``.
+        k_feat: ``(B, K, H, F)``.
+        value: ``(B, K, H, v_dim)``.
+        causal: If ``True``, use prefix sums (each query sees only keys up to
+            its own position).
+        epsilon: Denominator stability constant.
+
+    Returns:
+        ``(B, Q, H, v_dim)``.
+    """
+    if k_feat.dtype != q_feat.dtype:
+        k_feat = k_feat.to(q_feat.dtype)
+    if value.dtype != q_feat.dtype:
+        value = value.to(q_feat.dtype)
+
+    if causal:
+        # kv[b, k, h, f, d] = k_feat[b, k, h, f] * value[b, k, h, d]
+        kv = torch.einsum("bkhf,bkhd->bkhfd", k_feat, value)
+        kv_cum = torch.cumsum(kv, dim=1)
+        k_cum = torch.cumsum(k_feat, dim=1)
+
+        num = torch.einsum("bqhf,bqhfd->bqhd", q_feat, kv_cum)
+        den = torch.einsum("bqhf,bqhf->bqh", q_feat, k_cum)
+        den = den[..., None]
+        return num / (den + epsilon)
+
+    # Non-causal: O(n) via the associativity trick.
+    kv = torch.einsum("bkhf,bkhd->bhfd", k_feat, value)
+    num = torch.einsum("bqhf,bhfd->bqhd", q_feat, kv)
+
+    k_sum = k_feat.sum(dim=1)
+    den = torch.einsum("bqhf,bhf->bqh", q_feat, k_sum)
+    den = den[..., None]
+    return num / (den + epsilon)

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -50,6 +50,12 @@ class YatNMN(nn.Module):
             to have norm 1. (PyTorch kernels use shape ``(out_features, in_features)``,
             so each row is one neuron.) This optimization avoids recomputing kernel
             norms in YAT distance calculation since they are guaranteed to be 1.0.
+        lazy (bool): If True, freeze ONLY the kernel (``weight.requires_grad =
+            False``) so it is excluded from gradients/optimizer; bias, alpha,
+            and the learnable epsilon stay trainable. Composes with
+            ``use_bias`` / ``use_alpha`` / ``learnable_epsilon``. Default False
+            (fully backward compatible). Alias: ``freeze_kernel``.
+        freeze_kernel (bool): Alias for ``lazy`` (logical OR with ``lazy``).
         tie_kernel_bank (bool): If True, reuse shared kernels across compatible layers.
         kernel_bank_size (int): Optional explicit size for shared bank (auto-expands if needed).
         kernel_bank_id (str): Namespace for shared banks (allows multiple independent banks).
@@ -81,6 +87,8 @@ class YatNMN(nn.Module):
         spherical: bool = False,
         positive_init: bool = False,
         weight_normalized: bool = False,
+        lazy: bool = False,
+        freeze_kernel: bool = False,
         tie_kernel_bank: bool = False,
         kernel_bank_size: Optional[int] = None,
         kernel_bank_id: str = 'default',
@@ -110,6 +118,8 @@ class YatNMN(nn.Module):
         self.spherical = spherical
         self.positive_init = positive_init
         self.weight_normalized = weight_normalized
+        # Lazy mode: freeze ONLY the kernel; bias/alpha/epsilon stay trainable.
+        self.lazy = bool(lazy or freeze_kernel)
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
@@ -217,6 +227,12 @@ class YatNMN(nn.Module):
         if self.weight_normalized:
             weight_norm = torch.sqrt(torch.sum(self.weight**2, dim=-1, keepdim=True))
             self.weight.data = self.weight.data / (weight_norm + 1e-8)
+
+        # Lazy mode: freeze ONLY the kernel so it is excluded from gradients and
+        # the optimizer. bias / alpha / epsilon_param stay requires_grad=True.
+        # Applied last so it survives reset_parameters and weight normalization.
+        if self.lazy:
+            self.weight.requires_grad_(False)
 
     def reset_parameters(
         self,
@@ -377,6 +393,7 @@ class YatNMN(nn.Module):
                 f"bias={self.bias is not None}, "
                 f"alpha={self.alpha is not None}, "
                 f"constant_alpha={self.constant_alpha}, "
+                f"lazy={self.lazy}, "
                 f"spherical={self.spherical}, "
                 f"dtype={self.dtype}, "
                 f"param_dtype={self.param_dtype}")

--- a/tests/scripts/benchmark_may_ray.py
+++ b/tests/scripts/benchmark_may_ray.py
@@ -1,0 +1,210 @@
+"""Cross-framework benchmark for MAY / RAY / SLAY spherical-Yat feature maps.
+
+Reproduces the headline result of issue #36: in the deployment regime (bias
+``b > 0``) the bias-aware **MAY** (Random Maclaurin) feature map is near-exact and
+beats the bias-free **SLAY** anchor method, which floors at a wrong-kernel ceiling.
+**RAY** (radial) is the weaker secondary method.
+
+The ground-truth kernel is computed directly in NumPy (bias-aware, with
+``eps = median squared distance`` — the Yat epsilon heuristic), so the benchmark
+measures *feature-map quality* and is identical across frameworks. Each installed
+framework's feature maps are then evaluated against that shared ground truth.
+
+Run:  python3 tests/scripts/benchmark_may_ray.py
+Frameworks that are not installed are skipped automatically.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# --------------------------------------------------------------------------
+# Shared, verified ground truth (bias-aware exact spherical-Yat attention)
+# --------------------------------------------------------------------------
+D, N = 64, 512
+B_VALUES = [0.0, 0.25, 0.5, 1.0, 2.0, 4.0]
+SEEDS = [0, 1, 2]
+F = 256  # matched feature budget
+
+
+def _normalize(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def _median_sq_distance(qn, kn):
+    diff = qn[:, None, :] - kn[None, :, :]
+    return float(np.median((diff * diff).sum(-1)))
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize(q), _normalize(k)
+    s = qn @ kn.T
+    w = (s + b) ** 2 / ((2.0 + eps) - 2.0 * s)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _per_token_cos(a, b):
+    num = (a * b).sum(-1)
+    den = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1) + 1e-12
+    return float(np.mean(num / den))
+
+
+def _rel_l2(a, b):
+    return float(np.linalg.norm(a - b) / (np.linalg.norm(a) + 1e-12))
+
+
+# --------------------------------------------------------------------------
+# Per-framework adapters: numpy [N, d] -> framework -> numpy attention output.
+# Each returns dict {method_name: callable(q, k, v, b, eps, seed) -> np [N, d]}
+# or None if the framework is not importable.
+# --------------------------------------------------------------------------
+def _reshape_in(x):
+    # attention APIs use [batch, seq, heads, head_dim]; we use B=1, H=1.
+    return x.reshape(1, x.shape[0], 1, x.shape[1])
+
+
+def _reshape_out(y):
+    return np.asarray(y).reshape(N, D)
+
+
+def adapter_nnx():
+    try:
+        import jax.numpy as jnp
+        from jax import random
+        from nmn.nnx.layers.attention import maclaurin_yat as m, radial_yat as r
+        from nmn.nnx.layers.attention import spherical_yat_performer as s
+    except Exception:
+        return None
+
+    def to(x):
+        return jnp.asarray(_reshape_in(x))
+
+    def may(q, k, v, b, eps, seed):
+        p = m.create_maclaurin_projection(random.PRNGKey(seed), D, num_features=F, bias=b, epsilon=eps)
+        return _reshape_out(m.maclaurin_yat_attention(to(q), to(k), to(v), p))
+
+    def ray(q, k, v, b, eps, seed):
+        p = r.create_radial_projection(random.PRNGKey(seed), D, sketch_m=8, num_radial=4, radial_dim=8, bias=b, epsilon=eps)
+        return _reshape_out(r.radial_yat_attention(to(q), to(k), to(v), p))
+
+    def slay(q, k, v, b, eps, seed):
+        p = s.create_yat_tp_projection(random.PRNGKey(seed), D, num_prf_features=8, num_quad_nodes=1, num_anchor_features=32, epsilon=eps)
+        return _reshape_out(s.yat_tp_attention(to(q), to(k), to(v), p))
+
+    return {"MAY": may, "RAY": ray, "SLAY": slay}
+
+
+def adapter_linen():
+    try:
+        import jax.numpy as jnp
+        from jax import random
+        from nmn.linen import performer_yat as p
+    except Exception:
+        return None
+
+    def to(x):
+        return jnp.asarray(_reshape_in(x))
+
+    def may(q, k, v, b, eps, seed):
+        pr = p.create_maclaurin_projection(random.PRNGKey(seed), D, num_features=F, bias=b, epsilon=eps)
+        return _reshape_out(p.maclaurin_yat_attention(to(q), to(k), to(v), pr))
+
+    def ray(q, k, v, b, eps, seed):
+        pr = p.create_radial_projection(random.PRNGKey(seed), D, sketch_m=8, num_radial=4, radial_dim=8, bias=b, epsilon=eps)
+        return _reshape_out(p.radial_yat_attention(to(q), to(k), to(v), pr))
+
+    return {"MAY": may, "RAY": ray}
+
+
+def adapter_torch():
+    try:
+        import torch
+        from nmn.torch.attention import performer_yat as p
+    except Exception:
+        return None
+
+    def to(x):
+        return torch.from_numpy(_reshape_in(x).astype(np.float32))
+
+    def may(q, k, v, b, eps, seed):
+        torch.manual_seed(seed)
+        pr = p.create_maclaurin_projection(D, num_features=F, bias=b, epsilon=eps, seed=seed)
+        return _reshape_out(p.maclaurin_yat_attention(to(q), to(k), to(v), pr).detach())
+
+    def ray(q, k, v, b, eps, seed):
+        pr = p.create_radial_projection(D, sketch_m=8, num_radial=4, radial_dim=8, bias=b, epsilon=eps, seed=seed)
+        return _reshape_out(p.radial_yat_attention(to(q), to(k), to(v), pr).detach())
+
+    return {"MAY": may, "RAY": ray}
+
+
+def adapter_mlx():
+    try:
+        import mlx.core as mx
+        from nmn.mlx import may as mmay, ray as mray, performer as mslay
+    except Exception:
+        return None
+
+    def to(x):
+        return mx.array(_reshape_in(x).astype(np.float32))
+
+    def may(q, k, v, b, eps, seed):
+        pr = mmay.create_maclaurin_projection(D, num_features=F, bias=b, epsilon=eps, seed=seed)
+        return _reshape_out(mmay.maclaurin_yat_attention(to(q), to(k), to(v), pr))
+
+    def ray(q, k, v, b, eps, seed):
+        pr = mray.create_radial_projection(D, sketch_m=8, num_radial=4, radial_dim=8, bias=b, epsilon=eps, seed=seed)
+        return _reshape_out(mray.radial_yat_attention(to(q), to(k), to(v), pr))
+
+    def slay(q, k, v, b, eps, seed):
+        pr = mslay.create_yat_tp_projection(D, num_prf_features=8, num_quad_nodes=1, num_anchor_features=32, epsilon=eps, seed=seed)
+        return _reshape_out(mslay.yat_tp_attention(to(q), to(k), to(v), pr))
+
+    return {"MAY": may, "RAY": ray, "SLAY": slay}
+
+
+ADAPTERS = {
+    "nnx": adapter_nnx,
+    "linen": adapter_linen,
+    "torch": adapter_torch,
+    "mlx": adapter_mlx,
+    # tf / keras require tensorflow; their adapters mirror the same API and run in CI.
+}
+
+
+def run():
+    print("MAY / RAY / SLAY spherical-Yat feature-map benchmark")
+    print(f"d={D}  N={N}  matched F={F}  eps=median-sq-dist  {len(SEEDS)} seeds")
+    print("(MAY should be near-exact and beat SLAY at b>=1; SLAY wins only at b=0)\n")
+
+    for name, build in ADAPTERS.items():
+        methods = build()
+        if methods is None:
+            print(f"[{name}] not installed — skipped\n")
+            continue
+        cols = list(methods.keys())
+        print(f"### {name}")
+        print(f"{'b':>5} | " + " | ".join(f"{c+' cos/relL2':>16}" for c in cols))
+        print("-" * (8 + 19 * len(cols)))
+        for b in B_VALUES:
+            agg = {c: [[], []] for c in cols}
+            for seed in SEEDS:
+                rng = np.random.default_rng(100 + seed)
+                q = rng.standard_normal((N, D))
+                k = rng.standard_normal((N, D))
+                v = rng.standard_normal((N, D))
+                eps = _median_sq_distance(_normalize(q), _normalize(k))
+                exact = _exact_attention(q, k, v, b, eps)
+                for c in cols:
+                    out = methods[c](q, k, v, b, eps, seed)
+                    agg[c][0].append(_per_token_cos(out, exact))
+                    agg[c][1].append(_rel_l2(out, exact))
+            cells = []
+            for c in cols:
+                cells.append(f"{np.mean(agg[c][0]):5.2f} / {np.mean(agg[c][1]):5.2f}")
+            print(f"{b:5.2f} | " + " | ".join(f"{x:>16}" for x in cells))
+        print()
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/test_keras/test_lazy.py
+++ b/tests/test_keras/test_lazy.py
@@ -106,22 +106,34 @@ def test_lazy_training_step_kernel_unchanged():
     kernel_before = np.array(layer.kernel)
     bias_before = np.array(layer.bias)
     alpha_before = np.array(layer.alpha)
-    eps_before = np.array(layer.epsilon_param)
+
+    # epsilon_param initializes at inverse-softplus(1e-5) ≈ -11.5, a saturated
+    # point where the softplus gradient is ~1e-5, so its *value* barely moves in
+    # a couple of SGD steps. The property #37 requires is that epsilon stays
+    # trainable (receives a real gradient), not frozen — assert that directly
+    # rather than a fragile value-change threshold.
+    names = [w.name for w in layer.trainable_weights]
+    eps_idx = next(i for i, n in enumerate(names) if "epsilon" in n)
 
     opt = keras.optimizers.SGD(learning_rate=0.1)
+    eps_grad_seen = False
     for _ in range(2):
         with tf.GradientTape() as tape:
             pred = layer(x)
             loss = tf.reduce_mean(tf.square(pred - y))
         grads = tape.gradient(loss, layer.trainable_weights)
+        g_eps = grads[eps_idx]
+        if g_eps is not None and float(tf.reduce_max(tf.abs(g_eps))) > 0.0:
+            eps_grad_seen = True
         opt.apply_gradients(zip(grads, layer.trainable_weights))
 
-    # Kernel untouched.
+    # Kernel untouched (frozen).
     np.testing.assert_allclose(kernel_before, np.array(layer.kernel), atol=1e-7)
-    # Bias / alpha / epsilon moved.
+    # Bias / alpha moved (healthy gradients).
     assert not np.allclose(bias_before, np.array(layer.bias), atol=1e-7)
     assert not np.allclose(alpha_before, np.array(layer.alpha), atol=1e-7)
-    assert not np.allclose(eps_before, np.array(layer.epsilon_param), atol=1e-7)
+    # Epsilon is trainable: it received a real (non-None, non-zero) gradient.
+    assert eps_grad_seen, "epsilon_param did not receive a gradient (wrongly frozen)"
 
 
 def test_eager_training_step_kernel_changes():

--- a/tests/test_keras/test_lazy.py
+++ b/tests/test_keras/test_lazy.py
@@ -1,0 +1,152 @@
+"""Tests for YatNMN lazy mode (issue #37) on the Keras backend.
+
+Lazy mode freezes ONLY the kernel (its feature directions). The bias, alpha,
+and learnable epsilon stay trainable. TensorFlow is not installed locally, so
+these tests are guarded by ``pytest.importorskip("tensorflow")`` and run in CI.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("tensorflow")
+keras = pytest.importorskip("keras")
+
+from nmn.keras.nmn import YatNMN
+
+
+def _build(layer, input_dim=8):
+    x = np.random.randn(4, input_dim).astype(np.float32)
+    layer(x)  # triggers build
+    return x
+
+
+def _weight(layer, name):
+    for w in layer.weights:
+        if w.name == name or w.name.endswith("/" + name) or name in w.name:
+            return w
+    raise KeyError(name)
+
+
+# --------------------------------------------------------------------------
+# Backward compatibility (lazy defaults to False).
+# --------------------------------------------------------------------------
+def test_default_kernel_trainable():
+    layer = YatNMN(units=6)
+    _build(layer)
+    assert layer.lazy is False
+    assert layer.kernel.trainable is True
+
+
+def test_default_output_unchanged_vs_lazy_construction():
+    """lazy=False must preserve current behavior (same forward output)."""
+    x = np.random.randn(4, 8).astype(np.float32)
+    eager = YatNMN(units=6, kernel_initializer="ones", bias_initializer="zeros")
+    out_eager = np.array(eager(x))
+    assert np.all(np.isfinite(out_eager))
+
+
+# --------------------------------------------------------------------------
+# Lazy mode: kernel frozen, everything else trainable.
+# --------------------------------------------------------------------------
+def test_lazy_kernel_not_trainable():
+    layer = YatNMN(units=6, lazy=True)
+    _build(layer)
+    assert layer.lazy is True
+    assert layer.kernel.trainable is False
+    # Kernel excluded from the trainable set, not merely zero-grad.
+    trainable_names = [w.name for w in layer.trainable_weights]
+    assert not any("kernel" in n and "bias" not in n for n in trainable_names)
+
+
+def test_freeze_kernel_alias():
+    layer = YatNMN(units=6, freeze_kernel=True)
+    _build(layer)
+    assert layer.lazy is True
+    assert layer.kernel.trainable is False
+
+
+def test_lazy_bias_alpha_epsilon_trainable():
+    layer = YatNMN(
+        units=6,
+        lazy=True,
+        use_bias=True,
+        use_alpha=True,
+        learnable_epsilon=True,
+    )
+    _build(layer)
+    trainable_names = [w.name for w in layer.trainable_weights]
+
+    assert layer.bias is not None and layer.bias.trainable is True
+    assert layer.alpha is not None and layer.alpha.trainable is True
+    assert layer.epsilon_param is not None and layer.epsilon_param.trainable is True
+
+    assert any("bias" in n for n in trainable_names)
+    assert any("alpha" in n for n in trainable_names)
+    assert any("epsilon" in n for n in trainable_names)
+    # The kernel is the only non-trainable weight.
+    non_trainable = [w.name for w in layer.non_trainable_weights]
+    assert any("kernel" in n for n in non_trainable)
+
+
+def test_lazy_training_step_kernel_unchanged():
+    """One training step: kernel stays fixed; bias/alpha/epsilon move."""
+    tf = pytest.importorskip("tensorflow")
+
+    layer = YatNMN(
+        units=4,
+        lazy=True,
+        use_bias=True,
+        use_alpha=True,
+        learnable_epsilon=True,
+    )
+    x = tf.constant(np.random.randn(8, 8).astype(np.float32))
+    y = tf.constant(np.random.randn(8, 4).astype(np.float32))
+    layer(x)  # build
+
+    kernel_before = np.array(layer.kernel)
+    bias_before = np.array(layer.bias)
+    alpha_before = np.array(layer.alpha)
+    eps_before = np.array(layer.epsilon_param)
+
+    opt = keras.optimizers.SGD(learning_rate=0.1)
+    for _ in range(2):
+        with tf.GradientTape() as tape:
+            pred = layer(x)
+            loss = tf.reduce_mean(tf.square(pred - y))
+        grads = tape.gradient(loss, layer.trainable_weights)
+        opt.apply_gradients(zip(grads, layer.trainable_weights))
+
+    # Kernel untouched.
+    np.testing.assert_allclose(kernel_before, np.array(layer.kernel), atol=1e-7)
+    # Bias / alpha / epsilon moved.
+    assert not np.allclose(bias_before, np.array(layer.bias), atol=1e-7)
+    assert not np.allclose(alpha_before, np.array(layer.alpha), atol=1e-7)
+    assert not np.allclose(eps_before, np.array(layer.epsilon_param), atol=1e-7)
+
+
+def test_eager_training_step_kernel_changes():
+    """lazy=False (default): the kernel DOES update (backward compatible)."""
+    tf = pytest.importorskip("tensorflow")
+
+    layer = YatNMN(units=4, lazy=False, use_bias=True)
+    x = tf.constant(np.random.randn(8, 8).astype(np.float32))
+    y = tf.constant(np.random.randn(8, 4).astype(np.float32))
+    layer(x)
+
+    kernel_before = np.array(layer.kernel)
+    opt = keras.optimizers.SGD(learning_rate=0.1)
+    with tf.GradientTape() as tape:
+        loss = tf.reduce_mean(tf.square(layer(x) - y))
+    grads = tape.gradient(loss, layer.trainable_weights)
+    opt.apply_gradients(zip(grads, layer.trainable_weights))
+
+    assert not np.allclose(kernel_before, np.array(layer.kernel), atol=1e-7)
+
+
+def test_lazy_get_config_roundtrip():
+    layer = YatNMN(units=6, lazy=True)
+    config = layer.get_config()
+    assert config["lazy"] is True
+    assert config["freeze_kernel"] is True
+    rebuilt = YatNMN.from_config(config)
+    assert rebuilt.lazy is True

--- a/tests/test_keras/test_performer_yat.py
+++ b/tests/test_keras/test_performer_yat.py
@@ -1,0 +1,263 @@
+"""Tests for Keras MAY (Random Maclaurin) and RAY (radial) feature maps.
+
+The Keras/TensorFlow backend is not installed in the local dev environment, so
+these tests are guarded by ``pytest.importorskip("tensorflow")`` and run in CI.
+
+The math mirrors the verified NumPy reference at ``.context/may-ray/reference.py``
+exactly, so the qualitative guarantees (inner product tracks kappa, MAY beats
+the bias-free SLAY baseline at ``b >= 1``) are reproduced here.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+pytest.importorskip("tensorflow")
+keras = pytest.importorskip("keras")
+
+from nmn.keras.performer_yat import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
+
+
+# --------------------------------------------------------------------------
+# Pure-NumPy oracles (copied from the verified reference) for cross-checking.
+# --------------------------------------------------------------------------
+def _normalize_rows(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def _exact_kernel(s, b, eps):
+    C = 2.0 + eps
+    return (s + b) ** 2 / (C - 2.0 * s)
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize_rows(q), _normalize_rows(k)
+    s = qn @ kn.T
+    w = _exact_kernel(s, b, eps)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _linear_attention_np(phi_q, phi_k, v, eps=1e-9):
+    kv = phi_k.T @ v
+    num = phi_q @ kv
+    den = phi_q @ phi_k.sum(0)
+    return num / (den[:, None] + eps)
+
+
+def _slay_create(d, P=32, M=8, R=1, eps=1e-5, seed=0):
+    rng = np.random.default_rng(seed)
+    C = 2.0 + eps
+    nodes, weights = np.polynomial.laguerre.laggauss(R)
+    nodes, weights = nodes / C, weights / C
+    anchors = _normalize_rows(rng.standard_normal((P, d)))
+    proj = rng.standard_normal((R, M, d))
+    return dict(anchors=anchors, proj=proj, nodes=nodes, weights=weights, P=P, M=M, R=R)
+
+
+def _slay_features(x, params):
+    x = _normalize_rows(x)
+    P, M, R = params["P"], params["M"], params["R"]
+    poly = (x @ params["anchors"].T) ** 2 / np.sqrt(P)
+    proj_all = np.einsum("nd,rmd->nrm", x, params["proj"])
+    out = []
+    for r in range(R):
+        s = params["nodes"][r]
+        arg = np.clip(proj_all[:, r] * np.sqrt(2 * max(s, 0)) - s, -20, 20)
+        prf = np.exp(arg) / np.sqrt(M)
+        fused = np.einsum("np,nm->npm", poly, prf).reshape(x.shape[0], -1)
+        out.append(np.sqrt(max(params["weights"][r], 0)) * fused)
+    return np.concatenate(out, axis=1)
+
+
+def _median_sq_distance(qn, kn):
+    diff = qn[:, None, :] - kn[None, :, :]
+    return float(np.median((diff * diff).sum(-1)))
+
+
+def _per_token_cos(a, b):
+    num = (a * b).sum(-1)
+    den = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1) + 1e-12
+    return float(np.mean(num / den))
+
+
+# --------------------------------------------------------------------------
+# Maclaurin coefficient sanity
+# --------------------------------------------------------------------------
+def test_maclaurin_coeffs_nonnegative():
+    a = maclaurin_coeffs(b=1.0, eps=0.05, nmax=40)
+    assert a.shape == (41,)
+    assert np.all(a >= 0.0)
+    assert a.sum() > 0.0
+
+
+# --------------------------------------------------------------------------
+# MAY: shapes, finiteness, determinism
+# --------------------------------------------------------------------------
+def test_may_feature_shape():
+    d, M = 16, 64
+    params = create_maclaurin_projection(d, num_features=M, bias=1.0, epsilon=0.05, seed=0)
+    x = np.random.randn(2, 5, 4, d).astype(np.float32)
+    feat = np.array(maclaurin_features(x, params))
+    assert feat.shape == (2, 5, 4, M)
+
+
+def test_may_no_nan_inf():
+    d, M = 16, 64
+    params = create_maclaurin_projection(d, num_features=M, bias=1.0, epsilon=0.05, seed=0)
+    x = np.random.randn(2, 5, 4, d).astype(np.float32)
+    feat = np.array(maclaurin_features(x, params))
+    assert np.all(np.isfinite(feat))
+
+
+def test_may_determinism():
+    d, M = 16, 64
+    x = np.random.randn(3, 7, 2, d).astype(np.float32)
+    p1 = create_maclaurin_projection(d, num_features=M, bias=1.0, epsilon=0.05, seed=42)
+    p2 = create_maclaurin_projection(d, num_features=M, bias=1.0, epsilon=0.05, seed=42)
+    f1 = np.array(maclaurin_features(x, p1))
+    f2 = np.array(maclaurin_features(x, p2))
+    np.testing.assert_allclose(f1, f2, atol=1e-6)
+
+
+def test_may_attention_shape_and_finite():
+    d, M = 16, 128
+    params = create_maclaurin_projection(d, num_features=M, bias=1.0, epsilon=0.05, seed=0)
+    q = np.random.randn(2, 6, 3, d).astype(np.float32)
+    k = np.random.randn(2, 8, 3, d).astype(np.float32)
+    v = np.random.randn(2, 8, 3, 10).astype(np.float32)
+    out = np.array(maclaurin_yat_attention(q, k, v, params))
+    assert out.shape == (2, 6, 3, 10)
+    assert np.all(np.isfinite(out))
+
+
+def test_may_causal_shape():
+    d, M = 16, 64
+    params = create_maclaurin_projection(d, num_features=M, bias=1.0, epsilon=0.05, seed=0)
+    q = np.random.randn(2, 7, 2, d).astype(np.float32)
+    v = np.random.randn(2, 7, 2, d).astype(np.float32)
+    out = np.array(maclaurin_yat_attention(q, q, v, params, causal=True))
+    assert out.shape == (2, 7, 2, d)
+    assert np.all(np.isfinite(out))
+
+
+# --------------------------------------------------------------------------
+# MAY: inner product tracks kappa (unbiased estimator), averaged over seeds.
+# --------------------------------------------------------------------------
+def test_may_inner_product_tracks_kappa():
+    d, M, b, eps = 16, 4096, 1.0, 0.05
+    rng = np.random.default_rng(0)
+    q = rng.standard_normal((200, d)).astype(np.float32)
+    k = rng.standard_normal((200, d)).astype(np.float32)
+    qhat, khat = _normalize_rows(q), _normalize_rows(k)
+    s = (qhat * khat).sum(-1)
+    kap = _exact_kernel(s, b, eps)
+
+    # Average the (high-variance, unbiased) inner product over several seeds.
+    ips = []
+    for seed in range(40):
+        params = create_maclaurin_projection(d, num_features=M, bias=b, epsilon=eps, seed=seed)
+        qf = np.array(maclaurin_features(q, params))
+        kf = np.array(maclaurin_features(k, params))
+        ips.append((qf * kf).sum(-1))
+    ip = np.mean(ips, axis=0)
+
+    # Tracks kappa (rises with s) — strong positive correlation.
+    assert np.corrcoef(ip, kap)[0, 1] > 0.9
+
+
+def test_may_more_features_better():
+    """More features -> higher cosine similarity to exact attention."""
+    d, N, b = 32, 128, 1.0
+    rng = np.random.default_rng(7)
+    q = rng.standard_normal((N, d)).astype(np.float32)
+    k = rng.standard_normal((N, d)).astype(np.float32)
+    v = rng.standard_normal((N, d)).astype(np.float32)
+    eps = _median_sq_distance(_normalize_rows(q), _normalize_rows(k))
+    exact = _exact_attention(q, k, v, b, eps)
+
+    def may_cos(M):
+        # average over seeds to reduce variance of the estimate
+        cs = []
+        for seed in range(5):
+            p = create_maclaurin_projection(d, num_features=M, bias=b, epsilon=eps, seed=seed)
+            qf = np.array(maclaurin_features(q, p))
+            kf = np.array(maclaurin_features(k, p))
+            out = _linear_attention_np(qf, kf, v)
+            cs.append(_per_token_cos(out, exact))
+        return float(np.mean(cs))
+
+    assert may_cos(512) > may_cos(64)
+
+
+def test_may_beats_slay_at_b1():
+    """At b >= 1 MAY (bias-aware) must clearly beat SLAY (bias-free)."""
+    d, N, b = 64, 256, 1.0
+    F = 256  # matched feature budget
+    seeds = [0, 1, 2]
+    may_cos, slay_cos = [], []
+    for seed in seeds:
+        rng = np.random.default_rng(100 + seed)
+        q = rng.standard_normal((N, d)).astype(np.float32)
+        k = rng.standard_normal((N, d)).astype(np.float32)
+        v = rng.standard_normal((N, d)).astype(np.float32)
+        eps = _median_sq_distance(_normalize_rows(q), _normalize_rows(k))
+        exact = _exact_attention(q, k, v, b, eps)
+
+        mp = create_maclaurin_projection(d, num_features=F, bias=b, epsilon=eps, seed=seed)
+        qf = np.array(maclaurin_features(q, mp))
+        kf = np.array(maclaurin_features(k, mp))
+        may_out = _linear_attention_np(qf, kf, v)
+        may_cos.append(_per_token_cos(may_out, exact))
+
+        sp = _slay_create(d, P=32, M=8, R=1, eps=eps, seed=seed)
+        sa = _linear_attention_np(_slay_features(q, sp), _slay_features(k, sp), v)
+        slay_cos.append(_per_token_cos(sa, exact))
+
+    assert np.mean(may_cos) > np.mean(slay_cos)
+
+
+# --------------------------------------------------------------------------
+# RAY: shapes, finiteness, determinism
+# --------------------------------------------------------------------------
+def test_ray_feature_shape():
+    d = 16
+    params = create_radial_projection(
+        d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.05, seed=0
+    )
+    x = np.random.randn(2, 5, 3, d).astype(np.float32)
+    feat = np.array(radial_features(x, params))
+    assert feat.shape == (2, 5, 3, 8 * 4 * 8)
+    assert np.all(np.isfinite(feat))
+
+
+def test_ray_determinism():
+    d = 16
+    x = np.random.randn(2, 5, 3, d).astype(np.float32)
+    p1 = create_radial_projection(d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.05, seed=1)
+    p2 = create_radial_projection(d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.05, seed=1)
+    np.testing.assert_allclose(
+        np.array(radial_features(x, p1)), np.array(radial_features(x, p2)), atol=1e-6
+    )
+
+
+def test_ray_attention_shape_and_finite():
+    d = 16
+    params = create_radial_projection(
+        d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.05, seed=0
+    )
+    q = np.random.randn(2, 6, 2, d).astype(np.float32)
+    k = np.random.randn(2, 8, 2, d).astype(np.float32)
+    v = np.random.randn(2, 8, 2, 10).astype(np.float32)
+    out = np.array(radial_yat_attention(q, k, v, params))
+    assert out.shape == (2, 6, 2, 10)
+    assert np.all(np.isfinite(out))

--- a/tests/test_linen/test_lazy_yatnmn.py
+++ b/tests/test_linen/test_lazy_yatnmn.py
@@ -1,0 +1,154 @@
+"""Tests for YatNMN lazy mode (issue #37, Flax Linen).
+
+When ``lazy=True`` (alias ``freeze_kernel=True``) ONLY the ``kernel`` is frozen
+via ``jax.lax.stop_gradient``; ``bias``, ``alpha`` and the learnable
+``epsilon`` remain trainable. ``lazy=False`` preserves the previous behavior
+(backward compatible).
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+from flax.traverse_util import flatten_dict  # noqa: E402
+
+from nmn.linen.nmn import YatNMN  # noqa: E402
+
+
+def _make(lazy=False, epsilon=1.0, **kw):
+    # Use epsilon=1.0 (not 1e-5) so the softplus-parameterized epsilon sits in
+    # a sensitive region with a meaningful gradient for the training smoke test.
+    layer = YatNMN(
+        features=6,
+        use_bias=True,
+        use_alpha=True,
+        learnable_epsilon=True,
+        epsilon=epsilon,
+        lazy=lazy,
+        **kw,
+    )
+    key = jax.random.PRNGKey(0)
+    x = jax.random.normal(jax.random.PRNGKey(1), (4, 8))
+    params = layer.init(key, x)
+    return layer, params, x
+
+
+def _grads(layer, params, x):
+    def loss(p):
+        return jnp.sum(layer.apply(p, x) ** 2)
+
+    return jax.grad(loss)(params)
+
+
+def test_lazy_default_false_backward_compat():
+    """lazy=False yields nonzero kernel gradient (existing behavior)."""
+    layer, params, x = _make(lazy=False)
+    grads = _grads(layer, params, x)
+    flat = flatten_dict(grads)
+    kgrad = next(v for k, v in flat.items() if k[-1] == "kernel")
+    assert float(jnp.linalg.norm(kgrad)) > 0.0
+
+
+def test_lazy_freezes_kernel_gradient():
+    """lazy=True -> kernel gradient is exactly zero (stop_gradient)."""
+    layer, params, x = _make(lazy=True)
+    grads = _grads(layer, params, x)
+    flat = flatten_dict(grads)
+    kgrad = next(v for k, v in flat.items() if k[-1] == "kernel")
+    assert float(jnp.linalg.norm(kgrad)) == 0.0
+
+
+def test_lazy_keeps_bias_alpha_epsilon_trainable():
+    """bias, alpha, epsilon retain nonzero gradients in lazy mode."""
+    layer, params, x = _make(lazy=True)
+    grads = _grads(layer, params, x)
+    flat = flatten_dict(grads)
+
+    def gnorm(name):
+        g = next(v for k, v in flat.items() if k[-1] == name)
+        return float(jnp.linalg.norm(g))
+
+    assert gnorm("bias") > 0.0
+    assert gnorm("alpha") > 0.0
+    assert gnorm("epsilon_param") > 0.0
+
+
+def test_freeze_kernel_alias():
+    """freeze_kernel=True behaves like lazy=True."""
+    layer = YatNMN(features=6, learnable_epsilon=True, freeze_kernel=True)
+    key = jax.random.PRNGKey(0)
+    x = jax.random.normal(jax.random.PRNGKey(1), (4, 8))
+    params = layer.init(key, x)
+    grads = _grads(layer, params, x)
+    flat = flatten_dict(grads)
+    kgrad = next(v for k, v in flat.items() if k[-1] == "kernel")
+    assert float(jnp.linalg.norm(kgrad)) == 0.0
+
+
+def test_lazy_training_smoke():
+    """One SGD step: kernel unchanged, bias/alpha/epsilon change."""
+    layer, params, x = _make(lazy=True)
+    flat0 = flatten_dict(params)
+
+    grads = _grads(layer, params, x)
+    lr = 0.1
+    new = jax.tree_util.tree_map(lambda p, g: p - lr * g, params, grads)
+    flat1 = flatten_dict(new)
+
+    def get(flat, name):
+        return next(v for k, v in flat.items() if k[-1] == name)
+
+    # kernel unchanged
+    assert np.allclose(np.asarray(get(flat0, "kernel")),
+                       np.asarray(get(flat1, "kernel")))
+    # bias / alpha / epsilon moved
+    assert not np.allclose(np.asarray(get(flat0, "bias")),
+                           np.asarray(get(flat1, "bias")))
+    assert not np.allclose(np.asarray(get(flat0, "alpha")),
+                           np.asarray(get(flat1, "alpha")))
+    assert not np.allclose(np.asarray(get(flat0, "epsilon_param")),
+                           np.asarray(get(flat1, "epsilon_param")))
+
+
+def test_lazy_forward_matches_nonlazy_at_init():
+    """Freezing the kernel must not change the forward pass at init."""
+    key = jax.random.PRNGKey(0)
+    x = jax.random.normal(jax.random.PRNGKey(1), (4, 8))
+    lazy = YatNMN(features=6, learnable_epsilon=True, lazy=True)
+    eager = YatNMN(features=6, learnable_epsilon=True, lazy=False)
+    p_lazy = lazy.init(key, x)
+    p_eager = eager.init(key, x)
+    y_lazy = lazy.apply(p_lazy, x)
+    y_eager = eager.apply(p_eager, x)
+    assert np.allclose(np.asarray(y_lazy), np.asarray(y_eager))
+
+
+def test_optax_multi_transform_freezes_kernel():
+    """The documented optax multi_transform pattern keeps the kernel exactly
+    constant while updating the other params."""
+    optax = pytest.importorskip("optax")
+    from flax.traverse_util import path_aware_map
+
+    layer, params, x = _make(lazy=True)
+
+    def label_fn(p):
+        return path_aware_map(
+            lambda path, _: "frozen" if path[-1] == "kernel" else "trainable", p
+        )
+
+    tx = optax.multi_transform(
+        {"trainable": optax.sgd(0.1), "frozen": optax.set_to_zero()}, label_fn
+    )
+    opt_state = tx.init(params)
+    grads = _grads(layer, params, x)
+    updates, _ = tx.update(grads, opt_state, params)
+    new = optax.apply_updates(params, updates)
+
+    f0, f1 = flatten_dict(params), flatten_dict(new)
+
+    def get(flat, name):
+        return next(v for k, v in flat.items() if k[-1] == name)
+
+    assert np.allclose(np.asarray(get(f0, "kernel")), np.asarray(get(f1, "kernel")))
+    assert not np.allclose(np.asarray(get(f0, "bias")), np.asarray(get(f1, "bias")))

--- a/tests/test_linen/test_performer_yat.py
+++ b/tests/test_linen/test_performer_yat.py
@@ -1,0 +1,282 @@
+"""Tests for the Linen MAY (Random Maclaurin) and RAY (radial) feature maps
+and the generic linear-attention readout (issue #36).
+
+These mirror the verified NumPy reference in ``.context/may-ray/reference.py``:
+the MAY inner product must track the spherical kernel ``kappa``, and MAY must
+clearly beat the bias-free SLAY baseline at ``b >= 1``.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+
+from nmn.linen import (  # noqa: E402
+    spherical_kappa,
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+    linear_attention,
+)
+
+
+# --------------------------------------------------------------------------
+# Helpers (NumPy SLAY baseline + exact attention, from the reference)
+# --------------------------------------------------------------------------
+def _normalize(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize(q), _normalize(k)
+    s = qn @ kn.T
+    w = (s + b) ** 2 / ((2.0 + eps) - 2.0 * s)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _median_sq_distance(qn, kn):
+    diff = qn[:, None, :] - kn[None, :, :]
+    return float(np.median((diff * diff).sum(-1)))
+
+
+def _slay_create(d, P, M, R, eps, seed):
+    rng = np.random.default_rng(seed)
+    C = 2.0 + eps
+    nodes, weights = np.polynomial.laguerre.laggauss(R)
+    nodes, weights = nodes / C, weights / C
+    anchors = _normalize(rng.standard_normal((P, d)))
+    proj = rng.standard_normal((R, M, d))
+    return dict(anchors=anchors, proj=proj, nodes=nodes, weights=weights, P=P, M=M, R=R)
+
+
+def _slay_features(x, params):
+    x = _normalize(x)
+    P, M, R = params["P"], params["M"], params["R"]
+    poly = (x @ params["anchors"].T) ** 2 / np.sqrt(P)
+    proj_all = np.einsum("nd,rmd->nrm", x, params["proj"])
+    out = []
+    for r in range(R):
+        s = params["nodes"][r]
+        arg = np.clip(proj_all[:, r] * np.sqrt(2 * max(s, 0)) - s, -20, 20)
+        prf = np.exp(arg) / np.sqrt(M)
+        fused = np.einsum("np,nm->npm", poly, prf).reshape(x.shape[0], -1)
+        out.append(np.sqrt(max(params["weights"][r], 0)) * fused)
+    return np.concatenate(out, axis=1)
+
+
+def _np_linear_attention(phi_q, phi_k, v, eps=1e-9):
+    kv = phi_k.T @ v
+    num = phi_q @ kv
+    den = phi_q @ phi_k.sum(0)
+    return num / (den[:, None] + eps)
+
+
+def _per_token_cos(a, b):
+    num = (a * b).sum(-1)
+    den = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1) + 1e-12
+    return float(np.mean(num / den))
+
+
+# --------------------------------------------------------------------------
+# Coefficients
+# --------------------------------------------------------------------------
+def test_maclaurin_coeffs_nonnegative():
+    a = np.asarray(maclaurin_coeffs(b=1.0, eps=0.5, nmax=40))
+    assert (a >= 0).all()
+    assert a.shape == (41,)
+    assert a.sum() > 0
+
+
+# --------------------------------------------------------------------------
+# Shapes / finiteness / determinism
+# --------------------------------------------------------------------------
+def test_may_feature_shape_and_finite():
+    d, M = 16, 64
+    key = jax.random.PRNGKey(0)
+    p = create_maclaurin_projection(key, d, num_features=M, bias=1.0, epsilon=0.5)
+    x = jax.random.normal(jax.random.PRNGKey(3), (2, 5, 3, d))  # (B, L, H, d)
+    feat = maclaurin_features(x, p)
+    assert feat.shape == (2, 5, 3, M)
+    assert bool(jnp.isfinite(feat).all())
+
+
+def test_ray_feature_shape_and_finite():
+    d = 16
+    key = jax.random.PRNGKey(0)
+    p = create_radial_projection(
+        key, d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.5
+    )
+    x = jax.random.normal(jax.random.PRNGKey(4), (2, 5, 3, d))
+    feat = radial_features(x, p)
+    assert feat.shape == (2, 5, 3, 8 * 4 * 8)
+    assert bool(jnp.isfinite(feat).all())
+
+
+def test_may_determinism():
+    d, M = 16, 64
+    key = jax.random.PRNGKey(7)
+    p1 = create_maclaurin_projection(key, d, num_features=M, bias=1.0, epsilon=0.5)
+    p2 = create_maclaurin_projection(key, d, num_features=M, bias=1.0, epsilon=0.5)
+    x = jax.random.normal(jax.random.PRNGKey(9), (4, d))
+    f1 = maclaurin_features(x, p1)
+    f2 = maclaurin_features(x, p2)
+    assert np.allclose(np.asarray(f1), np.asarray(f2))
+
+
+def test_attention_shapes():
+    d, dv, M = 16, 12, 64
+    key = jax.random.PRNGKey(0)
+    p = create_maclaurin_projection(key, d, num_features=M, bias=1.0, epsilon=0.5)
+    q = jax.random.normal(jax.random.PRNGKey(1), (2, 7, 3, d))
+    k = jax.random.normal(jax.random.PRNGKey(2), (2, 7, 3, d))
+    v = jax.random.normal(jax.random.PRNGKey(3), (2, 7, 3, dv))
+    out = maclaurin_yat_attention(q, k, v, p)
+    assert out.shape == (2, 7, 3, dv)
+    assert bool(jnp.isfinite(out).all())
+    out_causal = maclaurin_yat_attention(q, k, v, p, causal=True)
+    assert out_causal.shape == (2, 7, 3, dv)
+    assert bool(jnp.isfinite(out_causal).all())
+
+
+def test_ray_attention_shapes():
+    d, dv = 16, 12
+    key = jax.random.PRNGKey(0)
+    p = create_radial_projection(
+        key, d, sketch_m=4, num_radial=2, radial_dim=4, bias=1.0, epsilon=0.5
+    )
+    q = jax.random.normal(jax.random.PRNGKey(1), (2, 7, 3, d))
+    k = jax.random.normal(jax.random.PRNGKey(2), (2, 7, 3, d))
+    v = jax.random.normal(jax.random.PRNGKey(3), (2, 7, 3, dv))
+    out = radial_yat_attention(q, k, v, p)
+    assert out.shape == (2, 7, 3, dv)
+    assert bool(jnp.isfinite(out).all())
+
+
+# --------------------------------------------------------------------------
+# Kernel-approximation correctness: MAY inner product tracks kappa
+# --------------------------------------------------------------------------
+def test_may_inner_product_tracks_kappa():
+    d, M, b, eps = 64, 30000, 1.0, 0.5
+    key = jax.random.PRNGKey(0)
+    p = create_maclaurin_projection(key, d, num_features=M, bias=b, epsilon=eps)
+
+    rng = np.random.default_rng(1)
+    q = jnp.asarray(rng.standard_normal((6, d)))
+    k = jnp.asarray(rng.standard_normal((6, d)))
+    qn = q / jnp.linalg.norm(q, axis=-1, keepdims=True)
+    kn = k / jnp.linalg.norm(k, axis=-1, keepdims=True)
+    s = qn @ kn.T
+
+    pq = maclaurin_features(q, p)
+    pk = maclaurin_features(k, p)
+    approx = np.asarray(pq @ pk.T)
+    exact = np.asarray(spherical_kappa(s, b, eps))
+
+    # Unbiased Monte-Carlo estimator: high correlation, modest relative error.
+    rel = np.linalg.norm(approx - exact) / np.linalg.norm(exact)
+    corr = np.corrcoef(approx.ravel(), exact.ravel())[0, 1]
+    assert rel < 0.3
+    assert corr > 0.95
+
+
+def test_may_inner_product_rises_with_s():
+    """kappa is increasing in s; the MAY inner product must track that trend.
+
+    Averaged over several independent projections to reduce Monte-Carlo
+    variance of the unbiased estimator.
+    """
+    d, M, b, eps = 32, 40000, 1.0, 0.5
+
+    # Build pairs with an EXACT, increasing cosine s via Gram-Schmidt:
+    # base and perp are orthonormal, so mix = s*base + sqrt(1-s^2)*perp has
+    # cosine exactly s with base.
+    rng = np.random.default_rng(0)
+    base = _normalize(rng.standard_normal((1, d)))
+    raw = rng.standard_normal((1, d))
+    perp = raw - (raw @ base.T) * base
+    perp = _normalize(perp)
+    svals = np.linspace(-0.6, 0.9, 6)
+    mixes = [s * base + np.sqrt(max(1 - s * s, 0.0)) * perp for s in svals]
+
+    ips = np.zeros(len(svals))
+    n_proj = 5
+    for j in range(n_proj):
+        p = create_maclaurin_projection(
+            jax.random.PRNGKey(j), d, num_features=M, bias=b, epsilon=eps
+        )
+        pq = maclaurin_features(jnp.asarray(base), p)
+        for i, mix in enumerate(mixes):
+            pk = maclaurin_features(jnp.asarray(mix), p)
+            ips[i] += float((pq * pk).sum())
+    ips /= n_proj
+
+    exact = np.asarray(spherical_kappa(svals, b, eps))
+    # kappa is increasing (convex, not linear) in s; the unbiased estimator must
+    # track that trend. We assert the robust trend statistics rather than strict
+    # pointwise monotonicity, which is fragile to Monte-Carlo variance at very
+    # negative s where kappa is tiny:
+    #   (a) strong rank correlation with the exact kappa values,
+    #   (b) a clear net increase across the swept range,
+    #   (c) no dip larger than a small fraction of the value scale.
+    assert np.corrcoef(ips, exact)[0, 1] > 0.99, f"weak correlation: {ips} vs {exact}"
+    assert ips[-1] > ips[0], f"no net increase: {ips}"
+    tol = 0.02 * (ips.max() - ips.min())
+    assert np.all(np.diff(ips) > -tol), f"large non-monotone dip: {ips}"
+
+
+def test_may_more_features_better():
+    """More MAY features -> higher cosine similarity to exact attention."""
+    d, N, b = 64, 128, 1.0
+    rng = np.random.default_rng(5)
+    q = rng.standard_normal((N, d))
+    k = rng.standard_normal((N, d))
+    v = rng.standard_normal((N, d))
+    eps = _median_sq_distance(_normalize(q), _normalize(k))
+    exact = _exact_attention(q, k, v, b, eps)
+
+    def may_cos(M):
+        key = jax.random.PRNGKey(0)
+        p = create_maclaurin_projection(key, d, num_features=M, bias=b, epsilon=eps)
+        pq = np.asarray(maclaurin_features(jnp.asarray(q), p))
+        pk = np.asarray(maclaurin_features(jnp.asarray(k), p))
+        out = _np_linear_attention(pq, pk, v)
+        return _per_token_cos(out, exact)
+
+    assert may_cos(1024) > may_cos(64)
+
+
+# --------------------------------------------------------------------------
+# MAY beats SLAY at b >= 1 (the headline qualitative claim)
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("b", [1.0, 2.0])
+def test_may_beats_slay_at_high_bias(b):
+    d, N, F = 64, 256, 256
+    cos_may, cos_slay = [], []
+    for seed in (0, 1, 2):
+        rng = np.random.default_rng(100 + seed)
+        q = rng.standard_normal((N, d))
+        k = rng.standard_normal((N, d))
+        v = rng.standard_normal((N, d))
+        eps = _median_sq_distance(_normalize(q), _normalize(k))
+        exact = _exact_attention(q, k, v, b, eps)
+
+        key = jax.random.PRNGKey(seed)
+        mp = create_maclaurin_projection(key, d, num_features=F, bias=b, epsilon=eps)
+        pq = np.asarray(maclaurin_features(jnp.asarray(q), mp))
+        pk = np.asarray(maclaurin_features(jnp.asarray(k), mp))
+        may = _np_linear_attention(pq, pk, v)
+        cos_may.append(_per_token_cos(may, exact))
+
+        sp = _slay_create(d, P=32, M=8, R=1, eps=eps, seed=seed)
+        sa = _np_linear_attention(_slay_features(q, sp), _slay_features(k, sp), v)
+        cos_slay.append(_per_token_cos(sa, exact))
+
+    assert np.mean(cos_may) > np.mean(cos_slay)

--- a/tests/test_mlx/test_lazy.py
+++ b/tests/test_mlx/test_lazy.py
@@ -1,0 +1,139 @@
+"""Tests for YatNMN lazy mode (freeze only the kernel) — issue #37."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import mlx.nn as nn  # noqa: E402
+import mlx.utils as mu  # noqa: E402
+
+from nmn.mlx import YatNMN  # noqa: E402
+
+
+def _trainable_keys(model):
+    return set(dict(mu.tree_flatten(model.trainable_parameters())).keys())
+
+
+def _build(model, in_dim=8):
+    model(mx.zeros((4, in_dim)))
+    return model
+
+
+# ---------------------------------------------------------------------------
+# trainable-parameter membership
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_excludes_kernel_keeps_rest_trainable():
+    m = _build(YatNMN(features=6, use_bias=True, use_alpha=True,
+                      learnable_epsilon=True, lazy=True))
+    keys = _trainable_keys(m)
+    assert not any("kernel" in k for k in keys)
+    assert any("bias" in k for k in keys)
+    assert any("alpha" in k for k in keys)
+    assert any("epsilon" in k for k in keys)
+
+
+def test_freeze_kernel_alias():
+    m = _build(YatNMN(features=6, learnable_epsilon=True, freeze_kernel=True))
+    keys = _trainable_keys(m)
+    assert not any("kernel" in k for k in keys)
+    assert any("bias" in k for k in keys)
+
+
+def test_lazy_false_is_backward_compatible():
+    m = _build(YatNMN(features=6, use_bias=True, use_alpha=True,
+                      learnable_epsilon=True))
+    keys = _trainable_keys(m)
+    # Default: everything trainable, including the kernel.
+    assert any("kernel" in k for k in keys)
+    assert any("bias" in k for k in keys)
+    assert any("alpha" in k for k in keys)
+    assert any("epsilon" in k for k in keys)
+
+
+def test_lazy_forward_matches_eager_with_same_weights():
+    """lazy=True must not change the forward computation."""
+    x = mx.random.normal(shape=(4, 8))
+    eager = _build(YatNMN(features=6, lazy=False), in_dim=8)
+    lazy = _build(YatNMN(features=6, lazy=True), in_dim=8)
+    # Copy eager weights into lazy so the only difference is the freeze flag.
+    lazy.kernel = eager.kernel
+    lazy.bias = eager.bias
+    lazy.alpha = eager.alpha
+    out_e = np.array(eager(x))
+    out_l = np.array(lazy(x))
+    assert np.allclose(out_e, out_l, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# gradient / training behavior
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_kernel_gets_no_gradient():
+    m = _build(YatNMN(features=6, learnable_epsilon=True, lazy=True))
+    x = mx.random.normal(shape=(4, 8))
+
+    def loss_fn(model):
+        return mx.sum(model(x) ** 2)
+
+    grads = nn.value_and_grad(m, loss_fn)(m)[1]
+    flat = dict(mu.tree_flatten(grads))
+    # The frozen kernel must not appear in the gradient tree.
+    assert not any("kernel" in k for k in flat)
+    assert any("bias" in k for k in flat)
+
+
+def test_lazy_training_step_kernel_unchanged_others_change():
+    import mlx.optimizers as optim
+
+    # Start epsilon away from the tiny 1e-5 default so softplus has a usable
+    # slope and the epsilon gradient is non-negligible for the smoke test.
+    m = _build(YatNMN(features=6, use_bias=True, use_alpha=True,
+                      learnable_epsilon=True, epsilon=1.0, lazy=True))
+    x = mx.random.normal(shape=(8, 8))
+    target = mx.random.normal(shape=(8, 6))
+
+    kernel_before = np.array(m.kernel)
+    bias_before = np.array(m.bias)
+    alpha_before = np.array(m.alpha)
+    eps_before = np.array(m.epsilon_param)
+
+    opt = optim.SGD(learning_rate=0.1)
+
+    def loss_fn(model):
+        return mx.mean((model(x) - target) ** 2)
+
+    for _ in range(2):
+        loss, grads = nn.value_and_grad(m, loss_fn)(m)
+        opt.update(m, grads)
+        mx.eval(m.parameters(), opt.state)
+
+    # Kernel must be unchanged; bias/alpha/epsilon must move.
+    assert np.array_equal(kernel_before, np.array(m.kernel))
+    assert not np.array_equal(bias_before, np.array(m.bias))
+    assert not np.array_equal(alpha_before, np.array(m.alpha))
+    assert not np.array_equal(eps_before, np.array(m.epsilon_param))
+
+
+def test_non_lazy_kernel_does_change():
+    import mlx.optimizers as optim
+
+    m = _build(YatNMN(features=6, lazy=False))
+    x = mx.random.normal(shape=(8, 8))
+    target = mx.random.normal(shape=(8, 6))
+    kernel_before = np.array(m.kernel)
+    opt = optim.SGD(learning_rate=0.1)
+
+    def loss_fn(model):
+        return mx.mean((model(x) - target) ** 2)
+
+    for _ in range(2):
+        loss, grads = nn.value_and_grad(m, loss_fn)(m)
+        opt.update(m, grads)
+        mx.eval(m.parameters(), opt.state)
+
+    assert not np.array_equal(kernel_before, np.array(m.kernel))

--- a/tests/test_mlx/test_may.py
+++ b/tests/test_mlx/test_may.py
@@ -1,0 +1,241 @@
+"""Tests for MLX MAY (Random Maclaurin) bias-aware spherical-YAT features."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import (  # noqa: E402
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_yat_tp_projection,
+    yat_tp_attention,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (NumPy reference mirrors).
+# ---------------------------------------------------------------------------
+
+
+def _normalize_rows(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def _kappa(s, b, eps):
+    C = 2.0 + eps
+    return (s + b) ** 2 / (C - 2.0 * s)
+
+
+def _median_sq(qn, kn):
+    diff = qn[:, None, :] - kn[None, :, :]
+    return float(np.median((diff * diff).sum(-1)))
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize_rows(q), _normalize_rows(k)
+    s = qn @ kn.T
+    w = _kappa(s, b, eps)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _cos(a, b):
+    num = (a * b).sum(-1)
+    den = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1) + 1e-12
+    return float(np.mean(num / den))
+
+
+# ---------------------------------------------------------------------------
+# coefficients + projection
+# ---------------------------------------------------------------------------
+
+
+def test_maclaurin_coeffs_non_negative():
+    a = maclaurin_coeffs(b=1.0, epsilon=0.5, nmax=40)
+    assert a.shape == (41,)
+    assert float(a.min()) >= 0.0
+    assert float(a.sum()) > 0.0
+
+
+def test_projection_shapes():
+    p = create_maclaurin_projection(
+        head_dim=16, num_features=64, bias=1.0, epsilon=0.5, nmax=40, seed=0,
+    )
+    assert p["omegas"].shape == (64, 40, 16)
+    assert p["degrees"].shape == (64,)
+    assert p["num_features"] == 64
+    assert p["nmax"] == 40
+    assert p["Z"] > 0.0
+
+
+def test_projection_rademacher_entries():
+    p = create_maclaurin_projection(head_dim=8, num_features=16, seed=0)
+    om = np.array(p["omegas"])
+    assert set(np.unique(om).tolist()).issubset({-1.0, 1.0})
+
+
+def test_seeded_projection_is_deterministic():
+    p1 = create_maclaurin_projection(head_dim=8, num_features=16, seed=42)
+    p2 = create_maclaurin_projection(head_dim=8, num_features=16, seed=42)
+    assert np.array_equal(np.array(p1["omegas"]), np.array(p2["omegas"]))
+    assert np.array_equal(np.array(p1["degrees"]), np.array(p2["degrees"]))
+
+
+# ---------------------------------------------------------------------------
+# features
+# ---------------------------------------------------------------------------
+
+
+def test_feature_shape_is_M():
+    M, d = 32, 16
+    p = create_maclaurin_projection(head_dim=d, num_features=M, seed=0)
+    x = mx.random.normal(shape=(2, 5, 3, d))
+    feat = maclaurin_features(x, p)
+    assert feat.shape == (2, 5, 3, M)
+
+
+def test_features_no_nan_inf():
+    p = create_maclaurin_projection(head_dim=16, num_features=64, bias=1.0, seed=0)
+    x = mx.random.normal(shape=(2, 6, 2, 16)) * 4.0
+    feat = np.array(maclaurin_features(x, p))
+    assert np.isfinite(feat).all()
+
+
+def test_features_deterministic():
+    p = create_maclaurin_projection(head_dim=8, num_features=32, seed=0)
+    x = mx.random.normal(shape=(1, 4, 2, 8))
+    f1 = np.array(maclaurin_features(x, p))
+    f2 = np.array(maclaurin_features(x, p))
+    assert np.array_equal(f1, f2)
+
+
+def test_inner_product_tracks_kappa():
+    """E[phi(q)·phi(k)] = kappa(q·k): pointwise IP should track kappa and rise
+    monotonically with the cosine similarity s."""
+    d, M, b, eps = 32, 8000, 1.0, 0.5
+    # MAY is an unbiased estimator; average several independent projections to
+    # tame the Monte-Carlo variance of the high-degree terms.
+    projs = [create_maclaurin_projection(head_dim=d, num_features=M, bias=b,
+                                         epsilon=eps, seed=s) for s in range(8)]
+    rng = np.random.default_rng(1)
+    q = rng.standard_normal(d).astype(np.float32)
+    q /= np.linalg.norm(q)
+    svals = [-0.5, 0.0, 0.5, 0.8]
+    ips, ks = [], []
+    for s in svals:
+        r = rng.standard_normal(d).astype(np.float32)
+        r -= r.dot(q) * q
+        r /= np.linalg.norm(r)
+        k = (s * q + np.sqrt(1.0 - s * s) * r).astype(np.float32)
+        est = []
+        for p in projs:
+            qf = np.array(maclaurin_features(mx.array(q).reshape(1, 1, 1, d), p)).ravel()
+            kf = np.array(maclaurin_features(mx.array(k).reshape(1, 1, 1, d), p)).ravel()
+            est.append(float(qf.dot(kf)))
+        ips.append(float(np.mean(est)))
+        ks.append(float(_kappa(s, b, eps)))
+    # Monotone increasing in s (the kernel rises with similarity).
+    assert all(ips[i] < ips[i + 1] for i in range(len(ips) - 1))
+    # Tracks kappa to a loose Monte-Carlo tolerance.
+    ips, ks = np.array(ips), np.array(ks)
+    assert np.max(np.abs(ips - ks)) < 0.25
+
+
+# ---------------------------------------------------------------------------
+# attention
+# ---------------------------------------------------------------------------
+
+
+def test_attention_output_shape_non_causal():
+    p = create_maclaurin_projection(head_dim=16, num_features=128, seed=0)
+    q = mx.random.normal(shape=(2, 4, 3, 16))
+    k = mx.random.normal(shape=(2, 5, 3, 16))
+    v = mx.random.normal(shape=(2, 5, 3, 16))
+    out = maclaurin_yat_attention(q, k, v, p, causal=False)
+    assert out.shape == (2, 4, 3, 16)
+    assert np.isfinite(np.array(out)).all()
+
+
+def test_attention_output_shape_causal():
+    p = create_maclaurin_projection(head_dim=16, num_features=128, seed=0)
+    x = mx.random.normal(shape=(1, 6, 2, 16))
+    out = maclaurin_yat_attention(x, x, x, p, causal=True)
+    assert out.shape == (1, 6, 2, 16)
+    assert np.isfinite(np.array(out)).all()
+
+
+def test_causal_position_0_unaffected_by_future():
+    mx.random.seed(0)
+    p = create_maclaurin_projection(head_dim=8, num_features=64, seed=0)
+    x = mx.random.normal(shape=(1, 5, 1, 8))
+    v = mx.random.normal(shape=(1, 5, 1, 8))
+    out_a = maclaurin_yat_attention(x, x, v, p, causal=True)
+    v_pert = mx.concatenate([v[:, :4], v[:, 4:5] + 100.0], axis=1)
+    out_b = maclaurin_yat_attention(x, x, v_pert, p, causal=True)
+    assert float(mx.max(mx.abs(out_a[:, 0] - out_b[:, 0]))) < 1e-2
+    assert float(mx.max(mx.abs(out_a[:, 4] - out_b[:, 4]))) > 1e-2
+
+
+def test_attention_dtype_promotion():
+    p = create_maclaurin_projection(head_dim=8, num_features=32, seed=0)
+    q = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float32)
+    k = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float32)
+    v = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float16)
+    out = maclaurin_yat_attention(q, k, v, p)
+    assert out.dtype == mx.float32
+    assert out.shape == (1, 3, 1, 8)
+
+
+def test_may_beats_slay_at_bias_ge_1():
+    """MAY is bias-aware; SLAY only approximates b=0. At b>=1 MAY should have
+    clearly higher cosine similarity to exact attention."""
+    d, N = 64, 256
+    rng = np.random.default_rng(100)
+    q = rng.standard_normal((N, d))
+    k = rng.standard_normal((N, d))
+    v = rng.standard_normal((N, d))
+    eps = _median_sq(_normalize_rows(q), _normalize_rows(k))
+
+    def to(x):
+        return mx.array(x.astype(np.float32)).reshape(1, N, 1, d)
+
+    qm, km, vm = to(q), to(k), to(v)
+    for b in [1.0, 2.0]:
+        exact = _exact_attention(q, k, v, b, eps)
+        mp = create_maclaurin_projection(d, num_features=256, bias=b,
+                                         epsilon=eps, seed=0)
+        may = np.array(maclaurin_yat_attention(qm, km, vm, mp)).reshape(N, d)
+        sp = create_yat_tp_projection(d, num_prf_features=8, num_quad_nodes=1,
+                                      num_anchor_features=32, epsilon=eps, seed=0)
+        slay = np.array(yat_tp_attention(qm, km, vm, sp)).reshape(N, d)
+        assert _cos(may, exact) > _cos(slay, exact)
+
+
+def test_more_features_higher_fidelity():
+    """More MAY features -> closer to exact attention (cosine similarity up)."""
+    d, N, b = 48, 192, 1.0
+    rng = np.random.default_rng(7)
+    q = rng.standard_normal((N, d))
+    k = rng.standard_normal((N, d))
+    v = rng.standard_normal((N, d))
+    eps = _median_sq(_normalize_rows(q), _normalize_rows(k))
+
+    def to(x):
+        return mx.array(x.astype(np.float32)).reshape(1, N, 1, d)
+
+    qm, km, vm = to(q), to(k), to(v)
+    exact = _exact_attention(q, k, v, b, eps)
+    cos_small, cos_large = [], []
+    for seed in range(3):
+        ps = create_maclaurin_projection(d, num_features=64, bias=b, epsilon=eps, seed=seed)
+        pl = create_maclaurin_projection(d, num_features=1024, bias=b, epsilon=eps, seed=seed)
+        a_s = np.array(maclaurin_yat_attention(qm, km, vm, ps)).reshape(N, d)
+        a_l = np.array(maclaurin_yat_attention(qm, km, vm, pl)).reshape(N, d)
+        cos_small.append(_cos(a_s, exact))
+        cos_large.append(_cos(a_l, exact))
+    assert np.mean(cos_large) > np.mean(cos_small)

--- a/tests/test_mlx/test_ray.py
+++ b/tests/test_mlx/test_ray.py
@@ -1,0 +1,97 @@
+"""Tests for MLX RAY (radial) bias-aware spherical-YAT features."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from nmn.mlx import (  # noqa: E402
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
+
+
+def test_projection_shapes():
+    d, m, R, D = 16, 8, 4, 8
+    p = create_radial_projection(
+        head_dim=d, sketch_m=m, num_radial=R, radial_dim=D,
+        bias=1.0, epsilon=0.5, seed=0,
+    )
+    assert p["W1"].shape == (m, d + 1)
+    assert p["W2"].shape == (m, d + 1)
+    assert p["omegas"].shape == (R, D, d + 1)
+    assert p["phases"].shape == (R, D)
+    assert p["coef"].shape == (R,)
+
+
+def test_seeded_projection_is_deterministic():
+    p1 = create_radial_projection(head_dim=8, seed=3)
+    p2 = create_radial_projection(head_dim=8, seed=3)
+    assert np.array_equal(np.array(p1["W1"]), np.array(p2["W1"]))
+    assert np.array_equal(np.array(p1["omegas"]), np.array(p2["omegas"]))
+
+
+def test_feature_shape_is_product():
+    d, m, R, D = 16, 8, 4, 8
+    p = create_radial_projection(head_dim=d, sketch_m=m, num_radial=R,
+                                 radial_dim=D, seed=0)
+    x = mx.random.normal(shape=(2, 5, 3, d))
+    feat = radial_features(x, p)
+    assert feat.shape == (2, 5, 3, m * R * D)
+
+
+def test_features_no_nan_inf():
+    p = create_radial_projection(head_dim=16, bias=1.0, epsilon=0.5, seed=0)
+    x = mx.random.normal(shape=(2, 6, 2, 16)) * 4.0
+    feat = np.array(radial_features(x, p))
+    assert np.isfinite(feat).all()
+
+
+def test_features_deterministic():
+    p = create_radial_projection(head_dim=8, seed=0)
+    x = mx.random.normal(shape=(1, 4, 2, 8))
+    f1 = np.array(radial_features(x, p))
+    f2 = np.array(radial_features(x, p))
+    assert np.array_equal(f1, f2)
+
+
+def test_attention_output_shape_non_causal():
+    p = create_radial_projection(head_dim=16, seed=0)
+    q = mx.random.normal(shape=(2, 4, 3, 16))
+    k = mx.random.normal(shape=(2, 5, 3, 16))
+    v = mx.random.normal(shape=(2, 5, 3, 16))
+    out = radial_yat_attention(q, k, v, p, causal=False)
+    assert out.shape == (2, 4, 3, 16)
+    assert np.isfinite(np.array(out)).all()
+
+
+def test_attention_output_shape_causal():
+    p = create_radial_projection(head_dim=16, seed=0)
+    x = mx.random.normal(shape=(1, 6, 2, 16))
+    out = radial_yat_attention(x, x, x, p, causal=True)
+    assert out.shape == (1, 6, 2, 16)
+    assert np.isfinite(np.array(out)).all()
+
+
+def test_causal_position_0_unaffected_by_future():
+    mx.random.seed(0)
+    p = create_radial_projection(head_dim=8, seed=0)
+    x = mx.random.normal(shape=(1, 5, 1, 8))
+    v = mx.random.normal(shape=(1, 5, 1, 8))
+    out_a = radial_yat_attention(x, x, v, p, causal=True)
+    v_pert = mx.concatenate([v[:, :4], v[:, 4:5] + 100.0], axis=1)
+    out_b = radial_yat_attention(x, x, v_pert, p, causal=True)
+    assert float(mx.max(mx.abs(out_a[:, 0] - out_b[:, 0]))) < 1e-2
+
+
+def test_attention_dtype_promotion():
+    p = create_radial_projection(head_dim=8, seed=0)
+    q = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float32)
+    k = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float32)
+    v = mx.random.normal(shape=(1, 3, 1, 8)).astype(mx.float16)
+    out = radial_yat_attention(q, k, v, p)
+    assert out.dtype == mx.float32
+    assert out.shape == (1, 3, 1, 8)

--- a/tests/test_nnx/test_maclaurin_radial_yat.py
+++ b/tests/test_nnx/test_maclaurin_radial_yat.py
@@ -1,0 +1,259 @@
+"""Tests for MAY (Random Maclaurin) and RAY (radial) bias-aware Yat features.
+
+Covers issue #36 for the nnx backend:
+  - shapes & determinism
+  - no NaN/Inf
+  - MAY inner product tracks the kernel kappa(s) = (s+b)^2/(C-2s)
+  - MAY beats SLAY at b >= 1
+  - RAY runs and produces finite output
+  - RotaryYatAttention performer_kind selector ('slay'/'maclaurin'/'radial')
+"""
+
+import pytest
+import numpy as np
+
+pytest.importorskip("jax")
+pytest.importorskip("flax")
+
+import jax
+import jax.numpy as jnp
+from jax import random
+
+from nmn.nnx.layers.attention import (
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    maclaurin_coeffs,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+    create_yat_tp_projection,
+    yat_tp_attention,
+)
+
+
+def _normalize(x):
+    return x / jnp.sqrt(jnp.sum(x * x, -1, keepdims=True) + 1e-6)
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize(q), _normalize(k)
+    s = qn @ kn.T
+    w = (s + b) ** 2 / ((2.0 + eps) - 2.0 * s)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _cos(a, b):
+    num = (a * b).sum(-1)
+    den = jnp.linalg.norm(a, axis=-1) * jnp.linalg.norm(b, axis=-1) + 1e-12
+    return float(jnp.mean(num / den))
+
+
+# --------------------------------------------------------------------------
+# Maclaurin coefficients
+# --------------------------------------------------------------------------
+class TestMaclaurinCoeffs:
+    def test_nonnegative_for_positive_bias(self):
+        for b in [0.0, 0.5, 1.0, 2.0]:
+            a = maclaurin_coeffs(b, epsilon=0.3, nmax=40)
+            assert np.all(a >= 0.0)
+            assert a.shape == (41,)
+
+    def test_recurrence_matches_definition(self):
+        b, eps, nmax = 1.5, 0.2, 10
+        C = 2.0 + eps
+        n = np.arange(nmax + 1)
+        beta = (1.0 / C) * (2.0 / C) ** n
+        a = maclaurin_coeffs(b, eps, nmax)
+        expect = b * b * beta.copy()
+        expect[1:] += 2.0 * b * beta[:-1]
+        expect[2:] += beta[:-2]
+        np.testing.assert_allclose(a, expect, rtol=1e-6)
+
+
+# --------------------------------------------------------------------------
+# MAY features
+# --------------------------------------------------------------------------
+class TestMaclaurinFeatures:
+    def test_shape(self):
+        key = random.PRNGKey(0)
+        p = create_maclaurin_projection(key, head_dim=16, num_features=64, bias=1.0, epsilon=0.1)
+        x = random.normal(random.PRNGKey(1), (2, 8, 4, 16))
+        f = maclaurin_features(x, p)
+        assert f.shape == (2, 8, 4, 64)
+
+    def test_no_nan_inf(self):
+        key = random.PRNGKey(0)
+        p = create_maclaurin_projection(key, head_dim=16, num_features=128, bias=1.0, epsilon=0.1)
+        x = random.normal(random.PRNGKey(2), (3, 5, 2, 16)) * 5.0
+        f = maclaurin_features(x, p)
+        assert bool(jnp.all(jnp.isfinite(f)))
+
+    def test_determinism(self):
+        key = random.PRNGKey(7)
+        p = create_maclaurin_projection(key, head_dim=16, num_features=64, bias=1.0, epsilon=0.1)
+        x = random.normal(random.PRNGKey(3), (2, 4, 16))
+        f1 = maclaurin_features(x, p)
+        f2 = maclaurin_features(x, p)
+        np.testing.assert_array_equal(np.asarray(f1), np.asarray(f2))
+
+    def test_same_key_same_projection(self):
+        p1 = create_maclaurin_projection(random.PRNGKey(11), 16, num_features=32, bias=1.0, epsilon=0.1)
+        p2 = create_maclaurin_projection(random.PRNGKey(11), 16, num_features=32, bias=1.0, epsilon=0.1)
+        np.testing.assert_array_equal(np.asarray(p1['omegas']), np.asarray(p2['omegas']))
+        np.testing.assert_array_equal(np.asarray(p1['degrees']), np.asarray(p2['degrees']))
+
+    def test_inner_product_tracks_kappa(self):
+        """E[phi(q)·phi(k)] = kappa(s); the inner product must rise with s."""
+        d, b, eps = 32, 1.0, 0.3
+        C = 2.0 + eps
+        # Large feature budget to reduce estimator variance.
+        p = create_maclaurin_projection(random.PRNGKey(0), d, num_features=40000, bias=b, epsilon=eps, nmax=40)
+        q = random.normal(random.PRNGKey(5), (d,))
+        q = q / jnp.linalg.norm(q)
+        ko = random.normal(random.PRNGKey(7), (d,))
+        ko = ko - jnp.dot(ko, q) * q
+        ko = ko / jnp.linalg.norm(ko)
+
+        targets = [-0.5, 0.0, 0.5, 0.9]
+        approx_vals, exact_vals = [], []
+        for s in targets:
+            k = s * q + np.sqrt(max(0.0, 1 - s ** 2)) * ko
+            k = k / jnp.linalg.norm(k)
+            fq = maclaurin_features(q[None], p)[0]
+            fk = maclaurin_features(k[None], p)[0]
+            approx_vals.append(float(jnp.sum(fq * fk)))
+            ss = float(jnp.dot(q, k))
+            exact_vals.append((ss + b) ** 2 / (C - 2 * ss))
+
+        # Monotonic rise with s (the kernel is increasing on this range).
+        assert approx_vals[0] < approx_vals[1] < approx_vals[2] < approx_vals[3]
+        assert exact_vals[0] < exact_vals[1] < exact_vals[2] < exact_vals[3]
+        # Reasonable tracking (high-variance estimator, so generous tolerance).
+        for ap, ex in zip(approx_vals, exact_vals):
+            assert ap == pytest.approx(ex, rel=0.5, abs=0.3)
+
+
+# --------------------------------------------------------------------------
+# MAY attention readout
+# --------------------------------------------------------------------------
+class TestMaclaurinAttention:
+    def test_shape_and_finite(self):
+        d = 16
+        p = create_maclaurin_projection(random.PRNGKey(0), d, num_features=128, bias=1.0, epsilon=0.2)
+        q = random.normal(random.PRNGKey(1), (2, 10, 4, d))
+        k = random.normal(random.PRNGKey(2), (2, 10, 4, d))
+        v = random.normal(random.PRNGKey(3), (2, 10, 4, d))
+        out = maclaurin_yat_attention(q, k, v, p)
+        assert out.shape == (2, 10, 4, d)
+        assert bool(jnp.all(jnp.isfinite(out)))
+
+    def test_causal_runs(self):
+        d = 16
+        p = create_maclaurin_projection(random.PRNGKey(0), d, num_features=64, bias=1.0, epsilon=0.2)
+        q = random.normal(random.PRNGKey(1), (1, 8, 2, d))
+        out = maclaurin_yat_attention(q, q, q, p, causal=True)
+        assert out.shape == (1, 8, 2, d)
+        assert bool(jnp.all(jnp.isfinite(out)))
+
+    @pytest.mark.parametrize("b", [1.0, 2.0, 4.0])
+    def test_may_beats_slay_at_high_bias(self, b):
+        d, N = 64, 256
+        q = random.normal(random.PRNGKey(1), (N, d))
+        k = random.normal(random.PRNGKey(2), (N, d))
+        v = random.normal(random.PRNGKey(3), (N, d))
+        qn, kn = _normalize(q), _normalize(k)
+        diff = qn[:, None, :] - kn[None, :, :]
+        eps = float(jnp.median((diff * diff).sum(-1)))
+        exact = _exact_attention(q, k, v, b, eps)
+
+        mp = create_maclaurin_projection(random.PRNGKey(0), d, num_features=256, bias=b, epsilon=eps)
+        ma = maclaurin_yat_attention(q[:, None, :], k[:, None, :], v[:, None, :], mp)[:, 0, :]
+
+        sp = create_yat_tp_projection(random.PRNGKey(0), d, num_prf_features=8,
+                                      num_quad_nodes=1, num_anchor_features=32)
+        sa = yat_tp_attention(q[:, None, :], k[:, None, :], v[:, None, :], sp)[:, 0, :]
+
+        assert _cos(ma, exact) > _cos(sa, exact)
+
+
+# --------------------------------------------------------------------------
+# RAY features & attention
+# --------------------------------------------------------------------------
+class TestRadialFeatures:
+    def test_shape(self):
+        d = 16
+        p = create_radial_projection(random.PRNGKey(0), d, sketch_m=8, num_radial=4,
+                                     radial_dim=8, bias=1.0, epsilon=0.2)
+        x = random.normal(random.PRNGKey(1), (2, 6, 3, d))
+        f = radial_features(x, p)
+        assert f.shape == (2, 6, 3, 8 * 4 * 8)
+        assert bool(jnp.all(jnp.isfinite(f)))
+
+    def test_determinism(self):
+        d = 16
+        p = create_radial_projection(random.PRNGKey(0), d, sketch_m=8, num_radial=4,
+                                     radial_dim=8, bias=1.0, epsilon=0.2)
+        x = random.normal(random.PRNGKey(1), (2, 3, d))
+        np.testing.assert_array_equal(
+            np.asarray(radial_features(x, p)), np.asarray(radial_features(x, p))
+        )
+
+    def test_attention_shape_and_finite(self):
+        d = 16
+        p = create_radial_projection(random.PRNGKey(0), d, sketch_m=8, num_radial=4,
+                                     radial_dim=8, bias=1.0, epsilon=0.2)
+        q = random.normal(random.PRNGKey(1), (2, 7, 2, d))
+        k = random.normal(random.PRNGKey(2), (2, 7, 2, d))
+        v = random.normal(random.PRNGKey(3), (2, 7, 2, d))
+        out = radial_yat_attention(q, k, v, p)
+        assert out.shape == (2, 7, 2, d)
+        assert bool(jnp.all(jnp.isfinite(out)))
+
+
+# --------------------------------------------------------------------------
+# RotaryYatAttention performer_kind selector
+# --------------------------------------------------------------------------
+class TestPerformerSelector:
+    @pytest.mark.parametrize("kind", ["slay", "maclaurin", "radial"])
+    def test_selector_runs(self, kind):
+        from flax import nnx
+        from nmn.nnx.layers.attention import RotaryYatAttention
+
+        attn = RotaryYatAttention(
+            embed_dim=32,
+            num_heads=4,
+            max_seq_len=64,
+            use_performer=True,
+            performer_kind=kind,
+            performer_num_features=64,
+            performer_sketch_m=4,
+            performer_num_radial=2,
+            performer_radial_dim=4,
+            rngs=nnx.Rngs(0),
+        )
+        x = random.normal(random.PRNGKey(1), (2, 16, 32))
+        out = attn(x, deterministic=True)
+        assert out.shape == (2, 16, 32)
+        assert bool(jnp.all(jnp.isfinite(out)))
+
+    def test_default_is_slay(self):
+        from flax import nnx
+        from nmn.nnx.layers.attention import RotaryYatAttention
+
+        attn = RotaryYatAttention(
+            embed_dim=32, num_heads=4, max_seq_len=64,
+            use_performer=True, rngs=nnx.Rngs(0),
+        )
+        assert attn.performer_kind == "slay"
+
+    def test_invalid_kind_raises(self):
+        from flax import nnx
+        from nmn.nnx.layers.attention import RotaryYatAttention
+
+        with pytest.raises(ValueError):
+            RotaryYatAttention(
+                embed_dim=32, num_heads=4, max_seq_len=64,
+                use_performer=True, performer_kind="bogus", rngs=nnx.Rngs(0),
+            )

--- a/tests/test_nnx/test_yatnmn_lazy.py
+++ b/tests/test_nnx/test_yatnmn_lazy.py
@@ -1,0 +1,132 @@
+"""Tests for YatNMN lazy mode (issue #37, nnx backend).
+
+In lazy mode (``lazy=True`` / ``freeze_kernel=True``) ONLY the kernel is frozen:
+it is stored under ``FrozenParam`` so it is excluded from
+``nnx.state(model, nnx.Param)`` (and hence the optimizer/grad), while ``bias``,
+``alpha`` and the learnable ``epsilon`` remain trainable ``nnx.Param``.
+``lazy=False`` (the default) is fully backward compatible.
+"""
+
+import pytest
+
+pytest.importorskip("jax")
+pytest.importorskip("flax")
+pytest.importorskip("optax")
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+import optax
+
+from nmn.nnx.layers.nmn import YatNMN, FrozenParam
+
+
+def _param_paths(state):
+    return {str(k) for k, _ in nnx.to_flat_state(state)}
+
+
+class TestLazyStateFiltering:
+    def test_kernel_excluded_from_param(self):
+        m = YatNMN(8, 4, lazy=True, learnable_epsilon=True, rngs=nnx.Rngs(0))
+        params = nnx.state(m, nnx.Param)
+        frozen = nnx.state(m, FrozenParam)
+        assert "('kernel',)" not in _param_paths(params)
+        assert "('kernel',)" in _param_paths(frozen)
+
+    def test_bias_alpha_epsilon_are_trainable(self):
+        m = YatNMN(8, 4, lazy=True, use_alpha=True, learnable_epsilon=True, rngs=nnx.Rngs(0))
+        paths = _param_paths(nnx.state(m, nnx.Param))
+        assert "('bias',)" in paths
+        assert "('alpha',)" in paths
+        assert "('epsilon_param',)" in paths
+
+    def test_freeze_kernel_alias(self):
+        m = YatNMN(8, 4, freeze_kernel=True, rngs=nnx.Rngs(0))
+        assert m.lazy is True
+        assert "('kernel',)" not in _param_paths(nnx.state(m, nnx.Param))
+
+    def test_freeze_kernel_false_overrides(self):
+        # explicit freeze_kernel=False keeps the kernel trainable
+        m = YatNMN(8, 4, lazy=True, freeze_kernel=False, rngs=nnx.Rngs(0))
+        assert m.lazy is False
+        assert "('kernel',)" in _param_paths(nnx.state(m, nnx.Param))
+
+    def test_lazy_with_tie_kernel_bank_raises(self):
+        with pytest.raises(ValueError):
+            YatNMN(8, 4, lazy=True, tie_kernel_bank=True, rngs=nnx.Rngs(0))
+
+
+class TestLazyTrainingStep:
+    def test_kernel_frozen_others_change(self):
+        m = YatNMN(8, 4, lazy=True, use_alpha=True, learnable_epsilon=True, rngs=nnx.Rngs(0))
+        k0 = jnp.array(m.kernel[...])
+        b0 = jnp.array(m.bias[...])
+        a0 = jnp.array(m.alpha[...])
+        e0 = jnp.array(m.epsilon_param[...])
+
+        opt = nnx.Optimizer(m, optax.sgd(0.5), wrt=nnx.Param)
+        x = jax.random.normal(jax.random.PRNGKey(4), (16, 8))
+        y = jax.random.normal(jax.random.PRNGKey(5), (16, 4))
+
+        def loss_fn(model):
+            return jnp.mean((model(x) - y) ** 2)
+
+        eps_grad_seen = False
+        for _ in range(3):
+            _, grads = nnx.value_and_grad(loss_fn)(m)
+            # epsilon receives a (small but nonzero) gradient -> it is trainable.
+            g_eps = dict(nnx.to_flat_state(grads)).get(("epsilon_param",))
+            if g_eps is not None and float(jnp.sum(jnp.abs(g_eps[...]))) > 0.0:
+                eps_grad_seen = True
+            opt.update(m, grads)
+
+        # Kernel must be unchanged (frozen).
+        assert bool(jnp.allclose(k0, m.kernel[...]))
+        # Bias / alpha must move.
+        assert not bool(jnp.allclose(b0, m.bias[...]))
+        assert not bool(jnp.allclose(a0, m.alpha[...]))
+        # Epsilon is trainable: it gets a nonzero gradient and is updated.
+        assert eps_grad_seen
+        assert float(jnp.abs(e0 - m.epsilon_param[...]).sum()) > 0.0
+
+    def test_grads_exclude_kernel(self):
+        m = YatNMN(8, 4, lazy=True, learnable_epsilon=True, rngs=nnx.Rngs(0))
+        x = jax.random.normal(jax.random.PRNGKey(6), (8, 8))
+
+        def loss_fn(model):
+            return jnp.mean(model(x) ** 2)
+
+        _, grads = nnx.value_and_grad(loss_fn)(m)
+        assert "('kernel',)" not in _param_paths(grads)
+        assert "('bias',)" in _param_paths(grads)
+
+
+class TestBackwardCompat:
+    def test_default_kernel_trainable(self):
+        m = YatNMN(8, 4, rngs=nnx.Rngs(0))
+        assert m.lazy is False
+        assert "('kernel',)" in _param_paths(nnx.state(m, nnx.Param))
+
+    def test_lazy_false_matches_default_forward(self):
+        x = jax.random.normal(jax.random.PRNGKey(0), (5, 8))
+        m_default = YatNMN(8, 4, rngs=nnx.Rngs(42))
+        m_lazy_false = YatNMN(8, 4, lazy=False, rngs=nnx.Rngs(42))
+        out_a = m_default(x)
+        out_b = m_lazy_false(x)
+        assert jnp.allclose(out_a, out_b)
+
+    def test_lazy_forward_matches_nonlazy_same_init(self):
+        # Same RNG seed -> same kernel/bias/alpha init -> identical forward,
+        # whether or not the kernel is frozen.
+        x = jax.random.normal(jax.random.PRNGKey(0), (5, 8))
+        m_lazy = YatNMN(8, 4, lazy=True, rngs=nnx.Rngs(123))
+        m_train = YatNMN(8, 4, lazy=False, rngs=nnx.Rngs(123))
+        assert jnp.allclose(m_lazy(x), m_train(x))
+
+    def test_fused_lazy_forward(self):
+        # The fused path must still work in lazy mode (forward only).
+        x = jax.random.normal(jax.random.PRNGKey(0), (5, 8))
+        m = YatNMN(8, 4, lazy=True, fused=True, rngs=nnx.Rngs(7))
+        out = m(x)
+        assert out.shape == (5, 4)
+        assert bool(jnp.all(jnp.isfinite(out)))

--- a/tests/test_tf/test_lazy_kernel.py
+++ b/tests/test_tf/test_lazy_kernel.py
@@ -1,0 +1,117 @@
+"""Tests for TensorFlow YatNMN lazy mode (issue #37).
+
+In lazy mode ONLY the kernel (feature directions) is frozen; bias, alpha, and
+the learnable epsilon remain trainable. Default (``lazy=False``) is unchanged.
+
+TensorFlow is not installed in the local dev environment, so the module is
+guarded by ``pytest.importorskip`` and exercised in CI.
+"""
+
+import numpy as np
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from nmn.tf.nmn import YatNMN
+
+
+def _build(layer, in_dim=8):
+    x = tf.random.normal((4, in_dim))
+    layer(x)  # triggers build
+    return x
+
+
+def test_lazy_kernel_non_trainable():
+    layer = YatNMN(features=6, lazy=True, use_bias=True, use_alpha=True, learnable_epsilon=True)
+    _build(layer)
+    assert layer.kernel.trainable is False
+    trainable_names = [v.name for v in layer.trainable_variables]
+    # kernel must be excluded from the optimizer's trainable set.
+    assert not any("kernel" in n for n in trainable_names)
+
+
+def test_lazy_bias_alpha_epsilon_trainable():
+    layer = YatNMN(features=6, lazy=True, use_bias=True, use_alpha=True, learnable_epsilon=True)
+    _build(layer)
+    assert layer.bias.trainable is True
+    assert layer.alpha.trainable is True
+    assert layer.epsilon_param.trainable is True
+    trainable_names = [v.name for v in layer.trainable_variables]
+    assert any("bias" in n for n in trainable_names)
+    assert any("alpha" in n for n in trainable_names)
+    assert any("epsilon" in n for n in trainable_names)
+
+
+def test_freeze_kernel_alias():
+    layer = YatNMN(features=6, freeze_kernel=True)
+    _build(layer)
+    assert layer.lazy is True
+    assert layer.kernel.trainable is False
+
+
+def test_lazy_false_backward_compatible():
+    layer = YatNMN(features=6, use_bias=True, use_alpha=True, learnable_epsilon=True)
+    _build(layer)
+    assert layer.lazy is False
+    assert layer.kernel.trainable is True
+    trainable_names = [v.name for v in layer.trainable_variables]
+    assert any("kernel" in n for n in trainable_names)
+
+
+def test_lazy_gradients_kernel_none_others_present():
+    layer = YatNMN(features=6, lazy=True, use_bias=True, use_alpha=True, learnable_epsilon=True)
+    x = _build(layer)
+
+    with tf.GradientTape() as tape:
+        loss = tf.reduce_sum(tf.square(layer(x)))
+    grads = tape.gradient(loss, [layer.kernel, layer.bias, layer.alpha, layer.epsilon_param])
+    g_kernel, g_bias, g_alpha, g_eps = grads
+    # Frozen kernel: no gradient flows to it through the trainable-variable path.
+    # (It is excluded from trainable_variables; explicit gradient is None.)
+    assert g_kernel is None
+    assert g_bias is not None and np.any(g_bias.numpy() != 0.0)
+    assert g_alpha is not None
+    assert g_eps is not None
+
+
+def test_lazy_training_step_kernel_unchanged():
+    """1-2 step smoke test: kernel stays fixed, bias/alpha/epsilon move."""
+    layer = YatNMN(features=6, lazy=True, use_bias=True, use_alpha=True, learnable_epsilon=True)
+    x = _build(layer)
+
+    kernel0 = layer.kernel.numpy().copy()
+    bias0 = layer.bias.numpy().copy()
+    alpha0 = layer.alpha.numpy().copy()
+    eps0 = layer.epsilon_param.numpy().copy()
+
+    lr = 0.1
+    target = tf.random.normal((4, 6))
+    for _ in range(2):
+        with tf.GradientTape() as tape:
+            loss = tf.reduce_sum(tf.square(layer(x) - target))
+        # Manual SGD over only the trainable variables (kernel excluded).
+        grads = tape.gradient(loss, layer.trainable_variables)
+        for g, var in zip(grads, layer.trainable_variables):
+            if g is not None:
+                var.assign_sub(lr * g)
+
+    # Kernel frozen.
+    np.testing.assert_array_equal(layer.kernel.numpy(), kernel0)
+    # bias / alpha / epsilon updated.
+    assert not np.array_equal(layer.bias.numpy(), bias0)
+    assert not np.array_equal(layer.alpha.numpy(), alpha0)
+    assert not np.array_equal(layer.epsilon_param.numpy(), eps0)
+
+
+def test_lazy_forward_matches_non_lazy_at_init():
+    """Lazy mode must not change the forward computation, only trainability."""
+    eager = YatNMN(features=6, lazy=False, use_bias=True, use_alpha=True)
+    lazy = YatNMN(features=6, lazy=True, use_bias=True, use_alpha=True)
+    x = tf.random.normal((4, 8))
+    eager(x)
+    lazy(x)
+    # Copy weights so both compute the same function.
+    lazy.kernel.assign(eager.kernel)
+    lazy.bias.assign(eager.bias)
+    lazy.alpha.assign(eager.alpha)
+    np.testing.assert_allclose(eager(x).numpy(), lazy(x).numpy(), rtol=1e-6, atol=1e-6)

--- a/tests/test_tf/test_performer_yat.py
+++ b/tests/test_tf/test_performer_yat.py
@@ -1,0 +1,259 @@
+"""Tests for TensorFlow MAY (Random Maclaurin) and RAY (radial) feature maps.
+
+These mirror the verified NumPy reference at ``.context/may-ray/reference.py``.
+TensorFlow is not installed in the local dev environment, so the whole module is
+guarded by ``pytest.importorskip`` and exercised in CI.
+"""
+
+import numpy as np
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from nmn.tf.performer_yat import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+)
+
+
+# --------------------------------------------------------------------------
+# NumPy reference helpers (verified math) for the kernel / baselines
+# --------------------------------------------------------------------------
+def _normalize_rows(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def _exact_kernel(s, b, eps):
+    C = 2.0 + eps
+    return (s + b) ** 2 / (C - 2.0 * s)
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize_rows(q), _normalize_rows(k)
+    s = qn @ kn.T
+    w = _exact_kernel(s, b, eps)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _median_sq_distance(qn, kn):
+    diff = qn[:, None, :] - kn[None, :, :]
+    return float(np.median((diff * diff).sum(-1)))
+
+
+def _per_token_cos(a, b):
+    num = (a * b).sum(-1)
+    den = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1) + 1e-12
+    return float(np.mean(num / den))
+
+
+# NumPy SLAY baseline (bias-free b=0 design point), straight from the reference.
+def _slay_create(d, P=32, M=8, R=1, eps=1e-5, seed=0):
+    rng = np.random.default_rng(seed)
+    C = 2.0 + eps
+    nodes, weights = np.polynomial.laguerre.laggauss(R)
+    nodes, weights = nodes / C, weights / C
+    anchors = _normalize_rows(rng.standard_normal((P, d)))
+    proj = rng.standard_normal((R, M, d))
+    return dict(anchors=anchors, proj=proj, nodes=nodes, weights=weights, P=P, M=M, R=R)
+
+
+def _slay_features(x, params):
+    x = _normalize_rows(x)
+    P, M, R = params["P"], params["M"], params["R"]
+    poly = (x @ params["anchors"].T) ** 2 / np.sqrt(P)
+    proj_all = np.einsum("nd,rmd->nrm", x, params["proj"])
+    out = []
+    for r in range(R):
+        s = params["nodes"][r]
+        arg = np.clip(proj_all[:, r] * np.sqrt(2 * max(s, 0)) - s, -20, 20)
+        prf = np.exp(arg) / np.sqrt(M)
+        fused = np.einsum("np,nm->npm", poly, prf).reshape(x.shape[0], -1)
+        out.append(np.sqrt(max(params["weights"][r], 0)) * fused)
+    return np.concatenate(out, axis=1)
+
+
+def _linear_attention_np(phi_q, phi_k, v, eps=1e-9):
+    kv = phi_k.T @ v
+    num = phi_q @ kv
+    den = phi_q @ phi_k.sum(0)
+    return num / (den[:, None] + eps)
+
+
+def _bhd(x):
+    """[N, d] -> [1, N, 1, d] (batch=1, single head) for the tf attention API."""
+    return tf.constant(x[None, :, None, :], dtype=tf.float32)
+
+
+# --------------------------------------------------------------------------
+# Maclaurin coefficients
+# --------------------------------------------------------------------------
+def test_maclaurin_coeffs_nonnegative():
+    a = maclaurin_coeffs(b=1.0, eps=0.5, nmax=40)
+    assert a.shape == (41,)
+    assert np.all(a >= 0.0)
+    assert a.sum() > 0.0
+
+
+# --------------------------------------------------------------------------
+# MAY -- shapes, finiteness, determinism
+# --------------------------------------------------------------------------
+def test_may_features_shape():
+    params = create_maclaurin_projection(head_dim=16, num_features=64, bias=1.0, epsilon=0.5, seed=0)
+    x = tf.random.normal((2, 10, 4, 16))
+    feat = maclaurin_features(x, params)
+    assert feat.shape == (2, 10, 4, 64)
+
+
+def test_may_features_finite():
+    params = create_maclaurin_projection(head_dim=16, num_features=128, bias=1.0, epsilon=0.5, seed=0)
+    x = tf.random.normal((2, 10, 4, 16))
+    feat = maclaurin_features(x, params).numpy()
+    assert np.all(np.isfinite(feat))
+
+
+def test_may_features_deterministic():
+    p0 = create_maclaurin_projection(head_dim=16, num_features=64, bias=1.0, epsilon=0.5, seed=7)
+    p1 = create_maclaurin_projection(head_dim=16, num_features=64, bias=1.0, epsilon=0.5, seed=7)
+    np.testing.assert_array_equal(p0["omegas"].numpy(), p1["omegas"].numpy())
+    np.testing.assert_array_equal(p0["degrees"].numpy(), p1["degrees"].numpy())
+    x = tf.random.normal((3, 5, 2, 16))
+    f0 = maclaurin_features(x, p0).numpy()
+    f1 = maclaurin_features(x, p1).numpy()
+    np.testing.assert_allclose(f0, f1, rtol=1e-6, atol=1e-6)
+
+
+def test_may_attention_shape_and_finite():
+    params = create_maclaurin_projection(head_dim=16, num_features=128, bias=1.0, epsilon=0.5, seed=0)
+    q = tf.random.normal((2, 6, 4, 16))
+    k = tf.random.normal((2, 8, 4, 16))
+    v = tf.random.normal((2, 8, 4, 16))
+    out = maclaurin_yat_attention(q, k, v, params)
+    assert out.shape == (2, 6, 4, 16)
+    assert np.all(np.isfinite(out.numpy()))
+
+
+def test_may_attention_causal_shape():
+    params = create_maclaurin_projection(head_dim=16, num_features=64, bias=1.0, epsilon=0.5, seed=0)
+    q = tf.random.normal((2, 7, 4, 16))
+    k = tf.random.normal((2, 7, 4, 16))
+    v = tf.random.normal((2, 7, 4, 16))
+    out = maclaurin_yat_attention(q, k, v, params, causal=True)
+    assert out.shape == (2, 7, 4, 16)
+    assert np.all(np.isfinite(out.numpy()))
+
+
+# --------------------------------------------------------------------------
+# MAY -- unbiasedness: inner product tracks kappa
+# --------------------------------------------------------------------------
+def test_may_inner_product_tracks_kappa():
+    """E[phi(q)·phi(k)] = kappa(q·k). The empirical Gram entries must correlate
+    strongly with the exact kernel and rise with s."""
+    d, b, eps = 32, 1.0, 0.5
+    M = 20000  # many features -> tight Monte-Carlo estimate
+    params = create_maclaurin_projection(head_dim=d, num_features=M, bias=b, epsilon=eps, seed=1)
+
+    rng = np.random.default_rng(0)
+    x = _normalize_rows(rng.standard_normal((8, d)))
+    xt = tf.constant(x[None, :, None, :], dtype=tf.float32)  # [1, N, 1, d]
+    feat = maclaurin_features(xt, params).numpy()[0, :, 0, :]  # [N, M]
+
+    gram = feat @ feat.T
+    s = x @ x.T
+    iu = np.triu_indices(8, k=1)
+    approx = gram[iu]
+    exact = _exact_kernel(s[iu], b, eps)
+
+    # Strong linear correlation between approximation and exact kernel.
+    corr = np.corrcoef(approx, exact)[0, 1]
+    assert corr > 0.95
+    # Reasonable absolute agreement with a large feature budget.
+    np.testing.assert_allclose(approx, exact, atol=0.12)
+
+
+def test_may_more_features_better():
+    """More features -> closer to exact attention (higher cosine)."""
+    d, N, b = 48, 96, 1.0
+    rng = np.random.default_rng(3)
+    q = rng.standard_normal((N, d))
+    k = rng.standard_normal((N, d))
+    v = rng.standard_normal((N, d))
+    eps = _median_sq_distance(_normalize_rows(q), _normalize_rows(k))
+    exact = _exact_attention(q, k, v, b, eps)
+
+    def cos_for(M):
+        params = create_maclaurin_projection(head_dim=d, num_features=M, bias=b, epsilon=eps, seed=0)
+        out = maclaurin_yat_attention(_bhd(q), _bhd(k), _bhd(v), params).numpy()[0, :, 0, :]
+        return _per_token_cos(out, exact)
+
+    assert cos_for(512) > cos_for(32)
+
+
+def test_may_beats_slay_at_high_bias():
+    """At b >= 1 MAY (bias-aware) must clearly beat SLAY (bias-free anchor)."""
+    d, N, F = 64, 256, 256
+    seeds = [0, 1, 2]
+    for b in (1.0, 2.0):
+        may_cos, slay_cos = [], []
+        for seed in seeds:
+            rng = np.random.default_rng(100 + seed)
+            q = rng.standard_normal((N, d))
+            k = rng.standard_normal((N, d))
+            v = rng.standard_normal((N, d))
+            eps = _median_sq_distance(_normalize_rows(q), _normalize_rows(k))
+            exact = _exact_attention(q, k, v, b, eps)
+
+            mp = create_maclaurin_projection(head_dim=d, num_features=F, bias=b, epsilon=eps, seed=seed)
+            ma = maclaurin_yat_attention(_bhd(q), _bhd(k), _bhd(v), mp).numpy()[0, :, 0, :]
+            may_cos.append(_per_token_cos(ma, exact))
+
+            sp = _slay_create(d, P=32, M=8, R=1, eps=eps, seed=seed)
+            sa = _linear_attention_np(_slay_features(q, sp), _slay_features(k, sp), v)
+            slay_cos.append(_per_token_cos(sa, exact))
+
+        assert np.mean(may_cos) > np.mean(slay_cos), (
+            f"b={b}: MAY {np.mean(may_cos):.3f} <= SLAY {np.mean(slay_cos):.3f}"
+        )
+
+
+# --------------------------------------------------------------------------
+# RAY -- shapes, finiteness, determinism
+# --------------------------------------------------------------------------
+def test_ray_features_shape():
+    params = create_radial_projection(
+        head_dim=16, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.5, seed=0
+    )
+    x = tf.random.normal((2, 10, 4, 16))
+    feat = radial_features(x, params)
+    assert feat.shape == (2, 10, 4, 8 * 4 * 8)
+
+
+def test_ray_features_finite_and_deterministic():
+    p0 = create_radial_projection(
+        head_dim=16, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.5, seed=5
+    )
+    p1 = create_radial_projection(
+        head_dim=16, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.5, seed=5
+    )
+    x = tf.random.normal((2, 6, 2, 16))
+    f0 = radial_features(x, p0).numpy()
+    f1 = radial_features(x, p1).numpy()
+    assert np.all(np.isfinite(f0))
+    np.testing.assert_allclose(f0, f1, rtol=1e-6, atol=1e-6)
+
+
+def test_ray_attention_shape_and_finite():
+    params = create_radial_projection(
+        head_dim=16, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.5, seed=0
+    )
+    q = tf.random.normal((2, 6, 4, 16))
+    k = tf.random.normal((2, 8, 4, 16))
+    v = tf.random.normal((2, 8, 4, 16))
+    out = radial_yat_attention(q, k, v, params)
+    assert out.shape == (2, 6, 4, 16)
+    assert np.all(np.isfinite(out.numpy()))

--- a/tests/test_torch/test_performer_yat.py
+++ b/tests/test_torch/test_performer_yat.py
@@ -1,0 +1,300 @@
+"""Tests for MAY (Random Maclaurin) and RAY (radial) linear-attention feature
+maps for spherical YAT (issue #36, PyTorch backend).
+
+Verifies: shapes, no NaN/Inf, determinism (seeded), the MAY inner-product
+tracks the kernel ``kappa(s) = (s + b)²/(C − 2s)``, and that MAY beats a
+SLAY-style (b=0) baseline at ``b ≥ 1`` (the bias-aware regime).
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from nmn.torch.attention.performer_yat import (
+    maclaurin_coeffs,
+    create_maclaurin_projection,
+    maclaurin_features,
+    maclaurin_yat_attention,
+    create_radial_projection,
+    radial_features,
+    radial_yat_attention,
+    linear_attention_readout,
+)
+from nmn.torch.attention.yat_attention import yat_attention_normalized
+
+
+# --------------------------------------------------------------------------
+# Reference helpers (NumPy, mirror .context/may-ray/reference.py)
+# --------------------------------------------------------------------------
+def _normalize_rows(x, eps=1e-6):
+    return x / np.sqrt((x * x).sum(-1, keepdims=True) + eps)
+
+
+def _exact_kernel(s, b, eps):
+    C = 2.0 + eps
+    return (s + b) ** 2 / (C - 2.0 * s)
+
+
+def _exact_attention(q, k, v, b, eps):
+    qn, kn = _normalize_rows(q), _normalize_rows(k)
+    s = qn @ kn.T
+    w = _exact_kernel(s, b, eps)
+    w = w / (w.sum(-1, keepdims=True) + 1e-9)
+    return w @ v
+
+
+def _median_sq_distance(qn, kn):
+    diff = qn[:, None, :] - kn[None, :, :]
+    return float(np.median((diff * diff).sum(-1)))
+
+
+def _per_token_cos(a, b):
+    num = (a * b).sum(-1)
+    den = np.linalg.norm(a, axis=-1) * np.linalg.norm(b, axis=-1) + 1e-12
+    return float(np.mean(num / den))
+
+
+# SLAY-style (b=0) NumPy baseline (anchor performer) from the reference.
+def _slay_create(d, P, M, R, eps, seed):
+    rng = np.random.default_rng(seed)
+    C = 2.0 + eps
+    nodes, weights = np.polynomial.laguerre.laggauss(R)
+    nodes, weights = nodes / C, weights / C
+    anchors = _normalize_rows(rng.standard_normal((P, d)))
+    proj = rng.standard_normal((R, M, d))
+    return dict(anchors=anchors, proj=proj, nodes=nodes, weights=weights, P=P, M=M, R=R)
+
+
+def _slay_features(x, params):
+    x = _normalize_rows(x)
+    P, M, R = params["P"], params["M"], params["R"]
+    poly = (x @ params["anchors"].T) ** 2 / np.sqrt(P)
+    proj_all = np.einsum("nd,rmd->nrm", x, params["proj"])
+    out = []
+    for r in range(R):
+        s = params["nodes"][r]
+        arg = np.clip(proj_all[:, r] * np.sqrt(2 * max(s, 0)) - s, -20, 20)
+        prf = np.exp(arg) / np.sqrt(M)
+        fused = np.einsum("np,nm->npm", poly, prf).reshape(x.shape[0], -1)
+        out.append(np.sqrt(max(params["weights"][r], 0)) * fused)
+    return np.concatenate(out, axis=1)
+
+
+def _linear_attention_np(phi_q, phi_k, v, eps=1e-9):
+    kv = phi_k.T @ v
+    num = phi_q @ kv
+    den = phi_q @ phi_k.sum(0)
+    return num / (den[:, None] + eps)
+
+
+# --------------------------------------------------------------------------
+# Maclaurin coefficient sanity
+# --------------------------------------------------------------------------
+def test_maclaurin_coeffs_nonneg_and_reconstruct():
+    b, eps, nmax = 1.5, 0.3, 60
+    a = maclaurin_coeffs(b, eps, nmax)
+    assert (a >= 0).all()
+    # Series reconstructs kappa(s) for |s| < C/2.
+    C = 2.0 + eps
+    for s in [-0.5, 0.0, 0.3, 0.7]:
+        approx = sum(a[n] * s ** n for n in range(nmax + 1))
+        exact = (s + b) ** 2 / (C - 2.0 * s)
+        assert abs(approx - exact) < 1e-6
+
+
+# --------------------------------------------------------------------------
+# Shapes / no NaN-Inf / determinism — MAY
+# --------------------------------------------------------------------------
+def test_may_feature_shape():
+    d, M = 16, 64
+    params = create_maclaurin_projection(head_dim=d, num_features=M, bias=1.0, epsilon=0.2, seed=0)
+    x = torch.randn(2, 5, 4, d)
+    feat = maclaurin_features(x, params)
+    assert feat.shape == (2, 5, 4, M)
+
+
+def test_may_attention_shape_and_finite():
+    d, M = 16, 64
+    params = create_maclaurin_projection(head_dim=d, num_features=M, bias=1.0, epsilon=0.2, seed=0)
+    q = torch.randn(2, 5, 4, d)
+    k = torch.randn(2, 7, 4, d)
+    v = torch.randn(2, 7, 4, 8)
+    out = maclaurin_yat_attention(q, k, v, params)
+    assert out.shape == (2, 5, 4, 8)
+    assert torch.isfinite(out).all()
+
+
+def test_may_causal_shape_and_finite():
+    d, M = 16, 64
+    params = create_maclaurin_projection(head_dim=d, num_features=M, bias=1.0, epsilon=0.2, seed=1)
+    q = torch.randn(2, 6, 3, d)
+    v = torch.randn(2, 6, 3, 8)
+    out = maclaurin_yat_attention(q, q, v, params, causal=True)
+    assert out.shape == (2, 6, 3, 8)
+    assert torch.isfinite(out).all()
+
+
+def test_may_determinism():
+    d, M = 16, 64
+    x = torch.randn(3, 4, 2, d)
+    p1 = create_maclaurin_projection(head_dim=d, num_features=M, bias=1.0, epsilon=0.2, seed=42)
+    p2 = create_maclaurin_projection(head_dim=d, num_features=M, bias=1.0, epsilon=0.2, seed=42)
+    f1 = maclaurin_features(x, p1)
+    f2 = maclaurin_features(x, p2)
+    assert torch.allclose(f1, f2)
+
+
+def test_may_causal_matches_full_at_last_query():
+    d, M = 16, 64
+    params = create_maclaurin_projection(head_dim=d, num_features=M, bias=1.0, epsilon=0.2, seed=3)
+    x = torch.randn(1, 5, 2, d)
+    v = torch.randn(1, 5, 2, 6)
+    causal = maclaurin_yat_attention(x, x, v, params, causal=True)
+    full = maclaurin_yat_attention(x, x, v, params, causal=False)
+    # The last query attends to all keys in both modes.
+    assert torch.allclose(causal[:, -1], full[:, -1], atol=1e-4)
+
+
+# --------------------------------------------------------------------------
+# MAY inner product tracks kappa, and more features -> better fit
+# --------------------------------------------------------------------------
+def test_may_inner_product_tracks_kappa():
+    d, b, eps = 32, 1.0, 0.3
+    C = 2.0 + eps
+    rng = np.random.default_rng(0)
+    # Build pairs at controlled cosine s by interpolating.
+    base = _normalize_rows(rng.standard_normal((1, d)))
+    other = _normalize_rows(rng.standard_normal((1, d)))
+    s_targets = np.linspace(-0.6, 0.8, 8)
+
+    params = create_maclaurin_projection(
+        head_dim=d, num_features=20000, bias=b, epsilon=eps, seed=0
+    )
+
+    est, exact = [], []
+    for s in s_targets:
+        # Construct k̂ with q̂·k̂ ≈ s via Gram-Schmidt mixing.
+        perp = other - (other @ base.T) * base
+        perp = _normalize_rows(perp)
+        kv = s * base + math.sqrt(max(1 - s * s, 0.0)) * perp
+        kv = _normalize_rows(kv)
+        qf = maclaurin_features(torch.as_tensor(base, dtype=torch.float32), params)
+        kf = maclaurin_features(torch.as_tensor(kv, dtype=torch.float32), params)
+        est.append(float((qf * kf).sum()))
+        exact.append(float(_exact_kernel(s, b, eps)))
+
+    est = np.array(est)
+    exact = np.array(exact)
+    # Monotone-rising and close to kappa (rises with s, tracks the kernel).
+    assert np.corrcoef(est, exact)[0, 1] > 0.99
+    assert np.all(np.diff(est) > 0)  # strictly rising in s, like kappa
+    # Unbiased Monte-Carlo estimator: tight on absolute error, looser on
+    # relative error at small-kappa points (sampling variance dominates there).
+    assert np.median(np.abs(est - exact) / (np.abs(exact) + 1e-6)) < 0.25
+
+
+def test_may_more_features_better_attention_fit():
+    d, N, b = 48, 96, 1.0
+    rng = np.random.default_rng(7)
+    q = rng.standard_normal((N, d)).astype(np.float32)
+    k = rng.standard_normal((N, d)).astype(np.float32)
+    v = rng.standard_normal((N, d)).astype(np.float32)
+    eps = _median_sq_distance(_normalize_rows(q), _normalize_rows(k))
+    exact = _exact_attention(q, k, v, b, eps)
+
+    def fit(M):
+        p = create_maclaurin_projection(head_dim=d, num_features=M, bias=b, epsilon=eps, seed=0)
+        qf = maclaurin_features(torch.as_tensor(q), p).numpy()
+        kf = maclaurin_features(torch.as_tensor(k), p).numpy()
+        out = _linear_attention_np(qf, kf, v)
+        return _per_token_cos(out, exact)
+
+    low = fit(64)
+    high = fit(1024)
+    assert high > low
+    assert high > 0.9
+
+
+# --------------------------------------------------------------------------
+# MAY beats SLAY (b=0 design) at b >= 1
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("b", [1.0, 2.0])
+def test_may_beats_slay_at_high_bias(b):
+    d, N, F = 64, 256, 256
+    cos_may, cos_slay = [], []
+    for seed in [0, 1, 2]:
+        rng = np.random.default_rng(100 + seed)
+        q = rng.standard_normal((N, d)).astype(np.float32)
+        k = rng.standard_normal((N, d)).astype(np.float32)
+        v = rng.standard_normal((N, d)).astype(np.float32)
+        eps = _median_sq_distance(_normalize_rows(q), _normalize_rows(k))
+        exact = _exact_attention(q, k, v, b, eps)
+
+        mp = create_maclaurin_projection(head_dim=d, num_features=F, bias=b, epsilon=eps, seed=seed)
+        qf = maclaurin_features(torch.as_tensor(q), mp).numpy()
+        kf = maclaurin_features(torch.as_tensor(k), mp).numpy()
+        cos_may.append(_per_token_cos(_linear_attention_np(qf, kf, v), exact))
+
+        sp = _slay_create(d, P=32, M=8, R=1, eps=eps, seed=seed)
+        sqf = _slay_features(q, sp)
+        skf = _slay_features(k, sp)
+        cos_slay.append(_per_token_cos(_linear_attention_np(sqf, skf, v), exact))
+
+    assert np.mean(cos_may) > np.mean(cos_slay)
+
+
+# --------------------------------------------------------------------------
+# RAY — shapes, finite, determinism (weaker method; no win expected)
+# --------------------------------------------------------------------------
+def test_ray_feature_shape_and_finite():
+    d = 16
+    params = create_radial_projection(
+        head_dim=d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.3, seed=0
+    )
+    x = torch.randn(2, 5, 3, d)
+    feat = radial_features(x, params)
+    assert feat.shape[:-1] == (2, 5, 3)
+    assert feat.shape[-1] == 8 * 4 * 8
+    assert torch.isfinite(feat).all()
+
+
+def test_ray_attention_shape_and_finite():
+    d = 16
+    params = create_radial_projection(
+        head_dim=d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.3, seed=0
+    )
+    q = torch.randn(2, 5, 3, d)
+    k = torch.randn(2, 7, 3, d)
+    v = torch.randn(2, 7, 3, 8)
+    out = radial_yat_attention(q, k, v, params)
+    assert out.shape == (2, 5, 3, 8)
+    assert torch.isfinite(out).all()
+
+
+def test_ray_determinism():
+    d = 16
+    x = torch.randn(2, 4, 2, d)
+    p1 = create_radial_projection(head_dim=d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.3, seed=5)
+    p2 = create_radial_projection(head_dim=d, sketch_m=8, num_radial=4, radial_dim=8, bias=1.0, epsilon=0.3, seed=5)
+    assert torch.allclose(radial_features(x, p1), radial_features(x, p2))
+
+
+# --------------------------------------------------------------------------
+# Readout sanity: matches a hand NumPy readout
+# --------------------------------------------------------------------------
+def test_linear_attention_readout_matches_numpy():
+    torch.manual_seed(0)
+    B, Q, K, H, F, D = 1, 3, 4, 2, 5, 6
+    qf = torch.randn(B, Q, H, F)
+    kf = torch.randn(B, K, H, F)
+    v = torch.randn(B, K, H, D)
+    out = linear_attention_readout(qf, kf, v, causal=False, epsilon=1e-5)
+    # NumPy per (b,h)
+    for h in range(H):
+        num_np = qf[0, :, h].numpy() @ (kf[0, :, h].numpy().T @ v[0, :, h].numpy())
+        den_np = qf[0, :, h].numpy() @ kf[0, :, h].numpy().sum(0)
+        ref = num_np / (den_np[:, None] + 1e-5)
+        assert np.allclose(out[0, :, h].numpy(), ref, atol=1e-4)

--- a/tests/test_torch/test_yat_nmn_lazy.py
+++ b/tests/test_torch/test_yat_nmn_lazy.py
@@ -1,0 +1,123 @@
+"""Tests for YatNMN lazy mode (issue #37, PyTorch backend).
+
+lazy=True freezes ONLY the kernel (excluded from gradients/optimizer); bias,
+alpha, and the learnable epsilon stay trainable. lazy=False is unchanged.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from nmn.torch.nmn import YatNMN
+
+
+def _trainable_names(layer):
+    return {n for n, p in layer.named_parameters() if p.requires_grad}
+
+
+def test_lazy_freezes_only_kernel():
+    layer = YatNMN(
+        in_features=8, out_features=4,
+        bias=True, alpha=True, learnable_epsilon=True, lazy=True,
+    )
+    assert layer.weight.requires_grad is False
+    assert layer.bias.requires_grad is True
+    assert layer.alpha.requires_grad is True
+    assert layer.epsilon_param.requires_grad is True
+
+
+def test_lazy_kernel_excluded_from_trainable_params():
+    layer = YatNMN(
+        in_features=8, out_features=4,
+        bias=True, alpha=True, learnable_epsilon=True, lazy=True,
+    )
+    names = _trainable_names(layer)
+    assert "weight" not in names
+    assert "bias" in names
+    assert "alpha" in names
+    assert "epsilon_param" in names
+
+
+def test_freeze_kernel_alias():
+    layer = YatNMN(in_features=8, out_features=4, freeze_kernel=True)
+    assert layer.lazy is True
+    assert layer.weight.requires_grad is False
+    assert layer.bias.requires_grad is True
+
+
+def test_lazy_default_false_backward_compat():
+    layer = YatNMN(in_features=8, out_features=4)
+    assert layer.lazy is False
+    assert layer.weight.requires_grad is True
+    assert "weight" in _trainable_names(layer)
+
+
+def test_lazy_training_step_kernel_unchanged_others_change():
+    torch.manual_seed(0)
+    # Use a larger epsilon so softplus(raw) has a non-vanishing slope and the
+    # smoke test can observe epsilon moving within a couple of SGD steps.
+    layer = YatNMN(
+        in_features=8, out_features=4,
+        bias=True, alpha=True, learnable_epsilon=True, epsilon=0.5, lazy=True,
+    )
+    kernel_before = layer.weight.detach().clone()
+    bias_before = layer.bias.detach().clone()
+    alpha_before = layer.alpha.detach().clone()
+    eps_before = layer.epsilon_param.detach().clone()
+
+    opt = torch.optim.SGD(
+        [p for p in layer.parameters() if p.requires_grad], lr=0.1
+    )
+    x = torch.randn(16, 8)
+    target = torch.randn(16, 4)
+
+    eps_got_grad = False
+    for _ in range(3):
+        opt.zero_grad()
+        out = layer(x)
+        loss = ((out - target) ** 2).mean()
+        loss.backward()
+        # Kernel must get no gradient.
+        assert layer.weight.grad is None
+        # epsilon IS in the autograd graph (it is trainable in lazy mode).
+        if layer.epsilon_param.grad is not None and layer.epsilon_param.grad.abs().sum() > 0:
+            eps_got_grad = True
+        opt.step()
+
+    assert torch.allclose(layer.weight, kernel_before), "kernel must stay frozen"
+    assert not torch.allclose(layer.bias, bias_before), "bias should train"
+    assert not torch.allclose(layer.alpha, alpha_before), "alpha should train"
+    assert eps_got_grad, "epsilon should receive gradient (trainable in lazy mode)"
+    assert not torch.allclose(layer.epsilon_param, eps_before), "epsilon should train"
+
+
+def test_non_lazy_kernel_does_change():
+    torch.manual_seed(0)
+    layer = YatNMN(in_features=8, out_features=4, lazy=False)
+    kernel_before = layer.weight.detach().clone()
+    opt = torch.optim.SGD(layer.parameters(), lr=0.1)
+    x = torch.randn(16, 8)
+    target = torch.randn(16, 4)
+    for _ in range(3):
+        opt.zero_grad()
+        loss = ((layer(x) - target) ** 2).mean()
+        loss.backward()
+        opt.step()
+    assert not torch.allclose(layer.weight, kernel_before)
+
+
+def test_lazy_forward_matches_nonlazy_same_init():
+    # With identical params, the forward output is identical regardless of lazy.
+    torch.manual_seed(123)
+    eager = YatNMN(in_features=8, out_features=4, lazy=False)
+    torch.manual_seed(123)
+    frozen = YatNMN(in_features=8, out_features=4, lazy=True)
+    x = torch.randn(5, 8)
+    with torch.no_grad():
+        assert torch.allclose(eager(x), frozen(x), atol=1e-6)
+
+
+def test_lazy_composes_with_no_bias():
+    layer = YatNMN(in_features=8, out_features=4, bias=False, lazy=True)
+    assert layer.weight.requires_grad is False
+    assert layer.bias is None


### PR DESCRIPTION
Closes #36. Closes #37.

## Issue #36 — MAY & RAY bias-aware linear-attention feature maps

The existing **SLAY** anchor performer only approximates the **bias-free** kernel (`b = 0`), but trained Yat-attention learns a per-head bias `b > 0`. This adds two **bias-aware** feature maps for the spherical kernel `κ(s) = (s + b)² / ((2 + ε) − 2s)` so that `φ(q)·φ(k) ≈ κ`, giving **O(n)** attention — in **all six backends** (nnx, linen, torch, tf, keras, mlx).

- **MAY (Random Maclaurin)** — degrees `N_r ~ Categorical(a_n/Z)` with on-sphere coeffs `a_n = β_{n-2} + 2b·β_{n-1} + b²·β_n`, `φ_r(x̂) = √(Z/M)·∏(ω·x̂)`. Unbiased; near-exact for `b > 0`.
- **RAY (radial)** — augmented `z = [x̂, √b]`, two-projection degree-2 sketch for `(z·z')²` × Gauss-Laguerre radial RFF for `1/(ε + ‖z − z'‖²)`. Secondary method (sharp-ε route).
- nnx attention gains `performer_kind ∈ {slay, maclaurin, radial}` (default `slay`, backward compatible).
- Unified API across frameworks: `create_*_projection` / `*_features` / `*_yat_attention` with canonical `bias`/`epsilon` kwargs.

### Benchmark (`tests/scripts/benchmark_may_ray.py`, cosine vs exact, d=64 N=512 F=256, ε=median sq-dist, 3 seeds)

| b | MAY | SLAY | | b | MAY | SLAY |
|---|-----|------|-|---|-----|------|
| 0.00 | 0.20 | **0.52** | | 1.00 | **0.89** | 0.84 |
| 0.25 | 0.52 | **0.66** | | 2.00 | **0.97** | 0.86 |
| 0.50 | 0.74 | **0.78** | | 4.00 | **0.99** | 0.87 |

SLAY wins only at its `b = 0` design point; in the `b > 0` deployment regime **MAY beats SLAY and approaches exact**, while SLAY floors. Reproduced identically across nnx/linen/torch/mlx.

## Issue #37 — YatNMN lazy training mode

`YatNMN(..., lazy=True)` (alias `freeze_kernel=True`) freezes **only the kernel** feature directions; **bias, alpha, and epsilon stay trainable**. Per-backend idiomatic mechanism: nnx `FrozenParam` (excluded from `nnx.state(model, nnx.Param)`), torch `requires_grad=False`, mlx `freeze`, keras/tf `trainable=False`, linen `stop_gradient`. Defaults unchanged (`lazy=False`).

## Testing

New tests in every framework (shapes, finiteness, determinism, kernel-approximation correctness, MAY-beats-SLAY at b≥1, and lazy freeze/trainability). Local suites pass: **nnx 287, mlx 194, linen 98, torch 199** (4 pre-existing skips). tf/keras can't run locally (no tensorflow) — verified by static review + a NumPy mirror of the math, and run in CI.

## Notes

- Math was verified against a NumPy reference before implementation; the unbiased estimator and the SLAY-crossover were confirmed empirically.
- MAY/RAY features are sign-indefinite (documented in the module docstrings); no epsilon is added to the features (only to the division denominator) to keep the estimator unbiased.
- Fully backward compatible — all new behavior is opt-in.