### PR TITLE
feat: add `nmn` discovery CLI + agent docs, refresh docs & dev experience

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,10 @@ repos:
     hooks:
       - id: isort
         files: ^(src|tests)/.*\.py$
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        # Configuration (max-line-length, ignores, per-file-ignores) lives in setup.cfg.
+        files: ^(src|tests)/.*\.py$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# AGENTS.md — NMN cheat sheet for coding agents
+
+Concise, accurate orientation for an agent working with the `nmn` package
+(Neural Matter Networks). For prose docs see [README.md](README.md),
+[docs/README.md](docs/README.md), and the per-framework guides under
+[docs/guides/](docs/guides/). For a machine-readable map see [llms.txt](llms.txt).
+
+## What NMN is
+
+`YatNMN` is a drop-in replacement for `Linear + activation`. The non-linearity is
+intrinsic: `y = (x·W)² / (||x − W||² + ε) · alpha`. The same layer family
+(`YatNMN`, YAT conv, YAT embedding, YAT multi-head attention) ships across six
+frameworks with numerically equivalent outputs. Current release: 0.3.2.
+
+## Pick a framework
+
+`nmn` (src layout, `src/nmn/`) has six independent backend subpackages. Each is a
+**separate optional install** — installing one does not install the others.
+
+| Framework  | Import root  | `pip install`  | When to choose |
+| ---------- | ------------ | -------------- | -------------- |
+| PyTorch    | `nmn.torch`  | `nmn[torch]`   | Most ergonomic API, broad GPU support |
+| Flax NNX   | `nmn.nnx`    | `nmn[nnx]`     | JAX speed + Pythonic API (recommended JAX entry point) |
+| Flax Linen | `nmn.linen`  | `nmn[linen]`   | Legacy Linen codebases |
+| Keras 3    | `nmn.keras`  | `nmn[keras]`   | Multi-backend Keras |
+| TensorFlow | `nmn.tf`     | `nmn[tf]`      | TF/SavedModel pipelines |
+| MLX        | `nmn.mlx`    | `nmn[mlx]`     | Apple Silicon, on-device |
+
+`pip install nmn[all]` pulls torch+nnx+keras+tf+linen (MLX is Apple-Silicon-only,
+install `nmn[mlx]` explicitly).
+
+## Exact imports + YatNMN signature (verify before you write code)
+
+The **size argument of `YatNMN` differs per backend** — this is the #1 gotcha:
+
+```python
+from nmn.torch import YatNMN     # YatNMN(in_features=128, out_features=64)
+from nmn.nnx   import YatNMN     # YatNMN(in_features=128, out_features=64, rngs=nnx.Rngs(0))
+from nmn.linen import YatNMN     # YatNMN(features=64)
+from nmn.keras import YatNMN     # YatNMN(units=64)        (also exported as YatDense)
+from nmn.tf    import YatNMN     # YatNMN(features=64)     (also exported as YatDense)
+from nmn.mlx   import YatNMN     # YatNMN(features=64)
+```
+
+Only the NNX backend requires `rngs=`. NNX uses dimension-generic names
+(`YatConv`, `Embed`, `MultiHeadAttention`) but also re-exports the cross-framework
+aliases (`YatConv2D`, `YatEmbed`, `MultiHeadYatAttention`) so code ports cleanly.
+
+Multi-head YAT attention:
+
+```python
+# torch / keras / tf / mlx
+from nmn.torch import MultiHeadYatAttention   # (embed_dim=256, num_heads=8)
+# nnx
+from nmn.nnx import MultiHeadAttention        # (num_heads=8, in_features=256, rngs=nnx.Rngs(0))
+```
+
+## Per-framework gotchas
+
+- **`YatNMN` size kwarg**: `in_features=/out_features=` (torch, nnx),
+  `features=` (linen, tf, mlx), `units=` (keras). Don't assume `in_features`
+  everywhere.
+- **NNX needs `rngs=`**: every NNX layer takes `rngs=nnx.Rngs(seed)`.
+- **Backends are independent optional installs**: never `import nmn.tf` unless TF
+  is installed. `import nmn` alone imports no ML framework. In this dev env
+  numpy, jax/flax, torch, and mlx are present; **TensorFlow is NOT installed**, so
+  `nmn.tf` / `nmn.keras` cannot be imported here.
+- **Keras also exports `YatDense`** (alias of `YatNMN`); MLX/TF do too.
+
+## MAY / RAY linear attention + lazy mode
+
+Bias-aware linear-attention feature maps are exported from **every** backend; the
+canonical kwargs are `bias=` and `epsilon=`:
+
+```python
+from nmn.nnx import (
+    create_maclaurin_projection, maclaurin_features, maclaurin_yat_attention,  # MAY
+    create_radial_projection,    radial_features,    radial_yat_attention,     # RAY
+)
+import jax, jax.numpy as jnp
+params = create_maclaurin_projection(jax.random.key(0), head_dim=64,
+                                     num_features=256, bias=1.0, epsilon=1e-5)
+out = maclaurin_yat_attention(q, k, v, params)   # q,k,v: [..., seq, heads, head_dim]
+```
+
+In NNX you can also select the feature map on the attention module via
+`performer_kind in {"slay", "maclaurin", "radial"}` together with
+`use_performer=True` (on `RotaryYatAttention`).
+
+**Lazy / frozen-kernel training** freezes ONLY the kernel (feature directions);
+bias, alpha, and the learnable epsilon stay trainable. Pass `lazy=True` (alias
+`freeze_kernel=True`) to `YatNMN` in any backend:
+
+```python
+from nmn.torch import YatNMN
+layer = YatNMN(in_features=128, out_features=64, lazy=True)   # weight.requires_grad = False
+# nnx / linen / tf / mlx: YatNMN(..., lazy=True)  — same semantics
+```
+
+## Discover the API from the shell
+
+Use the import-light `nmn` CLI (also `python -m nmn`) — it imports no ML
+framework, so it is safe and fast for agents:
+
+- `nmn` / `nmn info` — banner: version, the six frameworks, pip extras.
+- `nmn version` — version string only.
+- `nmn frameworks` — table of import line + `YatNMN` signature per framework.
+- `nmn guide <framework>` — self-contained quickstart (aliases: torch/pytorch,
+  tf/tensorflow, nnx/flax-nnx, linen/flax-linen, keras, mlx).
+- `nmn features` — MAY/RAY maps + lazy mode, with a NNX `performer_kind` snippet.
+- `nmn doctor` — per-backend import OK/missing + version; never raises.
+- `nmn examples` — runnable-example pointers + a NNX quickstart.
+
+Programmatic: `import nmn; nmn.help()` (== `nmn info`) and `nmn.doctor()`
+(== `nmn doctor`, returns `{framework: version_or_None}`). **Run `nmn doctor`
+first** to see which backends are importable in the current environment.
+
+## Run the tests
+
+```bash
+python3 -m pytest -q                 # whole suite
+python3 -m pytest -q -m "not slow"   # fast subset
+python3 -m pytest tests/test_torch -q # one backend: point pytest at its dir
+```
+
+Tests for a backend are skipped automatically when that framework is not
+installed, so a missing TensorFlow does not fail the run. To target a single
+backend, point pytest at its directory (`tests/test_torch`, `tests/test_nnx`,
+`tests/test_tf`, …) rather than a `-m` marker.
+
+## Rules for changes
+
+- Keep everything additive and backward compatible; don't break existing tests or
+  doc links.
+- Match each file's surrounding style.
+- Verify imports and constructor kwargs against the real code in `src/nmn/`
+  before writing them down.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,45 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [0.3.2] — 2026-06-09
 
 ### Added
