### PR TITLE
chore: link the original mlnomadpy/nmn repo as a synced mirror

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,48 @@
+name: Mirror to mlnomadpy/nmn
+
+# Keeps the original repository github.com/mlnomadpy/nmn in sync with the
+# canonical github.com/azettaai/nmn. On every push to master (and on version
+# tags) this fast-forwards the mirror's master and pushes all tags.
+#
+# Setup (one-time): create a Personal Access Token with `contents:write` (repo)
+# scope on mlnomadpy/nmn and add it to this repo's secrets as `MIRROR_PAT`
+# (Settings → Secrets and variables → Actions). Without the secret the job is a
+# no-op, so it never fails CI.
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-mlnomadpy
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    name: Push master + tags to mlnomadpy/nmn
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history + tags for a clean fast-forward
+
+      - name: Mirror to mlnomadpy/nmn
+        env:
+          MIRROR_PAT: ${{ secrets.MIRROR_PAT }}
+        run: |
+          if [ -z "${MIRROR_PAT}" ]; then
+            echo "MIRROR_PAT secret not set — skipping mirror (no-op)."
+            exit 0
+          fi
+          remote="https://x-access-token:${MIRROR_PAT}@github.com/mlnomadpy/nmn.git"
+          # Sync master (fast-forward only; the mirror should never diverge).
+          git push "${remote}" "HEAD:refs/heads/master"
+          # Sync all version tags.
+          git push "${remote}" --tags

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@
   <a href="https://azettaai.github.io/nmn/paper/"><strong>📄 Paper</strong></a>
 </p>
 
+<p align="center">
+  <sub>
+    Canonical repo: <a href="https://github.com/azettaai/nmn">azettaai/nmn</a> ·
+    Mirror of the original <a href="https://github.com/mlnomadpy/nmn">mlnomadpy/nmn</a> ·
+    Install from <a href="https://pypi.org/project/nmn/">PyPI</a> (<code>pip install nmn</code>)
+  </sub>
+</p>
+
 ---
 
 ## Contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/azettaai/nmn"
 "Bug Tracker" = "https://github.com/azettaai/nmn/issues"
+"Original Repository" = "https://github.com/mlnomadpy/nmn"
 
 [project.scripts]
 nmn = "nmn.cli:main"


### PR DESCRIPTION
Connects the project's original home, [mlnomadpy/nmn](https://github.com/mlnomadpy/nmn), to this canonical repo. The full history + all tags were already pushed there (clean fast-forward); this adds the connective tissue.

- **README**: cross-link note (canonical `azettaai/nmn` · original/mirror `mlnomadpy/nmn` · PyPI).
- **pyproject**: an `Original Repository` project URL so the PyPI page links to `mlnomadpy/nmn` (appears on the next release).
- **`.github/workflows/mirror.yml`**: on push to `master` / version tags, fast-forwards the mirror's `master` and pushes tags.

### One-time setup needed for auto-mirror
The workflow is a **no-op until** a secret is added (so it never fails CI):
1. Create a PAT with `contents:write` (repo) scope that can push to `mlnomadpy/nmn`.
2. Add it to this repo as **`MIRROR_PAT`** (Settings → Secrets and variables → Actions).

Also set (already applied via API, not in this PR): both repos' GitHub homepage → PyPI and 10 topics.

GitHub repo metadata + the content/tags sync are already live; this PR is the in-repo half.