+- **`nmn` command-line interface + `python -m nmn`** — a discovery/diagnostics CLI exposed via the `nmn` console script (and `python -m nmn`). It is import-light: importing the CLI does **not** import torch/jax/tf/mlx, so it stays fast and works even when no backend is installed. Commands:
+  - `nmn` / `nmn info` — banner with name, version, one-line description, the six frameworks with their pip extras (`nmn[torch]`, `nmn[nnx]`, `nmn[keras]`, `nmn[tf]`, `nmn[linen]`, `nmn[mlx]`), and a pointer to `nmn guide <framework>`.
+  - `nmn version` — prints the version string only.
+  - `nmn frameworks` — per-framework import line + the `YatNMN` constructor signature for that framework.
+  - `nmn guide <framework>` — self-contained quickstart (import + a small `YatNMN` MLP + a one-liner attention example) for `torch`/`pytorch`, `nnx`/`flax-nnx`, `linen`/`flax-linen`, `keras`, `tf`/`tensorflow`, `mlx` (aliases accepted).
+  - `nmn features` — concise usage of the MAY/RAY performer feature maps and lazy `YatNMN` mode, including a nnx `performer_kind` snippet.
+  - `nmn doctor` — reports import OK/missing + version for each of the six backends, plus the running Python and `nmn` version. Never raises on a missing backend.
+  - `nmn examples` — where to find runnable examples + a nnx quickstart, with a link to `EXAMPLES.md`.
+- **Programmatic helpers** `nmn.help()` and `nmn.doctor()` in `src/nmn/__init__.py` (kept import-light via lazy import). `nmn.help()` prints the `nmn info` banner; `nmn.doctor()` prints the `nmn doctor` report and returns a `{framework: version_str_or_None}` dict.
+- **Docs & developer-experience refresh** — updated `README.md` (CLI / discovery section, per-framework install extras), `CHANGELOG.md`, agent-oriented `llms.txt` / `AGENTS.md`, per-framework guides under `docs/guides/` (lazy-training notes + MAY/RAY/SLAY section), `EXAMPLES.md`, `docs/architecture.md`, `docs/migration.md`, plus `Makefile`, `.pre-commit-config.yaml`, and `CONTRIBUTING.md`.
+
+### Notes
+- Fully additive and backward compatible — no layer behavior changed in this release.
+
+---
+
+## [0.3.1] — 2026-06-08
+
+### Added
+- **Bias-aware linear-attention feature maps (MAY / RAY)** in **all six frameworks** (`nmn.torch`, `nmn.nnx`, `nmn.linen`, `nmn.keras`, `nmn.tf`, `nmn.mlx`). Linearized spherical-Yat attention approximates the kernel `κ(s) = (s + b)² / ((2 + ε) − 2s)` (with `s = q̂·k̂`) by a feature map `φ` so that `φ(q)·φ(k) ≈ κ`, giving **O(n)** attention.
+  - **MAY** (Random-Maclaurin, bias-aware): `create_maclaurin_projection`, `maclaurin_features`, `maclaurin_yat_attention` (+ `maclaurin_coeffs`).
+  - **RAY** (radial, sharp-`ε` route): `create_radial_projection`, `radial_features`, `radial_yat_attention`.
+  - Canonical kwargs `bias` and `epsilon`. MAY/RAY are bias-aware (`b > 0`), where the `b = 0` SLAY anchor cannot follow the learned per-head bias. Features are sign-indefinite — see the module docstrings for the caveat.
+  - On **Flax NNX**, the attention layer takes a selector `performer_kind="slay" | "maclaurin" | "radial"` (default `"slay"`).
+- **Lazy `YatNMN` training (freeze kernel)** in **all six frameworks** — `YatNMN(..., lazy=True)` (alias `freeze_kernel=True`) freezes **only the kernel** (feature directions) while keeping `bias`, `alpha`, and `epsilon` trainable. Each backend uses its idiomatic mechanism: NNX `FrozenParam` (excluded from `nnx.state(model, nnx.Param)`), torch `requires_grad=False`, mlx `freeze`, Keras/TF `trainable=False`, linen `stop_gradient`. Default is unchanged (`lazy=False`).
+- **GOAT value-only / projection-free YAT attention (MLX)** — `GoatYatAttention`, `goat_yat_attention`, `goat_yat_attention_weights` in `nmn.mlx`.
+
+### Notes
+- Backward compatible: new attention helpers and the `lazy`/`freeze_kernel` kwargs are additive; existing defaults and outputs are unchanged.
+
+---
+
+## [0.3.0] — 2026-05-14
+
+### Added
+- **MLX backend (Apple Silicon) — the sixth NMN framework** (`nmn.mlx`). Apple-Silicon-native YAT layers mirroring the `nmn.tf` / `nmn.keras` surface: `YatNMN` (alias `YatDense`, `features=`), `YatConv{1,2,3}D` / `YatConvTranspose{1,2,3}D`, `YatEmbed`, `MultiHeadYatAttention`, `RotaryYatAttention` (RoPE + KV cache), the Spherical-YAT-Performer (`create_yat_tp_projection` / `yat_tp_features` / `yat_tp_attention`), CIRCULAR/REFLECT/CAUSAL conv padding, a fused Metal-kernel YAT score (`fused_yat_score`, `is_gpu_available`), DropConnect + `weight_normalized` conv fast path, and the `softermax` / `softer_sigmoid` / `soft_tanh` squashers. Install with `nmn[mlx]`. MLX is wired into the cross-framework parity matrix and ships an MNIST example + framework guide.
 - **`learnable_epsilon` parameter** added to **every `YatNMN` and YAT conv layer in every framework**. When `True`, epsilon becomes a trainable parameter passed through softplus to guarantee strict positivity (it can never be zero or negative). The raw parameter is initialized via inverse softplus so that `softplus(param) ≈ epsilon`.
   - **Flax NNX**: `YatNMN`, `YatConv`, `YatConvTranspose`, `Embed`, `MultiHeadAttention`, `RotaryYatAttention`. The fused kernel path in NNX `YatNMN` is automatically disabled when epsilon is learnable to allow gradient flow.
   - **PyTorch**: `YatNMN`, `YatConv1D/2D/3D`, `YatConvTranspose1D/2D/3D`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Thanks for your interest in contributing to **Neural Matter Networks (NMN)**. Th
 - [Code of Conduct](#code-of-conduct)
 - [Where to Start](#where-to-start)
 - [Development Setup](#development-setup)
+- [Make Targets](#make-targets)
+- [The Optional-Dependency Model](#the-optional-dependency-model)
 - [Running Tests](#running-tests)
 - [Code Style](#code-style)
 - [Adding a New Layer](#adding-a-new-layer)
@@ -33,7 +35,7 @@ Good first contributions:
 - 📚 **Documentation** — typo fixes, clarifications, new examples, new guides under [`docs/`](docs/).
 - ✅ **Tests** — increasing coverage in `tests/test_*/`, adding edge cases, cross-framework consistency checks.
 - ⚡ **Examples** — new application examples under `src/nmn/<framework>/examples/`.
-- ✨ **New layers** — implementing parity for a layer that exists in one framework but not another (see the [Layer Support Matrix](README.md#-layer-support-matrix)).
+- ✨ **New layers** — implementing parity for a layer that exists in one framework but not another (see the [Layer Reference](README.md#layer-reference)).
 
 Larger work (new layer families, new framework backends, kernel optimizations) should start with an issue or [discussion](https://github.com/azettaai/nmn/discussions) so we can align on the design.
 
@@ -82,6 +84,69 @@ python -c "import nmn; print(nmn.__version__)"
 pytest tests/test_torch/ -v       # or whichever framework you installed
 ```
 
+You can also confirm the install with the bundled CLI:
+
+```bash
+nmn doctor        # reports which backends are importable + their versions
+nmn info          # banner with the six frameworks and their pip extras
+```
+
+### 5. (Optional) install the pre-commit hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+This wires up the hooks in [`.pre-commit-config.yaml`](.pre-commit-config.yaml) — **black**, **isort**, **flake8** (config in [`setup.cfg`](setup.cfg)), plus whitespace/merge-conflict checks — to run automatically on every commit. Run them across the whole tree at any time with `pre-commit run --all-files`.
+
+---
+
+## Make Targets
+
+A [`Makefile`](Makefile) wraps the common workflows. Every target invokes its tool through `python3 -m …`, so it works inside your virtualenv without globally-installed console scripts. Run `make help` (the default target) to see the full list.
+
+```bash
+make install        # editable install with dev extras (".[dev]")
+
+make test           # full test suite
+make test-fast      # skip slow tests (-m "not slow")
+make test-torch     # one backend's tests (also: -nnx, -linen, -keras, -tf, -mlx)
+
+make lint           # flake8 errors (E9,F63,F7,F82) + advisory style pass
+make format         # auto-format with black + isort
+make format-check   # check formatting without writing
+make typecheck      # mypy on the torch and nnx backends
+
+make build          # build sdist + wheel
+make docs           # where to find the documentation
+make clean          # remove build/test/cache artifacts
+```
+
+Override the interpreter when needed, e.g. `make PYTHON=python3.11 test-nnx`.
+
+---
+
+## The Optional-Dependency Model
+
+Each of the six framework backends — `nmn.torch`, `nmn.nnx`, `nmn.linen`, `nmn.keras`, `nmn.tf`, `nmn.mlx` — is an **independent optional install**. Installing `nmn` pulls in *no* heavyweight framework by default; you opt in via extras:
+
+| Extra | Installs | Backend(s) it enables |
+| --- | --- | --- |
+| `nmn[torch]` | torch, torchvision | `nmn.torch` |
+| `nmn[nnx]` | jax, jaxlib, flax | `nmn.nnx` |
+| `nmn[linen]` | jax, jaxlib, flax | `nmn.linen` |
+| `nmn[keras]` | tensorflow | `nmn.keras` |
+| `nmn[tf]` | tensorflow | `nmn.tf` |
+| `nmn[mlx]` | mlx (Apple Silicon) | `nmn.mlx` |
+
+Practical consequences for contributors:
+
+- **Only install the backends you touch.** A torch-only change needs `pip install -e ".[dev,torch]"`, and `make test-torch` will pass even with no other framework present.
+- **Never import a framework at top level in shared code.** Keep framework imports inside the relevant `nmn.<framework>` subpackage so that `import nmn` (and `nmn.cli`) stay import-light.
+- **`make test-mlx` only runs on Apple Silicon** (mlx is not available on other platforms); CI skips it accordingly.
+- Use `nmn doctor` to see exactly which backends are importable in your environment.
+
 ---
 
 ## Running Tests
@@ -95,10 +160,17 @@ tests/
 ├── test_tf/         TensorFlow
 ├── test_nnx/        Flax NNX (JAX)
 ├── test_linen/      Flax Linen (JAX)
+├── test_mlx/        MLX (Apple Silicon)
 ├── integration/     Cross-framework numerical consistency
 ├── benchmarks/      Performance benchmarks
 └── scripts/         One-off validation scripts
 ```
+
+The quickest way to run a backend's tests is the matching `make` target —
+`make test-torch`, `make test-nnx`, `make test-linen`, `make test-keras`,
+`make test-tf`, `make test-mlx` — or `make test` / `make test-fast` for the
+whole suite. The raw `pytest` invocations below are equivalent and handy when
+you need finer control.
 
 ### Common commands
 
@@ -136,7 +208,16 @@ Custom markers are declared in [`pyproject.toml`](pyproject.toml): `slow`, `inte
 
 ## Code Style
 
-Style is enforced by **black**, **isort**, **flake8**, and **mypy** — all configured in [`pyproject.toml`](pyproject.toml).
+Style is enforced by **black**, **isort**, **flake8**, and **mypy**. black/isort/mypy are configured in [`pyproject.toml`](pyproject.toml); flake8 is configured in [`setup.cfg`](setup.cfg). The simplest entry points are the `make` targets:
+
+```bash
+make format        # black + isort (writes changes)
+make format-check  # black + isort in --check mode
+make lint          # flake8 errors (must pass) + advisory style pass
+make typecheck     # mypy on the torch and nnx backends
+```
+
+The equivalent raw commands:
 
 ```bash
 # Format
@@ -166,7 +247,7 @@ CI fails only on **flake8 errors** (`E9,F63,F7,F82`) and test failures. Black/is
 
 ## Adding a New Layer
 
-Layers should reach **all 5 frameworks** before being considered complete. The recommended order:
+Layers should reach **all 6 frameworks** before being considered complete. The recommended order:
 
 1. **Reference implementation in Flax NNX** (`src/nmn/nnx/layers/`). NNX is the cleanest place to prototype because of explicit state.
 2. **PyTorch** (`src/nmn/torch/layers/` or top-level). Mirror parameter names where possible.
@@ -175,7 +256,7 @@ Layers should reach **all 5 frameworks** before being considered complete. The r
 5. **Cross-framework consistency test** in `tests/integration/`.
 6. **Per-framework unit tests** in `tests/test_<framework>/`.
 7. **Update**:
-   - [`README.md`](README.md) Layer Support Matrix
+   - [`README.md`](README.md) Layer reference
    - [`EXAMPLES.md`](EXAMPLES.md) with a usage snippet
    - [`CHANGELOG.md`](CHANGELOG.md) under the **Unreleased** section
    - Public `__init__.py` re-exports

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,6 +2,19 @@
 
 Comprehensive examples for using Neural Matter Networks across all supported frameworks.
 
+> **New to NMN?** Run the bundled CLI to discover what is installed and grab a
+> per-framework quickstart without leaving the terminal:
+>
+> ```bash
+> nmn                     # banner: version, the six frameworks + pip extras
+> nmn guide nnx           # self-contained Flax NNX quickstart
+> nmn features            # MAY / RAY performer maps + lazy YatNMN mode
+> nmn doctor              # which backends are importable, with versions
+> nmn examples            # pointer back to this file + nnx quickstart
+> ```
+>
+> Equivalently from Python: `import nmn; nmn.help(); nmn.doctor()`.
+
 ---
 
 ## Table of Contents
@@ -16,7 +29,6 @@ Comprehensive examples for using Neural Matter Networks across all supported fra
 - [Architecture Examples](#architecture-examples)
   - [Vision: CNN with Yat Layers](#vision-cnn-with-yat-layers)
   - [NLP: Transformer Block](#nlp-transformer-block-with-yat-attention)
-  - [Sequence: RNN Cells](#sequence-yat-rnn-cells)
 - [Advanced Usage](#advanced-usage)
   - [DropConnect Regularization](#dropconnect-regularization)
   - [Custom Squashing Functions](#custom-squashing-functions)
@@ -88,7 +100,7 @@ from nmn.keras.conv import YatConv1D, YatConv2D, YatConvTranspose2D
 # Dense Layer
 # ═══════════════════════════════════════════════════════════════
 dense = YatNMN(
-    features=64,
+    units=64,
     use_bias=True,
     use_alpha=True,
     epsilon=1e-5
@@ -119,8 +131,8 @@ model = keras.Sequential([
     YatConv2D(64, (3, 3), padding='same'),
     keras.layers.MaxPooling2D((2, 2)),
     keras.layers.Flatten(),
-    YatNMN(features=128),
-    YatNMN(features=10),
+    YatNMN(units=128),
+    YatNMN(units=10),
 ])
 
 model.compile(optimizer='adam', loss='categorical_crossentropy')
@@ -175,8 +187,7 @@ result = forward(tf.random.normal((16, 128)))
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from nmn.nnx.nmn import YatNMN
-from nmn.nnx.conv import YatConv, YatConvTranspose
+from nmn.nnx import YatNMN, YatConv, YatConvTranspose
 
 # ═══════════════════════════════════════════════════════════════
 # Dense Layer
@@ -396,8 +407,7 @@ Using Flax NNX for a transformer architecture:
 ```python
 from flax import nnx
 import jax.numpy as jnp
-from nmn.nnx.attention import MultiHeadAttention
-from nmn.nnx.nmn import YatNMN
+from nmn.nnx import MultiHeadAttention, YatNMN
 
 class YatTransformerBlock(nnx.Module):
     """
@@ -460,69 +470,6 @@ sequence = jnp.zeros((2, 100, 512))  # (batch, seq_len, dim)
 output = block(sequence)  # (2, 100, 512)
 ```
 
-### Sequence: Yat-RNN Cells
-
-Using Yat-based RNN cells:
-
-```python
-from flax import nnx
-import jax
-import jax.numpy as jnp
-from nmn.nnx.rnn import YatSimpleCell, YatLSTMCell, YatGRUCell
-
-# ═══════════════════════════════════════════════════════════════
-# Simple RNN Cell
-# ═══════════════════════════════════════════════════════════════
-simple_cell = YatSimpleCell(
-    in_features=64,
-    hidden_features=128,
-    rngs=nnx.Rngs(0)
-)
-
-# Initialize hidden state
-batch_size = 16
-carry = simple_cell.initialize_carry(jax.random.key(0), (batch_size,))
-
-# Process one timestep
-x_t = jnp.zeros((batch_size, 64))
-new_carry, output = simple_cell(carry, x_t)
-
-# ═══════════════════════════════════════════════════════════════
-# LSTM Cell
-# ═══════════════════════════════════════════════════════════════
-lstm_cell = YatLSTMCell(
-    in_features=64,
-    hidden_features=128,
-    rngs=nnx.Rngs(1)
-)
-
-# LSTM carry is (cell_state, hidden_state)
-lstm_carry = lstm_cell.initialize_carry(jax.random.key(1), (batch_size,))
-
-# Process sequence
-sequence = jnp.zeros((batch_size, 20, 64))  # (batch, time, features)
-outputs = []
-carry = lstm_carry
-
-for t in range(20):
-    carry, output = lstm_cell(carry, sequence[:, t, :])
-    outputs.append(output)
-
-final_output = jnp.stack(outputs, axis=1)  # (batch, time, hidden)
-
-# ═══════════════════════════════════════════════════════════════
-# GRU Cell
-# ═══════════════════════════════════════════════════════════════
-gru_cell = YatGRUCell(
-    in_features=64,
-    hidden_features=128,
-    rngs=nnx.Rngs(2)
-)
-
-gru_carry = gru_cell.initialize_carry(jax.random.key(2), (batch_size,))
-new_carry, output = gru_cell(gru_carry, x_t)
-```
-
 ---
 
 ## Advanced Usage
@@ -533,7 +480,7 @@ Weight-level dropout for regularization (Flax NNX only):
 
 ```python
 from flax import nnx
-from nmn.nnx.nmn import YatNMN
+from nmn.nnx import YatNMN
 import jax.numpy as jnp
 
 # Create layer with DropConnect
@@ -559,7 +506,7 @@ y_eval = layer(x, deterministic=True)
 Smooth alternatives to standard activations:
 
 ```python
-from nmn.nnx.squashers import softermax, softer_sigmoid, soft_tanh
+from nmn.nnx import softermax, softer_sigmoid, soft_tanh
 import jax.numpy as jnp
 
 x = jnp.array([1.0, 2.0, 3.0, 4.0])
@@ -592,7 +539,7 @@ Yat-based attention mechanism:
 
 ```python
 from flax import nnx
-from nmn.nnx.attention import MultiHeadAttention
+from nmn.nnx import MultiHeadAttention
 import jax.numpy as jnp
 
 # ═══════════════════════════════════════════════════════════════
@@ -631,7 +578,7 @@ output = cross_attn(queries, context)  # (2, 50, 512)
 **Rotary YAT Attention** — Combines RoPE with YAT attention for position-aware transformers:
 
 ```python
-from nmn.nnx.attention import RotaryYatAttention
+from nmn.nnx import RotaryYatAttention
 import jax.numpy as jnp
 from flax import nnx
 
@@ -640,7 +587,6 @@ rotary_attn = RotaryYatAttention(
     embed_dim=512,
     num_heads=8,
     max_seq_len=2048,      # Maximum sequence length
-    use_yat=True,          # Use YAT formula (set False for standard attention)
     constant_alpha=True,   # Use constant alpha scaling
     rngs=nnx.Rngs(0)
 )
@@ -653,15 +599,14 @@ output = rotary_attn(x)  # (2, 100, 512)
 **Performer Attention** — O(n) linear complexity using FAVOR+ approximation:
 
 ```python
-from nmn.nnx.attention import RotaryYatAttention
+from nmn.nnx import RotaryYatAttention
 
 # Enable Performer mode for long sequences
 performer_attn = RotaryYatAttention(
     embed_dim=512,
     num_heads=8,
-    use_performer=True,    # Enable linear complexity
-    num_features=256,      # Number of random features
-    use_yat=True,          # Combine Performer with YAT
+    use_performer=True,           # Enable linear complexity
+    performer_num_features=256,   # Number of random features
     rngs=nnx.Rngs(0)
 )
 
@@ -670,46 +615,126 @@ long_sequence = jnp.zeros((2, 10000, 512))  # 10K tokens
 output = performer_attn(long_sequence)  # Still runs in O(n) time
 ```
 
-### RNN Wrappers
+### MAY / RAY Linear Attention (Flax NNX)
 
-**RNN Wrapper** — Process sequences with any RNN cell:
+The 0.3.x line adds two **bias-aware** O(n) feature maps for spherical Yat
+attention. Both approximate the full spherical Yat kernel
 
-```python
-from nmn.nnx.rnn import YatLSTMCell, RNN, Bidirectional
-from flax import nnx
-import jax.numpy as jnp
-
-# Create cell
-cell = YatLSTMCell(hidden_dim=256, rngs=nnx.Rngs(0))
-
-# Wrap in RNN for automatic sequence processing
-rnn = RNN(cell, return_sequences=True)  # Returns all timesteps
-
-# Process batch of sequences
-sequences = jnp.zeros((16, 50, 128))  # (batch, time, features)
-outputs, final_state = rnn(sequences)
-# outputs: (16, 50, 256) — all hidden states
-# final_state: tuple of (cell_state, hidden_state)
-
-# Return only final output
-rnn_final = RNN(cell, return_sequences=False)
-final_output, final_state = rnn_final(sequences)
-# final_output: (16, 256) — only last hidden state
+```
+kappa(s) = (s + b)^2 / ((2 + eps) - 2 s)     # s = q̂·k̂ on unit vectors
 ```
 
-**Bidirectional RNN** — Process sequences in both directions:
+including the bias term `b`, where the older **SLAY** anchor map only models the
+`b = 0` case `s^2 / ((2 + eps) - 2 s)`. Pick the map with `performer_kind`:
+
+- `slay` — the bias-free anchor map (default).
+- `maclaurin` (**MAY**) — Random-Maclaurin features; bias-aware, best at `b ≥ 1`.
+- `radial` (**RAY**) — radial / Gauss-Laguerre features; bias-aware.
 
 ```python
-from nmn.nnx.rnn import Bidirectional, YatGRUCell
+import jax.numpy as jnp
+from flax import nnx
+from nmn.nnx import RotaryYatAttention
 
-# Create bidirectional cell
-gru_cell = YatGRUCell(hidden_dim=256, rngs=nnx.Rngs(0))
-bi_rnn = Bidirectional(gru_cell)
+# Selector lives on RotaryYatAttention; performer_num_features is the budget M.
+attn = RotaryYatAttention(
+    embed_dim=512,
+    num_heads=8,
+    use_performer=True,
+    performer_kind="maclaurin",     # "slay" | "maclaurin" | "radial"
+    performer_num_features=256,     # feature budget M
+    performer_bias=1.0,             # the spherical-Yat bias b
+    epsilon=1e-5,
+    rngs=nnx.Rngs(0),
+)
 
-# Processes sequences forward and backward, concatenates results
-sequences = jnp.zeros((16, 50, 128))
-bi_output = bi_rnn(sequences)
-# Output shape: (16, 50, 512) — 256*2 from both directions
+long_sequence = jnp.zeros((2, 8000, 512))  # (batch, seq_len, embed_dim)
+output = attn(long_sequence)               # (2, 8000, 512), O(n) time
+```
+
+You can also call the feature maps directly — handy for custom attention or for
+checking the unbiased-estimator guarantee `E[φ(q̂)·φ(k̂)] = kappa(q̂·k̂)`:
+
+```python
+import jax
+import jax.numpy as jnp
+from nmn.nnx import (
+    create_maclaurin_projection, maclaurin_features, maclaurin_yat_attention,
+    create_radial_projection, radial_features, radial_yat_attention,
+)
+
+key = jax.random.key(0)
+heads, head_dim = 8, 64
+q = jnp.zeros((2, 256, heads, head_dim))  # (batch, q_len, heads, head_dim)
+k = jnp.zeros((2, 256, heads, head_dim))
+v = jnp.zeros((2, 256, heads, head_dim))
+
+# MAY — Random Maclaurin
+may = create_maclaurin_projection(key, head_dim=head_dim, num_features=256,
+                                  bias=1.0, epsilon=1e-5)
+out_may = maclaurin_yat_attention(q, k, v, may, causal=False)  # (2, 256, 8, 64)
+
+# RAY — radial / Gauss-Laguerre
+ray = create_radial_projection(key, head_dim=head_dim, sketch_m=128,
+                               num_radial=8, radial_dim=64, bias=1.0, epsilon=1e-5)
+out_ray = radial_yat_attention(q, k, v, ray, causal=False)     # (2, 256, 8, 64)
+```
+
+> **Bias matters.** SLAY's `b = 0` map cannot produce a constant (degree-0)
+> feature, so it cannot attend diffusely. MAY/RAY carry `b`, so at `b ≥ 1` they
+> faithfully track the deployed Yat kernel where SLAY's approximation breaks
+> down. Set `epsilon` to the *median squared distance* between normalized q and
+> k for the regime these maps target (not the `1e-5` training default).
+> See [`docs/architecture.md` § Spherical Yat attention](docs/architecture.md#9-spherical-yat-attention-slay--may--ray).
+
+### Lazy Mode — Freeze the Kernel, Train Bias / α / ε
+
+`YatNMN(lazy=True)` (alias `freeze_kernel=True`) freezes **only the kernel**: the
+bias, the learnable α, and a learnable ε stay trainable. This is a cheap
+fine-tuning / probing regime — you adapt the cheap per-neuron scalars while the
+expensive prototype matrix stays fixed. It is fully backward compatible
+(`lazy=False` is the default).
+
+**Flax NNX** — the frozen kernel is excluded from `nnx.state(model, nnx.Param)`,
+so the optimizer never sees it:
+
+```python
+import jax, jax.numpy as jnp
+from flax import nnx
+from nmn.nnx import YatNMN
+
+layer = YatNMN(in_features=128, out_features=64, lazy=True, rngs=nnx.Rngs(0))
+
+# Only bias / alpha (and learnable epsilon, if enabled) are trainable —
+# the frozen kernel is a FrozenParam, excluded from nnx.state(..., nnx.Param).
+trainable = nnx.state(layer, nnx.Param)
+print([p[0] for p in jax.tree_util.tree_leaves_with_path(trainable)])  # no 'kernel'
+
+def loss_fn(model, x, y):
+    return jnp.mean((model(x) - y) ** 2)
+
+x = jnp.ones((32, 128)); y = jnp.zeros((32, 64))
+grads = nnx.grad(loss_fn)(layer, x, y)   # gradients only for alpha / bias
+# Feed `grads` to your optimizer (e.g. nnx.Optimizer / optax) — the kernel,
+# having no gradient, stays fixed across every training step.
+```
+
+**PyTorch** — the kernel's `requires_grad` is set to `False`; α and bias remain
+trainable, so a standard optimizer over `model.parameters()` skips the kernel:
+
+```python
+import torch
+from nmn.torch import YatNMN
+
+layer = YatNMN(in_features=128, out_features=64, lazy=True)  # or freeze_kernel=True
+for name, p in layer.named_parameters():
+    print(name, p.requires_grad)   # weight False, alpha True, bias True
+
+opt = torch.optim.Adam(p for p in layer.parameters() if p.requires_grad)
+x = torch.randn(32, 128)
+loss = layer(x).pow(2).mean()
+loss.backward()
+opt.step()                          # only alpha / bias move
 ```
 
 ---
@@ -816,24 +841,20 @@ from nmn.tf.conv import YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose
 # ═══════════════════════════════════════════════════════════════
 # Flax NNX (Most Feature-Complete)
 # ═══════════════════════════════════════════════════════════════
-from nmn.nnx.nmn import YatNMN
+from nmn.nnx import YatNMN
 
 # Convolutions
-from nmn.nnx.conv import YatConv
+from nmn.nnx import YatConv
 
 # Transposed Convolutions
-from nmn.nnx.conv import YatConvTranspose
+from nmn.nnx import YatConvTranspose
 
 # Attention Mechanisms
-from nmn.nnx.attention import MultiHeadAttention, RotaryYatAttention
-from nmn.nnx.attention import yat_attention, rotary_yat_attention
-
-# RNN Cells
-from nmn.nnx.rnn import YatSimpleCell, YatLSTMCell, YatGRUCell
-from nmn.nnx.rnn import RNN, Bidirectional
+from nmn.nnx import MultiHeadAttention, RotaryYatAttention
+from nmn.nnx import yat_attention, rotary_yat_attention
 
 # Custom Squashing Functions
-from nmn.nnx.squashers import softermax, softer_sigmoid, soft_tanh
+from nmn.nnx import softermax, softer_sigmoid, soft_tanh
 
 # ═══════════════════════════════════════════════════════════════
 # Flax Linen
@@ -864,6 +885,7 @@ from nmn.mlx import softermax, softer_sigmoid, soft_tanh
 
 ## Next Steps
 
+- Run `nmn` / `nmn guide <framework>` / `nmn features` to discover the API from the terminal
 - Check out the [README](README.md) for installation and core concepts
 - See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines
 - Browse the [examples/](examples/) directory for complete training scripts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,126 @@
+# NMN — developer task runner
+#
+# All targets invoke tools via `python3 -m <tool>` so they work inside a
+# virtualenv without relying on globally-installed console scripts. Install the
+# dev tooling first with `make install` (or `pip install -e ".[dev]"`).
+#
+# Run `make help` (the default target) to list everything.
+
+# Use the active interpreter; override with `make PYTHON=python3.11 <target>`.
+PYTHON ?= python3
+PIP    := $(PYTHON) -m pip
+
+# Source roots used by the linters / formatters / type checker.
+SRC  := src/nmn
+TEST := tests
+
+.DEFAULT_GOAL := help
+
+.PHONY: help install test test-fast \
+        test-torch test-nnx test-linen test-keras test-tf test-mlx \
+        lint format format-check typecheck build docs clean
+
+help: ## Show this help (default target)
+	@echo "NMN developer commands — usage: make <target>"
+	@echo ""
+	@echo "Setup"
+	@echo "  install        Editable install with dev extras ('.[dev]')"
+	@echo ""
+	@echo "Testing"
+	@echo "  test           Run the full test suite"
+	@echo "  test-fast      Run tests excluding slow ones (-m 'not slow')"
+	@echo "  test-torch     Run the PyTorch tests        (tests/test_torch/)"
+	@echo "  test-nnx       Run the Flax NNX tests        (tests/test_nnx/)"
+	@echo "  test-linen     Run the Flax Linen tests      (tests/test_linen/)"
+	@echo "  test-keras     Run the Keras tests           (tests/test_keras/)"
+	@echo "  test-tf        Run the TensorFlow tests      (tests/test_tf/)"
+	@echo "  test-mlx       Run the MLX tests             (tests/test_mlx/)"
+	@echo ""
+	@echo "Quality"
+	@echo "  lint           flake8 errors (E9,F63,F7,F82) + advisory style pass"
+	@echo "  format         Auto-format with black + isort"
+	@echo "  format-check   Check formatting without writing (black/isort --check)"
+	@echo "  typecheck      mypy on the torch and nnx backends"
+	@echo ""
+	@echo "Build & docs"
+	@echo "  build          Build the sdist + wheel (python -m build)"
+	@echo "  docs           Where to find the documentation"
+	@echo "  clean          Remove build/test/cache artifacts"
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+install: ## Editable install with dev extras
+	$(PIP) install -e ".[dev]"
+
+# ---------------------------------------------------------------------------
+# Testing
+#
+# Each backend is an independent optional install; only the matching extra has
+# to be present for its test target (e.g. `pip install -e ".[dev,torch]"`).
+# ---------------------------------------------------------------------------
+
+test: ## Run the full test suite
+	$(PYTHON) -m pytest $(TEST)
+
+test-fast: ## Run tests excluding slow ones
+	$(PYTHON) -m pytest $(TEST) -m "not slow"
+
+test-torch: ## PyTorch backend tests
+	$(PYTHON) -m pytest $(TEST)/test_torch/
+
+test-nnx: ## Flax NNX backend tests
+	$(PYTHON) -m pytest $(TEST)/test_nnx/
+
+test-linen: ## Flax Linen backend tests
+	$(PYTHON) -m pytest $(TEST)/test_linen/
+
+test-keras: ## Keras backend tests
+	$(PYTHON) -m pytest $(TEST)/test_keras/
+
+test-tf: ## TensorFlow backend tests
+	$(PYTHON) -m pytest $(TEST)/test_tf/
+
+test-mlx: ## MLX backend tests
+	$(PYTHON) -m pytest $(TEST)/test_mlx/
+
+# ---------------------------------------------------------------------------
+# Quality
+# ---------------------------------------------------------------------------
+
+# Mirrors CI: errors (E9,F63,F7,F82) fail the build; the wider style pass is
+# advisory (--exit-zero). flake8 reads its config from setup.cfg.
+lint: ## flake8 errors + advisory style pass
+	$(PYTHON) -m flake8 $(SRC) --count --select=E9,F63,F7,F82 --show-source --statistics
+	$(PYTHON) -m flake8 $(SRC) --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+format: ## Auto-format with black + isort
+	$(PYTHON) -m black $(SRC) $(TEST)
+	$(PYTHON) -m isort $(SRC) $(TEST)
+
+format-check: ## Check formatting without modifying files
+	$(PYTHON) -m black --check --diff $(SRC) $(TEST)
+	$(PYTHON) -m isort --check-only --diff $(SRC) $(TEST)
+
+typecheck: ## mypy on the torch and nnx backends
+	$(PYTHON) -m mypy $(SRC)/torch --ignore-missing-imports
+	$(PYTHON) -m mypy $(SRC)/nnx --ignore-missing-imports
+
+# ---------------------------------------------------------------------------
+# Build & docs
+# ---------------------------------------------------------------------------
+
+build: ## Build sdist + wheel
+	$(PYTHON) -m build
+
+docs: ## Pointer to the documentation
+	@echo "Guides live under docs/ — start with docs/README.md."
+	@echo "Per-framework guides: docs/guides/<framework>.md"
+	@echo "The docs website is built with Docusaurus under website/docusaurus/ (npm run start)."
+
+clean: ## Remove build/test/cache artifacts
+	rm -rf build/ dist/ htmlcov/ .coverage coverage.xml
+	rm -rf .pytest_cache/ .mypy_cache/
+	find . -type d -name '__pycache__' -prune -exec rm -rf {} +
+	find . -type d -name '*.egg-info' -prune -exec rm -rf {} +

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 - [What is NMN?](#what-is-nmn)
 - [Install](#install)
+- [CLI / discovery](#cli--discovery)
 - [60-second tour](#60-second-tour)
 - [Choose your framework](#choose-your-framework)
 - [Layer reference](#layer-reference)
@@ -86,6 +87,43 @@ pip install "nmn[all]"            # everything except MLX (Linux/Windows safe)
 **Requirements:** Python ≥ 3.10 (≥ 3.11 if you want JAX/Flax).
 
 > **GPU/TPU note:** install the GPU/TPU build of your framework *first* (see [PyTorch](https://pytorch.org/get-started/locally/) or [JAX](https://jax.readthedocs.io/en/latest/installation.html) install pages), then `pip install nmn`.
+
+---
+
+## CLI / discovery
+
+`pip install nmn` ships a small `nmn` command (also `python -m nmn`) for discovery and diagnostics. It is **import-light** — it never imports a deep-learning framework just to print help, so it's instant and works even before any backend is installed.
+
+```bash
+nmn                       # banner: version, the six backends + pip extras
+nmn frameworks            # import line + YatNMN signature per framework
+nmn guide nnx             # self-contained quickstart for one framework
+nmn guide pytorch         # aliases: torch/pytorch, tf/tensorflow, nnx/flax-nnx, linen/flax-linen, keras, mlx
+nmn features              # MAY/RAY performer maps + lazy YatNMN, incl. a nnx performer_kind snippet
+nmn examples             # where to find runnable examples + a nnx quickstart
+nmn version              # the version string only
+nmn doctor               # which of the six backends import OK (+ versions), Python and nmn version
+```
+
+`nmn doctor` reports each backend independently and never fails on a missing one, so it's the quickest way (for humans or coding agents) to see what's installed:
+
+```bash
+$ nmn doctor
+torch       ok        2.x.x
+nnx/linen   ok        jax 0.9.x / flax 0.12.x
+keras       missing   pip install "nmn[keras]"
+tf          missing   pip install "nmn[tf]"
+mlx         ok        0.x.x
+```
+
+The same content is available programmatically (both stay import-light):
+
+```python
+import nmn
+
+nmn.help()                # prints the `nmn info` banner
+status = nmn.doctor()     # prints the report AND returns {framework: version_str_or_None}
+```
 
 ---
 
@@ -148,8 +186,8 @@ from nmn.keras import YatNMN
 model = keras.Sequential([
     keras.layers.Input((28, 28)),
     keras.layers.Flatten(),
-    YatNMN(features=256),
-    YatNMN(features=128),
+    YatNMN(units=256),
+    YatNMN(units=128),
     keras.layers.Dense(10),
 ])
 print(model(keras.ops.ones((32, 28, 28))).shape)  # (32, 10)
@@ -205,7 +243,7 @@ print(model.apply(params, jnp.ones((32, 28, 28, 1))).shape)  # (32, 10)
 
 ## Choose your framework
 
-All five backends expose the same operations with framework-idiomatic naming. They are **numerically equivalent** (verified in `tests/integration/`).
+All six backends expose the same operations with framework-idiomatic naming. They are **numerically equivalent** (verified in `tests/integration/`).
 
 | Framework      | Pick it when…                                                                   | Guide                                          |
 | -------------- | ------------------------------------------------------------------------------- | ---------------------------------------------- |
@@ -214,21 +252,22 @@ All five backends expose the same operations with framework-idiomatic naming. Th
 | **Flax Linen** | You're maintaining a legacy Linen codebase.                                     | [docs/guides/flax-linen.md](docs/guides/flax-linen.md) |
 | **Keras 3**    | You want one API that runs on JAX, TF, *or* PyTorch backends.                  | [docs/guides/keras.md](docs/guides/keras.md)     |
 | **TensorFlow** | You need TF-specific deployment (SavedModel, TFLite, Serving).                 | [docs/guides/tensorflow.md](docs/guides/tensorflow.md) |
+| **MLX**        | You're on Apple Silicon and want native Metal acceleration.                    | [docs/guides/mlx.md](docs/guides/mlx.md)         |
 
 ---
 
 ## Layer reference
 
-All layers are available across **all 5 frameworks** with verified parity.
+All layers are available across **all 6 frameworks** with verified parity.
 
-| Operation                  | PyTorch                    | TF / Keras                 | Flax NNX                 | Flax Linen                 |
-| -------------------------- | -------------------------- | -------------------------- | ------------------------ | -------------------------- |
-| Dense                      | `YatNMN`                   | `YatNMN`                   | `YatNMN`                 | `YatNMN`                   |
-| Conv 1D / 2D / 3D          | `YatConv{1,2,3}D`          | `YatConv{1,2,3}D`          | `YatConv`                | `YatConv{1,2,3}D`          |
-| ConvTranspose 1D / 2D / 3D | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` | `YatConvTranspose`       | `YatConvTranspose{1,2,3}D` |
-| Multi-Head Attention       | `MultiHeadYatAttention`    | `MultiHeadYatAttention`    | `MultiHeadAttention`     | `MultiHeadAttention`       |
-| Embedding                  | `YatEmbed`                 | `YatEmbed`                 | `Embed`                  | `YatEmbed`                 |
-| Squashers                  | `softermax`, `softer_sigmoid`, `soft_tanh` | same                       | same                     | same                       |
+| Operation                  | PyTorch                    | TF / Keras                 | Flax NNX                 | Flax Linen                 | MLX                        |
+| -------------------------- | -------------------------- | -------------------------- | ------------------------ | -------------------------- | -------------------------- |
+| Dense                      | `YatNMN`                   | `YatNMN`                   | `YatNMN`                 | `YatNMN`                   | `YatNMN`                   |
+| Conv 1D / 2D / 3D          | `YatConv{1,2,3}D`          | `YatConv{1,2,3}D`          | `YatConv`                | `YatConv{1,2,3}D`          | `YatConv{1,2,3}D`          |
+| ConvTranspose 1D / 2D / 3D | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` | `YatConvTranspose`       | `YatConvTranspose{1,2,3}D` | `YatConvTranspose{1,2,3}D` |
+| Multi-Head Attention       | `MultiHeadYatAttention`    | `MultiHeadYatAttention`    | `MultiHeadAttention`     | `MultiHeadAttention`       | `MultiHeadYatAttention`    |
+| Embedding                  | `YatEmbed`                 | `YatEmbed`                 | `Embed`                  | `YatEmbed`                 | `YatEmbed`                 |
+| Squashers                  | `softermax`, `softer_sigmoid`, `soft_tanh` | same                       | same                     | same                       | same                       |
 
 **Flax NNX exclusives:**
 
@@ -353,7 +392,7 @@ CI matrix: Linux × Python {3.10, 3.11, 3.12} for all frameworks, plus macOS-3.1
 
 | Area                       | Status                                                              |
 | -------------------------- | ------------------------------------------------------------------- |
-| Core layers across 5 frameworks | ✅ Production-ready, on PyPI                                  |
+| Core layers across 6 frameworks | ✅ Production-ready, on PyPI                                  |
 | Cross-framework consistency tests | ✅ Verified < 1e-6 in fp32                                  |
 | Documentation               | ✅ Per-platform guides, architecture, migration                     |
 | ONNX export                | 🚧 Should work (standard ops) — not yet covered in CI ([TODO.md](TODO.md)) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the **Neural Matter Networks** documentation. This is the local-repo 
 | **Understand the math**                       | [Architecture & Theory](architecture.md)                    |
 | **Port an existing model**                   | [Migration Cheat Sheet](migration.md)                       |
 | **Pick the right framework**                 | [Framework comparison](#framework-comparison) below          |
+| **Discover the package from a terminal**     | Run `nmn` / `nmn guide <fw>` / `nmn features` / `nmn doctor`  |
 | **See code snippets per framework**          | [`EXAMPLES.md`](../EXAMPLES.md) at repo root                |
 | **Run a full training script**               | [`src/nmn/<framework>/examples/`](../src/nmn/)              |
 | **Contribute**                                | [`CONTRIBUTING.md`](../CONTRIBUTING.md)                     |
@@ -63,7 +64,21 @@ All layers are available across **all 6 frameworks**.
 
 - `RotaryYatAttention` — YAT + RoPE positional encoding
 - `MultiHeadAttention(use_performer=True)` — Spherical YAT-Performer, O(n) complexity
+- `RotaryYatAttention(use_performer=True, performer_kind=...)` — selects the
+  linear-attention feature map: `"slay"` (default, bias-free anchor), `"maclaurin"`
+  (**MAY**, bias-aware Random-Maclaurin), or `"radial"` (**RAY**, bias-aware radial
+  RFF). Functional API: `create_maclaurin_projection` / `maclaurin_yat_attention`
+  and `create_radial_projection` / `radial_yat_attention` (canonical kwargs
+  `bias`, `epsilon`). See the [Flax NNX guide](guides/flax-nnx.md#6-linear-attention-may--ray--slay).
 - Pallas fused / flash yat-attention kernel (TPU/GPU)
+
+**Lazy mode — freeze the kernel (all frameworks):** every `YatNMN` accepts
+`lazy=True` (alias `freeze_kernel=True`) to freeze **only** the kernel (its
+feature directions) while `bias`, `alpha`, and the learnable `epsilon` keep
+training. Each framework implements it idiomatically — `requires_grad=False`
+(torch), `trainable=False` (tf/keras), `FrozenParam` (nnx), `stop_gradient`
+(linen), `Module.freeze(keys=["kernel"])` (mlx). See each guide's "Lazy training
+(freeze kernel)" section.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,127 @@ This is why Yat networks often learn cleaner, more interpretable representations
 
 ---
 
+## 9. Spherical Yat attention: SLAY / MAY / RAY
+
+Quadratic Yat attention scores every query against every key — `O(n²)` in
+sequence length. For long sequences NMN provides **linear-attention feature
+maps**: a function `φ` such that `φ(q̂)·φ(k̂)` approximates the Yat score, which
+lets the `softmax`-free readout be reordered into `O(n)` work (the standard
+Performer / FAVOR+ associativity trick).
+
+### The spherical kernel
+
+On **unit vectors** (`‖q̂‖ = ‖k̂‖ = 1`, so `s = q̂·k̂ ∈ [-1, 1]`), the Yat score
+reduces to a one-variable kernel:
+
+$$
+\kappa(s) = \frac{(s + b)^2}{(2 + \varepsilon) - 2s}
+$$
+
+This is exactly the geometric reading from § 1 specialized to the sphere: the
+denominator `(2 + ε) − 2s` is `‖q̂ − k̂‖² + ε` (since `‖q̂‖² + ‖k̂‖² = 2`), and the
+numerator is the squared (biased) inner product. Here `b` is a **per-head bias**
+and `ε` is the Yat epsilon. The whole job of a feature map is to reproduce this
+`κ(s)` cheaply and unbiasedly.
+
+### Why bias matters
+
+The numerator `(s + b)²` expands to `s² + 2bs + b²`. The `b²` term is a
+**constant** in `s`: it lets the kernel assign a non-zero floor to *every*
+key, i.e. attend diffusely. A feature map that drops `b` (sets `b = 0`) collapses
+the numerator to `s²` and **cannot** represent that constant — it can only sharpen
+toward the most-aligned keys. In the deployment regime `b ≥ 1`, ignoring bias is
+a large, structural approximation error, not a small one.
+
+### The three feature maps
+
+| Map      | `performer_kind` | Kernel modelled            | Idea                                                                 |
+| -------- | ---------------- | -------------------------- | ------------------------------------------------------------------- |
+| **SLAY** | `"slay"`         | `s² / ((2+ε) − 2s)` (`b=0`) | Bias-free **anchor** map; the original spherical performer.         |
+| **MAY**  | `"maclaurin"`    | full `(s+b)² / ((2+ε)−2s)` | **Random Maclaurin**: bias-aware, with a degree-0 (constant) feature. |
+| **RAY**  | `"radial"`       | full `(s+b)² / ((2+ε)−2s)` | **Radial** Gauss-Laguerre RFF over the exponential-integral form.   |
+
+**SLAY (anchor, `b = 0`).** Approximates only `s²/((2+ε)−2s)`. It is the cheapest
+and the historical baseline, but it structurally cannot carry the bias term — so
+it cannot attend diffusely.
+
+**MAY (Random Maclaurin, bias-aware).** Expands `κ` as a power series in `s`. The
+base `1/((2+ε)−2s)` has all-positive coefficients `βₙ`; multiplying by `(s+b)²`
+shifts indices to `aₙ = β_{n-2} + 2b·β_{n-1} + b²·βₙ ≥ 0`. Per feature it draws a
+random degree `Nᵣ ~ Categorical(aₙ/Z)` and `Nᵣ` Rademacher vectors, forming a
+product of projections. **Degree-0 draws produce the constant feature** — exactly
+what encodes `b²` and lets MAY attend diffusely. It is an *unbiased* estimator:
+`E[φ(q̂)·φ(k̂)] = κ(q̂·k̂)`. At `b ≥ 1`, MAY clearly beats SLAY.
+
+**RAY (radial, bias-aware).** Augments `x̂` to `z = [x̂, √b]` (folding the bias in
+geometrically), takes a degree-2 sketch of the numerator, and approximates the
+radial `1/(ε + r²)` denominator with a Gauss-Laguerre quadrature of random Fourier
+features (using `1/(ε+r²) = ∫₀^∞ e^{−t(ε+r²)} dt`). Also bias-aware; trades a
+different cost/variance profile than MAY.
+
+### Sign-indefinite caveat
+
+MAY/RAY features can be negative (odd-degree products / Fourier features), so the
+linear-attention denominator can in principle go non-positive. The implementation
+adds a stabilizing `epsilon` **only to the denominator** — never to the features,
+which would bias the estimator. Empirically the maps are well-conditioned at
+`b > 0`.
+
+### Tuning note
+
+These maps target the **deployment** regime, so set `epsilon` to the *median
+squared distance* between normalized q and k for your data — **not** the `1e-5`
+training default. The feature budget (`performer_num_features` / `num_features`)
+trades cost for fidelity: more features raise `φ(q̂)·φ(k̂)` toward exact attention.
+
+```python
+from nmn.nnx import RotaryYatAttention
+attn = RotaryYatAttention(
+    embed_dim=512, num_heads=8,
+    use_performer=True, performer_kind="maclaurin",  # or "slay" / "radial"
+    performer_num_features=256, performer_bias=1.0, epsilon=1e-5,
+    rngs=nnx.Rngs(0),
+)
+```
+
+The standalone maps (`create_maclaurin_projection` / `maclaurin_features` /
+`maclaurin_yat_attention`, and the `radial_*` equivalents) are exported from
+`nmn.nnx` for custom attention layers. See
+[`EXAMPLES.md` § MAY / RAY Linear Attention](../EXAMPLES.md#may--ray-linear-attention-flax-nnx).
+
+---
+
+## 10. Lazy mode — freezing only the kernel
+
+`YatNMN(lazy=True)` (alias `freeze_kernel=True`) freezes **only the kernel
+matrix**; the per-neuron scalars — bias, the learnable α, and the learnable ε
+(when enabled) — stay trainable. Everything is backward compatible: `lazy=False`
+is the default and changes nothing.
+
+This separates the two kinds of capacity in a Yat layer:
+
+- the **kernel** holds the prototypes (the expensive `in×out` matrix), and
+- **α / bias / ε** are cheap per-output scalars that rescale and shift the
+  response distribution.
+
+Freezing the kernel and training only the scalars is a lightweight regime for:
+
+- **Fine-tuning / domain shift** — keep learned prototypes, re-calibrate the
+  response (α, bias) and the numerical floor (ε) for new data.
+- **Probing** — measure how much signal the frozen prototypes already carry.
+- **Cheap warm starts** — fewer trainable parameters, smaller optimizer state.
+
+The mechanism differs per framework but the semantics are identical:
+
+| Framework | Mechanism                                                                 |
+| --------- | ------------------------------------------------------------------------- |
+| Flax NNX  | kernel stored under a `FrozenParam` → excluded from `nnx.state(m, nnx.Param)`, so the optimizer/grad never see it. |
+| PyTorch   | kernel `weight.requires_grad = False`; α / bias keep `requires_grad = True`. |
+
+See [`EXAMPLES.md` § Lazy Mode](../EXAMPLES.md#lazy-mode--freeze-the-kernel-train-bias--α--ε) for runnable training snippets.
+
+---
+
 ## Further reading
 
 - [`docs/migration.md`](migration.md) — drop-in replacement cheat sheet

--- a/docs/guides/flax-linen.md
+++ b/docs/guides/flax-linen.md
@@ -171,7 +171,44 @@ ckpt.save("/tmp/yat_linen", state.params)
 
 ---
 
-## 7. Differences vs NNX
+## 7. Lazy training (freeze kernel)
+
+Pass `lazy=True` (alias: `freeze_kernel=True`) to freeze **only** the kernel.
+Linen parameters are functional — there is no per-variable "trainable" flag — so
+in lazy mode the kernel is read through `jax.lax.stop_gradient` inside
+`__call__`. No gradient flows into the kernel, while `bias`, `alpha`, and the
+learnable `epsilon` stay fully trainable. Default `lazy=False`, fully backward
+compatible.
+
+```python
+import jax, jax.numpy as jnp
+import flax.linen as nn
+from nmn.linen import YatNMN
+
+class FC(nn.Module):
+    @nn.compact
+    def __call__(self, x):
+        return YatNMN(features=64, lazy=True)(x)   # kernel frozen via stop_gradient
+
+m = FC()
+params = m.init(jax.random.PRNGKey(0), jnp.ones((32, 128)))
+grads = jax.grad(lambda p: m.apply(p, jnp.ones((32, 128))).sum())(params)
+# The 'kernel' leaf receives zero gradient; bias / alpha / epsilon update.
+```
+
+Because the kernel still lives in the `params` pytree, its leaf simply gets a
+zero gradient. For *true* exclusion from the optimizer state (so it is not even
+carried), pair `lazy=True` with an `optax.multi_transform` that routes the
+`kernel` leaf to `optax.set_to_zero()` — see the class docstring for the
+pattern. Use lazy mode for a fixed random/anchored feature basis where only the
+scale/shift/`epsilon` adapt.
+
+> CLI: `nmn guide flax-linen` prints the quickstart; `nmn features` summarizes
+> lazy mode and the MAY/RAY performer maps.
+
+---
+
+## 8. Differences vs NNX
 
 | Aspect              | Linen                                            | NNX                                                  |
 | ------------------- | ------------------------------------------------ | ---------------------------------------------------- |
@@ -184,7 +221,7 @@ If you're new, learn NNX. If you're maintaining a Linen codebase, `nmn.linen` sl
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 | Symptom                                  | Likely cause                                            | Fix                                                                |
 | ---------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
@@ -195,7 +232,7 @@ If you're new, learn NNX. If you're maintaining a Linen codebase, `nmn.linen` sl
 
 ---
 
-## 9. Next steps
+## 10. Next steps
 
 - [Flax NNX guide](flax-nnx.md) — recommended for new code
 - [Architecture & theory](../architecture.md)

--- a/docs/guides/flax-nnx.md
+++ b/docs/guides/flax-nnx.md
@@ -157,14 +157,14 @@ print(attn(x).shape)  # (4, 16, 512)
 ```python
 from nmn.nnx import RotaryYatAttention
 
-attn = RotaryYatAttention(num_heads=8, in_features=512, rngs=nnx.Rngs(0))
+attn = RotaryYatAttention(embed_dim=512, num_heads=8, rngs=nnx.Rngs(0))
 y = attn(x)
 ```
 
 ### c) Spherical YAT-Performer — O(n) linear attention
 
 ```python
-attn = MultiHeadAttention(num_heads=8, in_features=512,
+attn = RotaryYatAttention(embed_dim=512, num_heads=8,
                           use_performer=True, rngs=nnx.Rngs(0))
 y = attn(x)
 ```
@@ -176,7 +176,89 @@ For long-context training on TPU/GPU, NMN ships a fused yat-attention kernel (Pa
 
 ---
 
-## 6. Embeddings
+## 6. Linear attention: MAY / RAY / SLAY
+
+For long sequences the quadratic `O(n²)` Yat softmax is replaced by a
+**bias-aware feature decomposition** that runs in `O(n)`. NMN ships three
+performer feature maps, selected by `performer_kind` on `RotaryYatAttention`:
+
+| `performer_kind` | Name | Feature map | Bias `b` |
+| ---------------- | ---- | ----------- | -------- |
+| `"slay"` (default) | Spherical-anchor performer | anchor + PRF decomposition | `b = 0` anchor regime |
+| `"maclaurin"`      | **MAY** — Random-Maclaurin | unbiased Maclaurin expansion of the Yat kernel | bias-aware (`b > 0`) |
+| `"radial"`         | **RAY** — radial / Gauss-Laguerre RFF | degree-2 sketch × radial random features | bias-aware (`b > 0`) |
+
+SLAY's bias-free approximation degrades when the deployment bias `b > 0`; MAY
+and RAY carry the bias term `b` through the feature map, so they stay faithful
+in that regime.
+
+```python
+from nmn.nnx import RotaryYatAttention
+from flax import nnx
+import jax.numpy as jnp
+
+# Bias-aware linear attention via Random-Maclaurin (MAY):
+attn = RotaryYatAttention(
+    embed_dim=512, num_heads=8,
+    use_performer=True, performer_kind="maclaurin",
+    num_prf_features=8,         # M — feature budget per scale
+    num_quad_nodes=1,           # R — quadrature nodes
+    rngs=nnx.Rngs(0),
+)
+x = jnp.ones((4, 4096, 512))    # long sequence
+y = attn(x)
+print(y.shape)                  # (4, 4096, 512)
+
+# Radial variant (RAY): same call, performer_kind="radial".
+```
+
+### Functional API
+
+Both maps expose a precompute-then-apply pair, mirroring the SLAY
+`create_yat_tp_projection` style. Build the projection once, then attend:
+
+```python
+import jax, jax.numpy as jnp
+from nmn.nnx import (
+    create_maclaurin_projection, maclaurin_yat_attention,   # MAY
+    create_radial_projection, radial_yat_attention,         # RAY
+)
+
+key = jax.random.PRNGKey(0)
+head_dim = 64
+
+# MAY — Random-Maclaurin projection (fixed at construction, shared by q & k).
+params = create_maclaurin_projection(
+    key, head_dim,
+    num_features=256,   # M
+    bias=1.0,           # the deployment bias b (canonical kwarg)
+    epsilon=1e-5,       # Yat epsilon → C = 2 + epsilon
+)
+
+q = jnp.ones((2, 4096, 8, head_dim))   # [..., seq, heads, head_dim]
+k = jnp.ones((2, 4096, 8, head_dim))
+v = jnp.ones((2, 4096, 8, head_dim))
+out = maclaurin_yat_attention(q, k, v, params, causal=False)   # O(n)
+
+# RAY — radial projection. Feature dim = sketch_m * num_radial * radial_dim.
+rparams = create_radial_projection(
+    key, head_dim,
+    sketch_m=128, num_radial=8, radial_dim=64,
+    bias=1.0, epsilon=1e-5,
+)
+out_ray = radial_yat_attention(q, k, v, rparams, causal=True)   # causal decode
+```
+
+`create_maclaurin_projection` / `maclaurin_features` / `maclaurin_yat_attention`
+and the matching `radial_*` functions are all re-exported from `nmn.nnx`. The
+canonical kwargs are `bias` and `epsilon`. Run `nmn features` for the
+framework-agnostic summary, and see [Architecture & theory](../architecture.md)
+for the spherical kernel `kappa(s) = (s + b)² / ((2 + eps) − 2s)` these maps
+approximate.
+
+---
+
+## 7. Embeddings
 
 ```python
 from nmn.nnx import Embed
@@ -192,7 +274,7 @@ scores = embed.attend(h[0, -1]) # (10_000,) — retrieval scoring
 
 ---
 
-## 7. Saving & loading
+## 8. Saving & loading
 
 Use [Orbax checkpointing](https://orbax.readthedocs.io/), the JAX-recommended pattern:
 
@@ -211,7 +293,7 @@ nnx.update(model, restored)
 
 ---
 
-## 8. Sharding / distributed training
+## 9. Sharding / distributed training
 
 `YatNMN` and `YatConv` are plain `nnx.Module`s. They compose with:
 
@@ -223,7 +305,40 @@ See the TPU ResNet example for a worked pattern.
 
 ---
 
-## 9. Troubleshooting
+## 10. Lazy training (freeze kernel)
+
+Pass `lazy=True` (alias: `freeze_kernel=True`) to freeze **only** the kernel.
+In NNX the kernel is then stored under a `FrozenParam` (a non-`nnx.Param`
+variable), so it is naturally excluded from `nnx.state(model, nnx.Param)` — and
+therefore from the optimizer and gradients — while `bias`, `alpha`, and the
+learnable `epsilon` stay ordinary `nnx.Param`s (trainable). Default
+`lazy=False`, fully backward compatible.
+
+```python
+import jax.numpy as jnp
+from flax import nnx
+from nmn.nnx import YatNMN
+
+layer = YatNMN(in_features=128, out_features=64, lazy=True, rngs=nnx.Rngs(0))
+
+# Only the trainable Params are visited by grads / the optimizer; the frozen
+# kernel is not in nnx.state(layer, nnx.Param).
+trainable = nnx.state(layer, nnx.Param)
+print(layer.lazy, layer.freeze_kernel)   # True True
+print(layer(jnp.ones((8, 128))).shape)   # (8, 64)
+```
+
+Because the frozen kernel lives outside `nnx.Param`, an
+`nnx.Optimizer(model, tx)` built with the default `wrt=nnx.Param` filter never
+touches it — no manual masking needed. Use this for a fixed feature basis where
+only the scale/shift/`epsilon` adapt.
+
+> `lazy/freeze_kernel` is not supported together with `tie_kernel_bank` (a
+> shared kernel bank cannot be frozen per-instance) — it raises `ValueError`.
+
+---
+
+## 11. Troubleshooting
 
 | Symptom                                  | Likely cause                                            | Fix                                                                |
 | ---------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
@@ -235,7 +350,7 @@ See the TPU ResNet example for a worked pattern.
 
 ---
 
-## 10. Next steps
+## 12. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Flax Linen guide](flax-linen.md) — for legacy Linen codebases

--- a/docs/guides/keras.md
+++ b/docs/guides/keras.md
@@ -20,7 +20,7 @@ import keras
 from nmn.keras import YatNMN
 
 print(keras.__version__)
-layer = YatNMN(features=64)
+layer = YatNMN(units=64)
 print(layer(keras.ops.ones((32, 128))).shape)  # (32, 64)
 ```
 
@@ -42,7 +42,7 @@ from nmn.keras import YatNMN
 # fc = keras.layers.Dense(64, activation="relu")
 
 # After:
-fc = YatNMN(features=64)
+fc = YatNMN(units=64)
 
 x = keras.ops.ones((32, 128))
 print(fc(x).shape)  # (32, 64)
@@ -63,8 +63,8 @@ x_test  = x_test.astype("float32") / 255.0
 model = keras.Sequential([
     keras.layers.Input((28, 28)),
     keras.layers.Flatten(),
-    YatNMN(features=256),
-    YatNMN(features=128),
+    YatNMN(units=256),
+    YatNMN(units=128),
     keras.layers.Dense(10),
 ])
 
@@ -106,7 +106,7 @@ model = keras.Sequential([
     YatConv2D(filters=64, kernel_size=3, padding="same"),
     keras.layers.MaxPooling2D(),
     keras.layers.GlobalAveragePooling2D(),
-    YatNMN(features=64),
+    YatNMN(units=64),
     keras.layers.Dense(10),
 ])
 ```
@@ -119,7 +119,7 @@ model = keras.Sequential([
 from nmn.keras import MultiHeadYatAttention
 import keras
 
-attn = MultiHeadYatAttention(num_heads=8, key_dim=64)
+attn = MultiHeadYatAttention(embed_dim=512, num_heads=8)
 x = keras.ops.ones((4, 16, 512))
 y = attn(x, x)
 print(y.shape)  # (4, 16, 512)
@@ -150,7 +150,35 @@ restored = keras.models.load_model(
 
 ---
 
-## 7. Export & deployment
+## 7. Lazy training (freeze kernel)
+
+Pass `lazy=True` (alias: `freeze_kernel=True`) to freeze **only** the kernel.
+The kernel weight is created with `trainable=False`, so it never appears in
+`model.trainable_variables` and the optimizer leaves it untouched, while `bias`,
+`alpha`, and the learnable `epsilon` stay trainable. Default `lazy=False`, fully
+backward compatible.
+
+```python
+import keras
+from nmn.keras import YatNMN
+
+layer = YatNMN(units=64, lazy=True)
+_ = layer(keras.ops.ones((1, 128)))   # build() creates the (frozen) kernel
+
+# The frozen kernel is excluded from training entirely:
+print([w.name for w in layer.trainable_weights])  # no 'kernel'
+```
+
+`lazy` and `freeze_kernel` are round-tripped through `get_config()`, so a model
+with frozen-kernel layers reloads correctly via `custom_objects=` (see § 6). Use
+lazy mode for a fixed feature basis where only the scale/shift/`epsilon` learn.
+
+> CLI: `nmn guide keras` prints the quickstart; `nmn features` summarizes the
+> lazy mode and the MAY/RAY performer maps.
+
+---
+
+## 8. Export & deployment
 
 - **TensorFlow SavedModel**: `model.export("yat_model_savedmodel")`
 - **TFLite**: convert from SavedModel with `tf.lite.TFLiteConverter.from_saved_model(...)` — Yat layers use only standard TF ops and should convert cleanly. Not currently in CI; please report results.
@@ -158,18 +186,18 @@ restored = keras.models.load_model(
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 | Symptom                                | Likely cause                                       | Fix                                                            |
 | -------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
-| `NaN` in early training                 | `epsilon` too small                                | `YatNMN(features=..., epsilon=1e-3)`                            |
+| `NaN` in early training                 | `epsilon` too small                                | `YatNMN(units=..., epsilon=1e-3)`                              |
 | `ValueError` on model load              | Custom layers not registered                       | Pass `custom_objects=` (see § 6)                                |
 | Slow training on CPU                    | Keras backend defaulted to TF and op fallback      | Switch to JAX backend: `KERAS_BACKEND=jax`                      |
-| Shape mismatch in attention block       | Forgot `key_dim`                                   | `MultiHeadYatAttention(num_heads=8, key_dim=embed_dim // 8)`    |
+| Shape mismatch in attention block       | `embed_dim` not divisible by `num_heads`           | `MultiHeadYatAttention(embed_dim=512, num_heads=8)`            |
 
 ---
 
-## 9. Next steps
+## 10. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Migration cheat sheet](../migration.md)

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -295,7 +295,40 @@ for your custom modules.
 
 ---
 
-## 9. Fused metal-kernel forward (Apple GPU only)
+## 9. Lazy training (freeze kernel)
+
+Distinct from the lazy *build* in § 8 (which is about *when* parameters are
+created), `lazy=True` (alias: `freeze_kernel=True`) freezes **only** the kernel
+so the optimizer never updates it. It is implemented with mlx's idiomatic
+per-variable freeze, `Module.freeze(keys=["kernel"])` — not stop-gradient — so
+the kernel is excluded from `trainable_parameters()`, while `bias`, `alpha`, and
+the learnable `epsilon` stay trainable. Default `lazy=False`, fully backward
+compatible.
+
+```python
+import mlx.core as mx
+from nmn.mlx import YatNMN
+
+layer = YatNMN(features=64, lazy=True)
+_ = layer(mx.zeros((1, 128)))   # build the (frozen) kernel on first call
+
+# 'kernel' is absent from the trainable tree; bias/alpha/epsilon remain.
+import mlx.utils
+print([k for k, _ in mlx.utils.tree_flatten(layer.trainable_parameters())])
+```
+
+Because the frozen kernel is removed from `trainable_parameters()`,
+`nn.value_and_grad(model, loss_fn)` and `optimizer.update(model, grads)` skip it
+automatically — no manual masking. (You still need the §8 warm-up so the kernel
+*exists* before you wrap the model.) Use lazy mode for a fixed feature basis
+where only the scale/shift/`epsilon` adapt.
+
+> CLI: `nmn guide mlx` prints the quickstart; `nmn features` summarizes the lazy
+> mode and the MAY/RAY performer maps.
+
+---
+
+## 10. Fused metal-kernel forward (Apple GPU only)
 
 `YatNMN` ships an opt-in fused forward that computes
 `α · (x · Wᵀ + b)² / (‖x − W‖² + ε)` in a single Metal kernel launch
@@ -329,7 +362,7 @@ y = fused_yat_score(x, w, bias=b, alpha=mx.array([1.5]), epsilon=1e-5)
 
 ---
 
-## 10. DropConnect regularization
+## 11. DropConnect regularization
 
 `YatNMN`, `YatConv{1,2,3}D`, and `YatConvTranspose{1,2,3}D` all accept a
 weight-level DropConnect:
@@ -350,7 +383,7 @@ with DropConnect.
 
 ---
 
-## 11. Device & precision notes
+## 12. Device & precision notes
 
 - **Default device is the Metal GPU** on Apple Silicon. The first kernel
   launch incurs a small JIT cost; subsequent steps are fast.
@@ -365,7 +398,7 @@ with DropConnect.
 
 ---
 
-## 12. Troubleshooting
+## 13. Troubleshooting
 
 | Symptom                                  | Likely cause                                      | Fix                                                                |
 | ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
@@ -374,11 +407,11 @@ with DropConnect.
 | `ValueError: padding must have length …` | Mixed scalar/tuple padding spec                   | Use a single scalar or a tuple matching the conv ndim               |
 | Slow first step, fast after              | Metal kernel JIT                                  | Reuse the same Module across steps                                  |
 | 3-D conv slower than expected            | First call is uncached                            | Warm up with a dummy `(1, *spatial, C)` input before benchmarking   |
-| Tests assert tighter than ~1e-3 fail     | Comparing GPU output to CPU numpy reference       | Pin the run to `mx.cpu` for parity tests (see § 9)                  |
+| Tests assert tighter than ~1e-3 fail     | Comparing GPU output to CPU numpy reference       | Pin the run to `mx.cpu` for parity tests (see § 12)                 |
 
 ---
 
-## 13. Next steps
+## 14. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Migration cheat sheet](../migration.md) — switching from PyTorch / NNX / TF

--- a/docs/guides/pytorch.md
+++ b/docs/guides/pytorch.md
@@ -196,7 +196,38 @@ If you successfully export a non-trivial Yat model to ONNX, please open a PR add
 
 ---
 
-## 7. Distributed training
+## 7. Lazy training (freeze kernel)
+
+Pass `lazy=True` (alias: `freeze_kernel=True`) to freeze **only** the kernel —
+its feature directions. The `weight` tensor is created with
+`requires_grad_(False)` so it is excluded from gradients and the optimizer,
+while `bias`, `alpha`, and the learnable `epsilon` stay trainable. This is fully
+backward compatible (default `lazy=False`).
+
+```python
+import torch
+from nmn.torch import YatNMN
+
+# Frozen kernel; bias / alpha / epsilon still learn.
+layer = YatNMN(in_features=128, out_features=64, lazy=True)
+
+# The kernel does not appear among the parameters that receive gradients:
+trainable = [n for n, p in layer.named_parameters() if p.requires_grad]
+print(trainable)  # ['bias', 'alpha', ...] — no 'weight'
+```
+
+Because the frozen `weight` still requires no special handling, you can build a
+model out of `lazy=True` layers and hand `model.parameters()` straight to the
+optimizer — frozen kernels are skipped automatically. Use this when you want a
+fixed random/anchored feature basis (cheaper to train, often a strong baseline)
+but still want the scale (`alpha`), shift (`bias`), and `epsilon` to adapt.
+
+> CLI: `nmn guide pytorch` prints this quickstart; `nmn features` summarizes the
+> lazy mode and the MAY/RAY performer maps across frameworks.
+
+---
+
+## 8. Distributed training
 
 `YatNMN` and `YatConv*` are plain `nn.Module`s, so they work unchanged with:
 
@@ -207,7 +238,7 @@ If you successfully export a non-trivial Yat model to ONNX, please open a PR add
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 | Symptom                                       | Likely cause                                             | Fix                                                                          |
 | --------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------- |
@@ -219,7 +250,7 @@ If you successfully export a non-trivial Yat model to ONNX, please open a PR add
 
 ---
 
-## 9. Next steps
+## 10. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Migration cheat sheet](../migration.md)

--- a/docs/guides/tensorflow.md
+++ b/docs/guides/tensorflow.md
@@ -124,7 +124,7 @@ model = tf.keras.Sequential([
 from nmn.tf import MultiHeadYatAttention
 import tensorflow as tf
 
-attn = MultiHeadYatAttention(num_heads=8, key_dim=64)
+attn = MultiHeadYatAttention(embed_dim=512, num_heads=8)
 x = tf.ones((4, 16, 512))
 y = attn(x, x)
 print(y.shape)
@@ -183,18 +183,46 @@ with strategy.scope():
 
 ---
 
-## 8. Troubleshooting
+## 8. Lazy training (freeze kernel)
+
+Pass `lazy=True` (alias: `freeze_kernel=True`) to freeze **only** the kernel.
+The kernel `tf.Variable` is created with `trainable=False`, so it never shows up
+in `model.trainable_variables` and the optimizer never updates it, while
+`bias`, `alpha`, and the learnable `epsilon` stay trainable. Default
+`lazy=False`, fully backward compatible.
+
+```python
+import tensorflow as tf
+from nmn.tf import YatNMN
+
+layer = YatNMN(features=64, lazy=True)
+_ = layer(tf.zeros((1, 128)))   # builds the (frozen) kernel Variable
+
+# The frozen kernel is excluded from gradients/optimizer:
+print([v.name for v in layer.trainable_variables])  # no 'kernel'
+```
+
+In a `tf.GradientTape` step, `tape.gradient(loss, model.trainable_variables)`
+simply never sees the kernel — no masking required. Use lazy mode for a fixed
+feature basis where only the scale/shift/`epsilon` adapt.
+
+> CLI: `nmn guide tensorflow` prints the quickstart; `nmn features` summarizes
+> the lazy mode and the MAY/RAY performer maps.
+
+---
+
+## 9. Troubleshooting
 
 | Symptom                                | Likely cause                                  | Fix                                                                          |
 | -------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------- |
 | `NaN` in early steps                    | `epsilon` too small                           | `YatNMN(features=..., epsilon=1e-3)`                                          |
 | `tf.function` retraces every step       | Python-int args mixed with tensors            | Wrap input shapes; ensure `train_step` signature is consistent               |
-| Wrong shape on attention output         | `key_dim` missing                             | Pass `key_dim=embed_dim // num_heads` to `MultiHeadYatAttention`              |
+| Wrong shape on attention output         | `embed_dim` not divisible by `num_heads`      | `MultiHeadYatAttention(embed_dim=512, num_heads=8)`                           |
 | `SavedModel` reload fails                | Custom layer class not on import path         | Ensure `nmn.tf` is importable in the loading process                          |
 
 ---
 
-## 9. Next steps
+## 10. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Keras guide](keras.md) — usually a nicer API for new TF code

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -6,6 +6,10 @@ This page shows how to convert an existing model from standard `Linear/Conv + ac
 
 For the underlying math, see [`architecture.md`](architecture.md).
 
+> **Tip:** run `nmn guide <framework>` for a self-contained quickstart, or
+> `nmn features` for the MAY/RAY performer maps and the lazy `YatNMN` mode
+> covered below. `nmn doctor` tells you which backends are importable.
+
 ---
 
 ## Drop-in replacement table
@@ -261,6 +265,45 @@ YatNMN(in_features=..., out_features=..., epsilon=1e-3)  # bumped from 1e-5
 ```
 
 See [`architecture.md` § Numerical stability](architecture.md#3-numerical-stability) for the full guidance.
+
+### Long sequences → linear attention (Flax NNX)
+
+Migrating a Performer / linear-attention block? NMN ships **bias-aware** O(n)
+spherical-Yat feature maps. Select one with `performer_kind` on
+`RotaryYatAttention`:
+
+```python
+from nmn.nnx import RotaryYatAttention
+
+attn = RotaryYatAttention(
+    embed_dim=512, num_heads=8,
+    use_performer=True,
+    performer_kind="maclaurin",     # "slay" (b=0 anchor) | "maclaurin" (MAY) | "radial" (RAY)
+    performer_num_features=256,     # feature budget M
+    performer_bias=1.0,             # the spherical-Yat bias b
+    rngs=nnx.Rngs(0),
+)
+```
+
+The standalone maps (`create_maclaurin_projection` / `maclaurin_yat_attention`
+and the `radial_*` equivalents) are exported from `nmn.nnx`. See
+[`architecture.md` § Spherical Yat attention](architecture.md#9-spherical-yat-attention-slay--may--ray).
+
+### Fine-tuning → freeze only the kernel
+
+To adapt a pretrained Yat layer without retraining the prototype matrix, pass
+`lazy=True` (alias `freeze_kernel=True`). Only the kernel is frozen; bias, α and
+the learnable ε stay trainable. Backward compatible — `lazy=False` is the default.
+
+```python
+# Flax NNX — frozen kernel is excluded from nnx.state(model, nnx.Param)
+YatNMN(in_features=128, out_features=64, lazy=True, rngs=nnx.Rngs(0))
+
+# PyTorch — kernel weight.requires_grad = False; alpha / bias stay trainable
+YatNMN(in_features=128, out_features=64, lazy=True)
+```
+
+See [`architecture.md` § Lazy mode](architecture.md#10-lazy-mode--freezing-only-the-kernel).
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,65 @@
+# NMN — Neural Matter Networks
+
+> NMN is a drop-in replacement for `Linear + activation` and `Conv + activation`
+> blocks: the non-linearity is built into the layer via a geometric ratio
+> `y = (x·W)² / (||x − W||² + ε) · alpha`, so no ReLU/GELU/Sigmoid is needed. The
+> same `YatNMN` layer (plus YAT conv, embedding, and attention) ships across six
+> frameworks — PyTorch, Flax NNX, Flax Linen, Keras 3, TensorFlow, and MLX (Apple
+> Silicon) — with numerically equivalent outputs. Each backend is an independent
+> optional install (`pip install nmn[<framework>]`). Current release: 0.3.2.
+
+## Docs
+
+- [README](README.md): What NMN is, install matrix, 60-second tour, layer reference, the math.
+- [Docs index](docs/README.md): Local documentation entry point; framework comparison and links.
+- [Architecture & theory](docs/architecture.md): The YAT/spherical kernel, the three linear-attention feature maps (SLAY/MAY/RAY), why bias matters, and the lazy-mode regime.
+- [Migration cheat sheet](docs/migration.md): Porting existing `Linear`/`Conv`/attention models to YAT layers.
+- [Examples](EXAMPLES.md): Copy-paste snippets per framework, MAY/RAY linear attention, and YatNMN lazy-mode training.
+
+## Guides (one per framework)
+
+- [PyTorch](docs/guides/pytorch.md): `from nmn.torch import YatNMN` — `YatNMN(in_features=, out_features=)`.
+- [Flax NNX](docs/guides/flax-nnx.md): `from nmn.nnx import YatNMN` — `YatNMN(in_features=, out_features=, rngs=)`; recommended JAX entry point. Includes the MAY/RAY/SLAY `performer_kind` selector.
+- [Flax Linen](docs/guides/flax-linen.md): `from nmn.linen import YatNMN` — `YatNMN(features=)`.
+- [Keras 3](docs/guides/keras.md): `from nmn.keras import YatNMN` — `YatNMN(units=)` (also exported as `YatDense`).
+- [TensorFlow](docs/guides/tensorflow.md): `from nmn.tf import YatNMN` — `YatNMN(features=)`.
+- [MLX](docs/guides/mlx.md): `from nmn.mlx import YatNMN` — `YatNMN(features=)` (Apple Silicon).
+
+## Imports
+
+Import only the backend you have installed; importing `nmn` itself pulls in no ML
+framework. The `YatNMN` constructor's size argument differs per backend:
+
+- PyTorch — `from nmn.torch import YatNMN, YatConv2D, MultiHeadYatAttention, YatEmbed` → `YatNMN(in_features=128, out_features=64)`
+- Flax NNX — `from nmn.nnx import YatNMN, YatConv, MultiHeadAttention, Embed` → `YatNMN(in_features=128, out_features=64, rngs=nnx.Rngs(0))`
+- Flax Linen — `from nmn.linen import YatNMN, MultiHeadAttention, YatEmbed` → `YatNMN(features=64)`
+- Keras 3 — `from nmn.keras import YatNMN, MultiHeadYatAttention, YatEmbed` → `YatNMN(units=64)`
+- TensorFlow — `from nmn.tf import YatNMN, MultiHeadYatAttention, YatEmbed` → `YatNMN(features=64)`
+- MLX — `from nmn.mlx import YatNMN, MultiHeadYatAttention, YatEmbed` → `YatNMN(features=64)`
+
+Multi-head YAT attention is `MultiHeadYatAttention(embed_dim=, num_heads=, ...)`
+in torch/keras/tf/mlx; in NNX it is `MultiHeadAttention(num_heads=, in_features=,
+rngs=)` (also exported under the alias `MultiHeadYatAttention`).
+
+MAY/RAY bias-aware linear-attention feature maps are exported from every backend:
+`create_maclaurin_projection` / `maclaurin_features` / `maclaurin_yat_attention`
+(MAY) and `create_radial_projection` / `radial_features` / `radial_yat_attention`
+(RAY); the canonical kwargs are `bias=` and `epsilon=`. Lazy / frozen-kernel
+training is `YatNMN(..., lazy=True)` (alias `freeze_kernel=True`), which freezes
+ONLY the kernel — bias, alpha, and a learnable epsilon stay trainable.
+
+## CLI
+
+The `nmn` console command (also `python -m nmn`) helps agents discover the API
+without importing any ML framework:
+
+- `nmn` / `nmn info` — banner with version, the six frameworks, and pip extras.
+- `nmn version` — the version string only.
+- `nmn frameworks` — table of each framework's import line + `YatNMN` signature.
+- `nmn guide <framework>` — self-contained quickstart (import + small YatNMN MLP + attention one-liner). Aliases: torch/pytorch, tf/tensorflow, nnx/flax-nnx, linen/flax-linen, keras, mlx.
+- `nmn features` — MAY/RAY performer maps and YatNMN lazy mode, with a NNX `performer_kind` snippet.
+- `nmn doctor` — reports import OK/missing + version for each backend; never raises on a missing one.
+- `nmn examples` — where to find runnable examples + a NNX quickstart, linking [EXAMPLES.md](EXAMPLES.md).
+
+Programmatic equivalents: `nmn.help()` (same as `nmn info`) and `nmn.doctor()`
+(same as `nmn doctor`, returns `{framework: version_or_None}`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 "Homepage" = "https://github.com/azettaai/nmn"
 "Bug Tracker" = "https://github.com/azettaai/nmn/issues"
 
+[project.scripts]
+nmn = "nmn.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0.0",

--- a/src/nmn/__init__.py
+++ b/src/nmn/__init__.py
@@ -5,17 +5,45 @@ try:
 except ImportError:
     __version__ = "0.0.0.dev0"
 
+
+def help() -> None:
+    """Print the ``nmn info`` banner (version, frameworks, pointers).
+
+    Import-light: ``nmn.cli`` is imported lazily so importing ``nmn`` does not
+    pull in any framework.
+    """
+    from nmn import cli
+
+    print(cli._render_info())
+
+
+def doctor():
+    """Print the ``nmn doctor`` report and return ``{framework: version_or_None}``.
+
+    Import-light: ``nmn.cli`` is imported lazily.
+    """
+    from nmn import cli
+
+    print(cli._render_doctor())
+    return cli._doctor_report()
+
+
 __all__ = [
     "__version__",
+    # Discovery / diagnostics helpers (mirror the `nmn` CLI):
+    "help",
+    "doctor",
     # Framework subpackages — import the one you need:
     #   from nmn.torch import YatNMN, YatConv2D, ...
     #   from nmn.nnx import YatNMN, YatConv, ...
     #   from nmn.keras import YatNMN, YatConv2D, ...
     #   from nmn.tf import YatNMN, YatConv2D, ...
     #   from nmn.linen import YatNMN, YatConv2D, ...
+    #   from nmn.mlx import YatNMN, YatConv2D, ...
     "torch",
     "nnx",
     "keras",
     "tf",
     "linen",
+    "mlx",
 ]

--- a/src/nmn/__main__.py
+++ b/src/nmn/__main__.py
@@ -1,0 +1,8 @@
+"""Enable ``python -m nmn`` to run the CLI."""
+
+from __future__ import annotations
+
+from nmn.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nmn/cli.py
+++ b/src/nmn/cli.py
@@ -1,0 +1,446 @@
+"""Command-line interface for Neural-Matter Network (NMN).
+
+This module is deliberately *import-light*: importing ``nmn.cli`` must NOT
+import any heavy framework (torch / jax / flax / tensorflow / keras / mlx).
+Only the :func:`doctor` command attempts framework imports, each guarded in a
+``try``/``except`` so a missing backend never raises.
+
+Entry points::
+
+    nmn               # console script (see [project.scripts])
+    python -m nmn     # via src/nmn/__main__.py
+
+All output is plain text (no color dependencies) so it stays readable in a
+terminal and greppable by coding agents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import platform
+import sys
+from typing import Dict, List, Optional
+
+# ---------------------------------------------------------------------------
+# Static metadata (kept here so the CLI needs no heavy imports)
+# ---------------------------------------------------------------------------
+
+DESCRIPTION = (
+    "Neural-Matter Network (NMN) - YAT neural network layers and attention "
+    "for six frameworks."
+)
+
+ONLINE_GUIDES = "https://github.com/azettaai/nmn/tree/master/docs/guides"
+ONLINE_EXAMPLES = "https://github.com/azettaai/nmn/blob/master/EXAMPLES.md"
+
+# Canonical framework order. Each entry: pip extra, import line, the YatNMN
+# constructor signature for that framework, and the doctor probe module(s).
+FRAMEWORKS = {
+    "torch": {
+        "extra": "nmn[torch]",
+        "label": "PyTorch",
+        "import": "from nmn.torch import YatNMN",
+        "ctor": "YatNMN(in_features=128, out_features=256)",
+        "probes": ["torch"],
+    },
+    "nnx": {
+        "extra": "nmn[nnx]",
+        "label": "Flax NNX",
+        "import": "from nmn.nnx import YatNMN",
+        "ctor": "YatNMN(in_features=128, out_features=256, rngs=nnx.Rngs(0))",
+        "probes": ["jax", "flax"],
+    },
+    "linen": {
+        "extra": "nmn[linen]",
+        "label": "Flax Linen",
+        "import": "from nmn.linen import YatNMN",
+        "ctor": "YatNMN(features=256)",
+        "probes": ["jax", "flax"],
+    },
+    "keras": {
+        "extra": "nmn[keras]",
+        "label": "Keras",
+        "import": "from nmn.keras import YatNMN",
+        "ctor": "YatNMN(units=256)",
+        "probes": ["keras"],
+    },
+    "tf": {
+        "extra": "nmn[tf]",
+        "label": "TensorFlow",
+        "import": "from nmn.tf import YatNMN",
+        "ctor": "YatNMN(features=256)",
+        "probes": ["tensorflow"],
+    },
+    "mlx": {
+        "extra": "nmn[mlx]",
+        "label": "MLX (Apple Silicon)",
+        "import": "from nmn.mlx import YatNMN",
+        "ctor": "YatNMN(features=256)",
+        # mlx exposes __version__ on mlx.core, not the top-level package.
+        "probes": ["mlx.core"],
+    },
+}
+
+# Aliases accepted by `nmn guide <framework>`.
+_ALIASES = {
+    "torch": "torch",
+    "pytorch": "torch",
+    "nnx": "nnx",
+    "flax-nnx": "nnx",
+    "flax_nnx": "nnx",
+    "linen": "linen",
+    "flax-linen": "linen",
+    "flax_linen": "linen",
+    "keras": "keras",
+    "tf": "tf",
+    "tensorflow": "tf",
+    "mlx": "mlx",
+}
+
+
+def _version() -> str:
+    """Return the installed nmn version string (import-light)."""
+    try:
+        from nmn import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover - defensive
+        return "0.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Embedded per-framework quickstarts (must NOT read docs/ — not shipped in wheel)
+# ---------------------------------------------------------------------------
+
+_GUIDES = {
+    "torch": """\
+NMN quickstart — PyTorch  (pip install nmn[torch])
+
+    import torch
+    from nmn.torch import YatNMN
+
+    # A small YAT MLP: each YatNMN layer computes
+    #   y = (x . W)^2 / (||x - W||^2 + epsilon) * alpha
+    mlp = torch.nn.Sequential(
+        YatNMN(in_features=64, out_features=128),
+        YatNMN(in_features=128, out_features=10),
+    )
+    y = mlp(torch.randn(8, 64))            # -> (8, 10)
+
+    # Attention (one-liner):
+    from nmn.torch import MultiHeadYatAttention
+    attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+
+Full guide: {guides}/pytorch.md
+""",
+    "nnx": """\
+NMN quickstart — Flax NNX  (pip install nmn[nnx])
+
+    import jax.numpy as jnp
+    from flax import nnx
+    from nmn.nnx import YatNMN, MultiHeadAttention
+
+    rngs = nnx.Rngs(0)
+
+    # A small YAT MLP (nnx needs in_features/out_features and rngs):
+    layer1 = YatNMN(in_features=64, out_features=128, rngs=rngs)
+    layer2 = YatNMN(in_features=128, out_features=10, rngs=rngs)
+    x = jnp.ones((8, 64))
+    y = layer2(layer1(x))                  # -> (8, 10)
+
+    # Attention (one-liner):
+    attn = MultiHeadAttention(num_heads=8, in_features=128, rngs=rngs)
+
+Full guide: {guides}/flax-nnx.md
+""",
+    "linen": """\
+NMN quickstart — Flax Linen  (pip install nmn[linen])
+
+    import jax, jax.numpy as jnp
+    from nmn.linen import YatNMN, MultiHeadAttention
+
+    # Linen uses `features=` and lazy params (no rngs in the constructor):
+    model = YatNMN(features=128)
+    x = jnp.ones((8, 64))
+    params = model.init(jax.random.PRNGKey(0), x)
+    y = model.apply(params, x)             # -> (8, 128)
+
+    # Attention (one-liner):
+    attn = MultiHeadAttention(num_heads=8, qkv_features=128, out_features=128)
+
+Full guide: {guides}/flax-linen.md
+""",
+    "keras": """\
+NMN quickstart — Keras  (pip install nmn[keras])
+
+    import keras
+    from nmn.keras import YatNMN, MultiHeadYatAttention
+
+    # Keras uses `units=` like keras.layers.Dense:
+    model = keras.Sequential([
+        YatNMN(units=128),
+        YatNMN(units=10),
+    ])
+    # model.build(input_shape=(None, 64))
+
+    # Attention (one-liner):
+    attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+
+Full guide: {guides}/keras.md
+""",
+    "tf": """\
+NMN quickstart — TensorFlow  (pip install nmn[tf])
+
+    import tensorflow as tf
+    from nmn.tf import YatNMN, MultiHeadYatAttention
+
+    # The tf backend uses `features=`:
+    layer1 = YatNMN(features=128)
+    layer2 = YatNMN(features=10)
+    x = tf.ones((8, 64))
+    y = layer2(layer1(x))                  # -> (8, 10)
+
+    # Attention (one-liner):
+    attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+
+Full guide: {guides}/tensorflow.md
+""",
+    "mlx": """\
+NMN quickstart — MLX (Apple Silicon)  (pip install nmn[mlx])
+
+    import mlx.core as mx
+    from nmn.mlx import YatNMN, MultiHeadYatAttention
+
+    # The mlx backend uses `features=`:
+    layer1 = YatNMN(features=128)
+    layer2 = YatNMN(features=10)
+    x = mx.ones((8, 64))
+    y = layer2(layer1(x))                  # -> (8, 10)
+
+    # Attention (one-liner):
+    attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+
+Full guide: {guides}/mlx.md
+""",
+}
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+def _render_info() -> str:
+    lines: List[str] = []
+    lines.append(f"nmn {_version()}")
+    lines.append(DESCRIPTION)
+    lines.append("")
+    lines.append("Frameworks (install only the one you need):")
+    for key, meta in FRAMEWORKS.items():
+        lines.append(
+            f"  {key:<6} {meta['label']:<20} pip install {meta['extra']}"
+        )
+    lines.append("")
+    lines.append("Get a self-contained quickstart for a framework with:")
+    lines.append("  nmn guide <framework>      e.g. nmn guide torch")
+    lines.append("")
+    lines.append("Other commands: version, frameworks, features, doctor, examples")
+    return "\n".join(lines)
+
+
+def _render_frameworks() -> str:
+    lines: List[str] = []
+    lines.append("Framework import lines and YatNMN constructor signatures:")
+    lines.append("")
+    for key, meta in FRAMEWORKS.items():
+        lines.append(f"{key} ({meta['label']}) — pip install {meta['extra']}")
+        lines.append(f"  import: {meta['import']}")
+        lines.append(f"  ctor:   {meta['ctor']}")
+        lines.append("")
+    lines.append(
+        "Note: each backend is an independent optional install; importing one "
+        "never pulls in another."
+    )
+    return "\n".join(lines)
+
+
+def _render_guide(name: str) -> Optional[str]:
+    canonical = _ALIASES.get(name.lower())
+    if canonical is None:
+        return None
+    return _GUIDES[canonical].format(guides=ONLINE_GUIDES)
+
+
+def _render_features() -> str:
+    return """\
+NMN performer feature maps (MAY / RAY / SLAY) and lazy YatNMN
+
+Linear-attention feature maps approximate the spherical YAT kernel
+    kappa(s) = (s + b)^2 / ((2 + epsilon) - 2s)
+so attention runs in O(n) instead of O(n^2). Three variants:
+  - SLAY   : bias-free anchor (b = 0)
+  - MAY    : Random-Maclaurin, bias-aware (faithful for b > 0)
+  - RAY    : radial / quadrature, bias-aware
+
+Framework-agnostic API (present in nnx / linen / keras / tf / torch / mlx):
+
+    from nmn.nnx import (              # same names in other backends
+        create_maclaurin_projection, maclaurin_features, maclaurin_yat_attention,
+        create_radial_projection,    radial_features,    radial_yat_attention,
+    )
+
+    import jax
+    params = create_maclaurin_projection(
+        jax.random.PRNGKey(0), head_dim=64, num_features=256,
+        bias=1.0, epsilon=1e-5,      # canonical kwargs: bias, epsilon
+    )
+    out = maclaurin_yat_attention(q, k, v, params)   # q,k,v: [..., L, H, D]
+
+nnx attention selector — pick the feature map with `performer_kind`:
+
+    from nmn.nnx import RotaryYatAttention
+    attn = RotaryYatAttention(
+        embed_dim=128, num_heads=8,
+        use_performer=True,
+        performer_kind="maclaurin",  # one of: slay, maclaurin, radial
+        rngs=nnx.Rngs(0),
+    )
+
+Lazy YatNMN (freeze ONLY the kernel; bias / alpha / epsilon stay trainable):
+
+    YatNMN(..., lazy=True)           # alias: freeze_kernel=True
+"""
+
+
+def _doctor_report() -> Dict[str, Optional[str]]:
+    """Probe each backend; return {framework: version_or_None}. Never raises."""
+    result: Dict[str, Optional[str]] = {}
+    for key, meta in FRAMEWORKS.items():
+        version: Optional[str] = None
+        ok = True
+        for mod_name in meta["probes"]:
+            try:
+                mod = importlib.import_module(mod_name)
+                version = getattr(mod, "__version__", "unknown")
+            except Exception:
+                ok = False
+                version = None
+                break
+        result[key] = version if ok else None
+    return result
+
+
+def _render_doctor() -> str:
+    report = _doctor_report()
+    lines: List[str] = []
+    lines.append(f"nmn {_version()}")
+    lines.append(f"Python {platform.python_version()} ({sys.executable})")
+    lines.append("")
+    lines.append("Backend import check:")
+    for key, meta in FRAMEWORKS.items():
+        version = report[key]
+        if version is None:
+            status = f"MISSING  (pip install {meta['extra']})"
+        else:
+            status = f"OK       version {version}"
+        lines.append(f"  {key:<6} {meta['label']:<20} {status}")
+    return "\n".join(lines)
+
+
+def _render_examples() -> str:
+    return f"""\
+NMN examples
+
+Runnable examples live alongside each backend in the source tree:
+  src/nmn/<framework>/examples/   (torch, nnx, linen, keras, tf, mlx)
+A curated walkthrough is in EXAMPLES.md:
+  {ONLINE_EXAMPLES}
+
+Quickstart for the most popular backend (Flax NNX):
+
+    import jax.numpy as jnp
+    from flax import nnx
+    from nmn.nnx import YatNMN
+
+    rngs = nnx.Rngs(0)
+    layer = YatNMN(in_features=64, out_features=128, rngs=rngs)
+    y = layer(jnp.ones((8, 64)))          # -> (8, 128)
+
+For a per-framework quickstart run:  nmn guide <framework>
+"""
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="nmn",
+        description=DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("info", help="banner: version, frameworks, pointers")
+    sub.add_parser("version", help="print the version string only")
+    sub.add_parser("frameworks", help="import lines + YatNMN constructor signatures")
+
+    guide = sub.add_parser("guide", help="self-contained quickstart for a framework")
+    guide.add_argument(
+        "framework",
+        help="one of: torch/pytorch, nnx/flax-nnx, linen/flax-linen, keras, "
+        "tf/tensorflow, mlx",
+    )
+
+    sub.add_parser("features", help="MAY/RAY performer maps + lazy YatNMN usage")
+    sub.add_parser("doctor", help="report which backends import + their versions")
+    sub.add_parser("examples", help="where to find runnable examples")
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point. Returns a process exit code (0 on success)."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    command = args.command or "info"
+
+    if command in ("info",):
+        print(_render_info())
+        return 0
+    if command == "version":
+        print(_version())
+        return 0
+    if command == "frameworks":
+        print(_render_frameworks())
+        return 0
+    if command == "guide":
+        text = _render_guide(args.framework)
+        if text is None:
+            valid = ", ".join(sorted(set(_ALIASES)))
+            print(
+                f"Unknown framework {args.framework!r}. Valid choices: {valid}",
+                file=sys.stderr,
+            )
+            return 2
+        print(text)
+        return 0
+    if command == "features":
+        print(_render_features())
+        return 0
+    if command == "doctor":
+        print(_render_doctor())
+        return 0
+    if command == "examples":
+        print(_render_examples())
+        return 0
+
+    # Should be unreachable (argparse rejects unknown subcommands with exit 2).
+    parser.print_help(sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -394,7 +394,7 @@ class RotaryYatAttention(Module):
 
     Example:
         >>> from flax import nnx
-        >>> from nmn.nnx.attention import RotaryYatAttention
+        >>> from nmn.nnx import RotaryYatAttention
         >>>
         >>> rngs = nnx.Rngs(0)
         >>> # Standard quadratic attention
@@ -411,7 +411,7 @@ class RotaryYatAttention(Module):
         ...     num_heads=8,
         ...     max_seq_len=8192,
         ...     use_performer=True,
-        ...     num_features=256,
+        ...     performer_num_features=256,
         ...     rngs=rngs,
         ... )
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,290 @@
+"""Tests for the import-light ``nmn`` CLI (``nmn.cli``)."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+from nmn import cli
+
+
+# ---------------------------------------------------------------------------
+# Import-lightness: importing nmn.cli must not pull in any heavy framework.
+# ---------------------------------------------------------------------------
+
+def test_cli_import_is_light():
+    # Force a clean (re)import of nmn.cli in a subprocess-free way: drop it and
+    # any heavy modules that may already be loaded by other tests, then import.
+    heavy = ["torch", "tensorflow", "jax", "flax", "keras", "mlx"]
+    saved = {name: sys.modules.get(name) for name in heavy + ["nmn.cli"]}
+    for name in heavy + ["nmn.cli"]:
+        sys.modules.pop(name, None)
+    try:
+        importlib.import_module("nmn.cli")
+        # The spec requires torch/tensorflow specifically to stay unimported.
+        assert "torch" not in sys.modules
+        assert "tensorflow" not in sys.modules
+    finally:
+        for name, mod in saved.items():
+            if mod is not None:
+                sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Exit codes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],
+        ["info"],
+        ["version"],
+        ["frameworks"],
+        ["features"],
+        ["doctor"],
+        ["examples"],
+        ["guide", "torch"],
+    ],
+)
+def test_commands_exit_zero(argv):
+    assert cli.main(argv) == 0
+
+
+def test_unknown_subcommand_exits_two():
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["definitely-not-a-command"])
+    assert exc.value.code == 2
+
+
+def test_unknown_guide_framework_exits_two():
+    assert cli.main(["guide", "cobol"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Content: key substrings
+# ---------------------------------------------------------------------------
+
+def test_info_default_banner(capsys):
+    assert cli.main([]) == 0
+    out = capsys.readouterr().out
+    assert "nmn" in out
+    # All six framework extras advertised.
+    for extra in ("nmn[torch]", "nmn[nnx]", "nmn[keras]", "nmn[tf]", "nmn[linen]", "nmn[mlx]"):
+        assert extra in out
+    assert "nmn guide" in out
+
+
+def test_version_prints_only_version(capsys):
+    assert cli.main(["version"]) == 0
+    out = capsys.readouterr().out.strip()
+    from nmn import __version__
+
+    assert out == __version__
+
+
+def test_frameworks_shows_import_and_ctor(capsys):
+    assert cli.main(["frameworks"]) == 0
+    out = capsys.readouterr().out
+    assert "from nmn.torch import YatNMN" in out
+    assert "in_features=128, out_features=256" in out  # torch / nnx ctor
+    assert "rngs=nnx.Rngs(0)" in out  # nnx-specific kwarg
+    assert "from nmn.linen import YatNMN" in out
+    assert "units=256" in out  # keras ctor
+    assert "from nmn.mlx import YatNMN" in out
+
+
+@pytest.mark.parametrize(
+    "alias,needle",
+    [
+        ("torch", "from nmn.torch import YatNMN"),
+        ("pytorch", "from nmn.torch import YatNMN"),
+        ("nnx", "rngs"),
+        ("flax-nnx", "rngs"),
+        ("linen", "from nmn.linen import YatNMN"),
+        ("flax-linen", "from nmn.linen import YatNMN"),
+        ("keras", "units="),
+        ("tf", "from nmn.tf import YatNMN"),
+        ("tensorflow", "from nmn.tf import YatNMN"),
+        ("mlx", "from nmn.mlx import YatNMN"),
+    ],
+)
+def test_guide_aliases(alias, needle, capsys):
+    assert cli.main(["guide", alias]) == 0
+    out = capsys.readouterr().out
+    assert needle in out
+    assert "Full guide" in out
+
+
+def test_guide_attention_kwargs_match_signatures(capsys):
+    """Every embedded attention quickstart must use the real ctor kwargs.
+
+    keras/tf/mlx -> MultiHeadYatAttention(embed_dim=..., num_heads=...) (NO key_dim)
+    linen        -> MultiHeadAttention(num_heads=..., qkv_features=..., out_features=...)
+    nnx          -> MultiHeadAttention(num_heads=..., in_features=..., rngs=...)
+    torch        -> MultiHeadYatAttention(embed_dim=..., num_heads=...)
+    """
+    guides = {}
+    for fw in ("torch", "nnx", "linen", "keras", "tf", "mlx"):
+        assert cli.main(["guide", fw]) == 0
+        guides[fw] = capsys.readouterr().out
+
+    # key_dim was the bug: it must not appear in ANY guide.
+    for fw, text in guides.items():
+        assert "key_dim" not in text, f"{fw} guide still mentions key_dim"
+
+    # keras/tf/mlx and torch -> embed_dim, no in_features in their attention.
+    for fw in ("torch", "keras", "tf", "mlx"):
+        assert "embed_dim=128" in guides[fw], f"{fw} guide missing embed_dim"
+
+    # linen attention must use qkv_features/out_features, never in_features.
+    assert "qkv_features=128" in guides["linen"]
+    assert "out_features=128" in guides["linen"]
+    assert "in_features=128" not in guides["linen"]
+    # The dead `class MLP(YatNMN): pass` snippet must be gone.
+    assert "class MLP" not in guides["linen"]
+
+    # nnx attention does take in_features (that is its real signature).
+    assert "in_features=128" in guides["nnx"]
+    assert "rngs=" in guides["nnx"]
+
+
+def test_guide_yatnmn_ctor_kwargs_match_signatures(capsys):
+    """The embedded YatNMN constructor line must use the per-framework kwarg."""
+    expected = {
+        "torch": "in_features=",
+        "nnx": "in_features=",
+        "linen": "features=128",
+        "keras": "units=",
+        "tf": "features=128",
+        "mlx": "features=128",
+    }
+    for fw, needle in expected.items():
+        assert cli.main(["guide", fw]) == 0
+        out = capsys.readouterr().out
+        assert needle in out, f"{fw} guide missing YatNMN kwarg {needle!r}"
+        # keras must NOT use features= (it is `units=`).
+        if fw == "keras":
+            assert "YatNMN(features=" not in out
+
+
+def _extract_lines(text, prefix_token):
+    """Return source lines (dedented) from a guide containing ``prefix_token``."""
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if prefix_token in line
+    ]
+
+
+def test_torch_guide_snippets_construct(capsys):
+    """For the torch backend (importable locally), the emitted YatNMN ctor and
+    attention lines must actually construct using the exact guide kwargs."""
+    try:
+        importlib.import_module("torch")
+    except Exception:
+        pytest.skip("torch backend not importable locally")
+
+    assert cli.main(["guide", "torch"]) == 0
+    text = capsys.readouterr().out
+
+    from nmn.torch import YatNMN, MultiHeadYatAttention
+
+    # Exec the YatNMN ctor lines verbatim from the guide.
+    for line in _extract_lines(text, "YatNMN(in_features="):
+        eval(line.rstrip(","), {"YatNMN": YatNMN})
+    line = _extract_lines(text, "MultiHeadYatAttention(embed_dim=")[0]
+    eval(
+        line.split("=", 1)[1].strip(),
+        {"MultiHeadYatAttention": MultiHeadYatAttention},
+    )
+
+
+@pytest.mark.parametrize("fw", ["nnx", "linen", "mlx"])
+def test_guide_attention_ctor_constructs_for_importable(fw, capsys):
+    """Construct the attention object from each importable backend's guide
+    using the exact kwargs the guide emits."""
+    backends = {
+        "nnx": ["jax", "flax"],
+        "linen": ["jax", "flax"],
+        "mlx": ["mlx.core"],
+    }
+    try:
+        for m in backends[fw]:
+            importlib.import_module(m)
+    except Exception:
+        pytest.skip(f"{fw} backend not importable locally")
+
+    assert cli.main(["guide", fw]) == 0
+    text = capsys.readouterr().out
+
+    if fw == "nnx":
+        from flax import nnx
+        from nmn.nnx import MultiHeadAttention
+        rngs = nnx.Rngs(0)
+        line = _extract_lines(text, "MultiHeadAttention(num_heads=")[0]
+        expr = line.split("=", 1)[1].strip()
+        eval(expr, {"MultiHeadAttention": MultiHeadAttention, "rngs": rngs, "nnx": nnx})
+    elif fw == "linen":
+        from nmn.linen import MultiHeadAttention
+        line = _extract_lines(text, "MultiHeadAttention(num_heads=")[0]
+        expr = line.split("=", 1)[1].strip()
+        eval(expr, {"MultiHeadAttention": MultiHeadAttention})
+    elif fw == "mlx":
+        from nmn.mlx import MultiHeadYatAttention
+        line = _extract_lines(text, "MultiHeadYatAttention(embed_dim=")[0]
+        expr = line.split("=", 1)[1].strip()
+        eval(expr, {"MultiHeadYatAttention": MultiHeadYatAttention})
+
+
+def test_features_mentions_may_ray_and_lazy(capsys):
+    assert cli.main(["features"]) == 0
+    out = capsys.readouterr().out
+    assert "create_maclaurin_projection" in out
+    assert "radial_yat_attention" in out
+    assert "performer_kind" in out
+    assert "lazy=True" in out
+    # canonical kwargs
+    assert "bias=" in out
+    assert "epsilon=" in out
+
+
+def test_doctor_lists_all_backends(capsys):
+    assert cli.main(["doctor"]) == 0
+    out = capsys.readouterr().out
+    for key in ("torch", "nnx", "linen", "keras", "tf", "mlx"):
+        assert key in out
+    assert "Python" in out
+
+
+def test_examples_points_to_examples_md(capsys):
+    assert cli.main(["examples"]) == 0
+    out = capsys.readouterr().out
+    assert "EXAMPLES.md" in out
+    assert "nmn guide" in out
+
+
+# ---------------------------------------------------------------------------
+# Programmatic API in nmn/__init__.py
+# ---------------------------------------------------------------------------
+
+def test_nmn_help(capsys):
+    import nmn
+
+    nmn.help()
+    out = capsys.readouterr().out
+    assert "nmn[torch]" in out
+
+
+def test_nmn_doctor_returns_dict(capsys):
+    import nmn
+
+    report = nmn.doctor()
+    capsys.readouterr()  # drain
+    assert isinstance(report, dict)
+    assert set(report) == {"torch", "nnx", "linen", "keras", "tf", "mlx"}
+    # values are either a version string or None; never raises on missing.
+    for value in report.values():
+        assert value is None or isinstance(value, str)


### PR DESCRIPTION
Makes `nmn` easy to discover and use — especially for **coding agents** — and brings docs, changelog, and dev tooling current with the 0.3.x releases (MLX backend, GOAT attention, MAY/RAY performer maps, YatNMN lazy mode).

## CLI / programmatic discovery
- **`nmn` console script** + `python -m nmn`: `info` · `version` · `frameworks` · `guide <framework>` · `features` · `doctor` · `examples`
- **Import-light**: only `doctor` touches backends (each guarded), so it works with any subset of the six frameworks installed. Quickstarts are embedded (no `docs/` files needed at runtime).
- **`nmn.help()` / `nmn.doctor()`** for REPL/notebook use.

```
$ nmn doctor
  torch  PyTorch              OK       version 2.11.0
  nnx    Flax NNX             OK       version 0.12.6
  keras  Keras                MISSING  (pip install nmn[keras])
  mlx    MLX (Apple Silicon)  OK       version 0.31.1
```

## Agent docs
- **`llms.txt`** (llms.txt-convention doc map) and **`AGENTS.md`** (coding-agent cheat sheet: framework selection, exact imports, gotchas, MAY/RAY/lazy entry points, running tests).

## Docs refresh
- **CHANGELOG** backfilled 0.3.0 / 0.3.1 / 0.3.2 (was stuck at 0.2.11).
- **README**: CLI/discovery section; reconciled to six frameworks.
- **Guides**: lazy-mode notes + a MAY/RAY/SLAY performer section (nnx).
- **EXAMPLES.md**: MAY/RAY + lazy examples; **removed two fabricated "Yat-RNN" sections** documenting a module that doesn't exist; fixed stale `nmn.nnx.rnn`/`nmn.nnx.squashers`/`nmn.nnx.attention` import paths and a wrong performer kwarg.
- **architecture.md / migration.md**: kernel + the three feature maps (SLAY/MAY/RAY) and the lazy regime.
- Fixed inaccurate doc kwargs (keras `YatNMN(units=)`, attention `embed_dim`/`num_heads`, removed fabricated `key_dim`).

## Dev experience
- **Makefile** (`install`/`test`/`test-<fw>`/`lint`/`format`/`typecheck`/`build`/`clean`/`help`), **flake8 pre-commit hook**, updated **CONTRIBUTING.md** (dev workflow + release flow).

## How it was built & verified
Built by multi-agent workflows across disjoint file ownership, with an adversarial verify stage that caught real bugs (fabricated `key_dim`, `units` vs `features`, a `pytest -m torch` that selects zero tests, the fictional RNN docs). All corrected against ground-truth signatures and re-validated.

All additive and backward compatible. **Tests pass:** nnx/mlx/linen/torch/cli **813**, keras/tf **259** (recreated a TF venv to verify the backends that can't run in the default py3.14 env), new `nmn` CLI tests **35**. Wheel ships `cli.py`/`__main__.py` and the `nmn` console entry point.