### PR TITLE
040: Add BF16-native and mixed-precision YatNMN execution modes

### DIFF
--- a/docs/guides/flax-nnx.md
+++ b/docs/guides/flax-nnx.md
@@ -305,7 +305,57 @@ See the TPU ResNet example for a worked pattern.
 
 ---
 
-## 10. Lazy training (freeze kernel)
+## 10. YatNMN precision modes
+
+`YatNMN` keeps its established FP32 score computation by default, even when
+the layer output is BF16. TPU workloads can opt into two reduced-precision
+modes explicitly:
+
+```python
+import jax.numpy as jnp
+from flax import nnx
+from nmn.nnx import YatNMN
+
+reference = YatNMN(128, 64, compute_mode="fp32", rngs=nnx.Rngs(0))
+
+# BF16 operands with FP32 dot/reduction accumulation (recommended TPU mode).
+mixed = YatNMN(
+    128, 64,
+    dtype=jnp.bfloat16,
+    param_dtype=jnp.bfloat16,
+    compute_mode="mixed",
+    rngs=nnx.Rngs(0),
+)
+
+# Experimental strict-BF16, dimension-scaled score evaluation.
+strict = YatNMN(
+    128, 64,
+    dtype=jnp.bfloat16,
+    param_dtype=jnp.bfloat16,
+    compute_mode="bf16",
+    distance_floor=1e-3,
+    rngs=nnx.Rngs(0),
+)
+```
+
+`distance_floor` clamps the squared distance before adding `epsilon`; it is
+useful when BF16 rounding makes nearby inputs and kernels indistinguishable.
+The default is `0.0`, so `compute_mode="fp32"` remains backward compatible.
+All three modes work with `fused=True`. Reduced-precision or clamped execution
+recomputes the same mode-specific expression in the fused backward, including
+the clamp, to preserve standard/fused forward and gradient parity. The unchanged
+default FP32 path retains its optimized analytical VJP.
+
+`mixed` requests FP32 accumulation via JAX's `preferred_element_type` without
+materializing full FP32 copies of low-precision inputs and kernels. Both
+`jnp.float16` and `jnp.bfloat16` operands are covered by numerical-parity tests;
+BF16 is the recommended TPU storage/operand dtype. Confirm the final lowered
+HLO and performance on the target TPU, since CPU/GPU execution is not a
+substitute for a TPU profile.
+
+---
+
+## 11. Lazy training (freeze kernel)
 
 Pass `lazy=True` (alias: `freeze_kernel=True`) to freeze **only** the kernel.
 In NNX the kernel is then stored under a `FrozenParam` (a non-`nnx.Param`
@@ -338,11 +388,12 @@ only the scale/shift/`epsilon` adapt.
 
 ---
 
-## 11. Troubleshooting
+## 12. Troubleshooting
 
 | Symptom                                  | Likely cause                                            | Fix                                                                |
 | ---------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------ |
 | `NaN` after first JIT compile            | `epsilon` too small relative to input scale             | `YatNMN(..., epsilon=1e-3)`                                        |
+| `NaN`/`Inf` in strict BF16 near `x ≈ W`   | Rounded distance is too close to zero                   | Set `distance_floor`, e.g. `YatNMN(..., compute_mode="bf16", distance_floor=1e-3)` |
 | `XlaRuntimeError` on TPU                 | Pallas kernel ran on a CPU/GPU runtime                  | Use standard `MultiHeadAttention` on CPU; pallas only on TPU/GPU   |
 | Slow first step, fast after              | Normal — JIT compile cost                               | Reuse the JIT-compiled function across steps                       |
 | Output range collapses to zero           | Inputs and weights nearly identical → numerator ≈ 0     | Add input normalization *before* first Yat layer                   |
@@ -350,7 +401,7 @@ only the scale/shift/`epsilon` adapt.
 
 ---
 
-## 12. Next steps
+## 13. Next steps
 
 - [Architecture & theory](../architecture.md)
 - [Flax Linen guide](flax-linen.md) — for legacy Linen codebases

--- a/src/nmn/nnx/README.md
+++ b/src/nmn/nnx/README.md
@@ -752,21 +752,41 @@ _ = compiled_forward(model, x_example)  # Triggers compilation
 logits = compiled_forward(model, x_real)
 ```
 
-### 4. **Use BFloat16 for TPUs**
+### 4. **Choose a YatNMN Precision Mode for TPUs**
 
 ```python
-# Define model with bfloat16 computation
-model = OptimizedYATNet(
-    num_classes=10,
-    rngs=rngs
+# Reference behavior: full FP32 YAT-score evaluation.
+reference = YatNMN(128, 64, compute_mode="fp32", rngs=rngs)
+
+# Recommended TPU path: BF16 operands, FP32 dot/reduction accumulation.
+mixed = YatNMN(
+    128, 64,
+    dtype=jnp.bfloat16,
+    param_dtype=jnp.bfloat16,
+    compute_mode="mixed",
+    rngs=rngs,
 )
 
-# Cast inputs to bfloat16
-x_bf16 = x.astype(jnp.bfloat16)
+# Experimental strict-BF16 path. The distance floor protects near-collisions.
+strict = YatNMN(
+    128, 64,
+    dtype=jnp.bfloat16,
+    param_dtype=jnp.bfloat16,
+    compute_mode="bf16",
+    distance_floor=1e-3,
+    rngs=rngs,
+)
 
-# Forward pass uses bfloat16 internally
-logits = model(x_bf16, deterministic=True)
+logits = mixed(x.astype(jnp.bfloat16), deterministic=True)
 ```
+
+`mixed` avoids explicit full-array FP32 operand casts and uses
+`preferred_element_type=jnp.float32`; numerical-parity tests cover both FP16
+and BF16 operands. `bf16` uses a dimension-scaled form to keep intermediate
+values near unit scale. All modes support `fused=True` with matching forward
+and backward semantics; the unchanged default FP32 path keeps its optimized
+analytical VJP. Benchmark lowered HLO and step time on the actual TPU before
+choosing a deployment mode.
 
 ## Performance Tips
 
@@ -848,6 +868,8 @@ YatConv(
     dtype: Optional[Dtype] = None,
     param_dtype: Dtype = jnp.float32,
     precision: PrecisionLike = None,
+    compute_mode: str = 'fp32',
+    distance_floor: float = 0.0,
     epsilon: float = 1e-5,
     learnable_epsilon: bool = False,
     drop_rate: float = 0.0,

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import math
 import threading
 import typing as tp
 
@@ -93,6 +94,13 @@ class YatNMN(Module):
     param_dtype: the dtype passed to parameter initializers (default: float32).
     precision: numerical precision of the computation see ``jax.lax.Precision``
       for details.
+    compute_mode: numerical mode for the YAT score. ``"fp32"`` preserves the
+      reference implementation, ``"mixed"`` keeps operands in ``dtype`` while
+      accumulating dot products and reductions in float32, and ``"bf16"`` uses
+      a dimension-scaled strict-BF16 formulation (default: ``"fp32"``).
+    distance_floor: non-negative lower bound applied to the squared distance
+      before epsilon is added. This is especially useful for near-collisions in
+      ``"bf16"`` mode (default: 0.0).
     kernel_init: initializer function for the weight matrix.
     bias_init: initializer function for the bias.
     alpha_init: initializer function for the learnable alpha (only used if constant_alpha is None).
@@ -140,6 +148,8 @@ class YatNMN(Module):
     dtype: tp.Optional[Dtype] = None,
     param_dtype: Dtype = jnp.float32,
     precision: PrecisionLike = None,
+    compute_mode: str = 'fp32',
+    distance_floor: float = 0.0,
     kernel_init: Initializer = default_kernel_init,
     bias_init: Initializer = default_bias_init,
     alpha_init: Initializer = default_alpha_init,
@@ -292,6 +302,18 @@ class YatNMN(Module):
     self.dtype = dtype
     self.param_dtype = param_dtype
     self.precision = precision
+    if compute_mode not in ('fp32', 'mixed', 'bf16'):
+      raise ValueError(
+        "compute_mode must be one of 'fp32', 'mixed', or 'bf16', "
+        f"got {compute_mode!r}"
+      )
+    distance_floor = float(distance_floor)
+    if not math.isfinite(distance_floor) or distance_floor < 0:
+      raise ValueError(
+        f"distance_floor must be finite and non-negative, got {distance_floor}"
+      )
+    self.compute_mode = compute_mode
+    self.distance_floor = distance_floor
     self.kernel_init = kernel_init
     self.bias_init = bias_init
     self.dot_general = dot_general
@@ -303,8 +325,12 @@ class YatNMN(Module):
     self.epsilon_param: nnx.Param[jax.Array] | None
     if learnable_epsilon:
       # Initialize so that softplus(raw) ≈ epsilon: raw = log(exp(eps) - 1)
-      raw_eps = jnp.log(jnp.exp(jnp.array(epsilon, dtype=param_dtype)) - 1.0)
-      self.epsilon_param = nnx.Param(raw_eps.reshape((1,)))
+      # Compute this in Python float precision before casting. Evaluating the
+      # inverse in bf16/fp16 rounds exp(1e-5) to 1 and produces ``-inf``.
+      raw_eps = epsilon + math.log(-math.expm1(-epsilon))
+      self.epsilon_param = nnx.Param(
+        jnp.asarray([raw_eps], dtype=param_dtype)
+      )
     else:
       self.epsilon_param = None
     self.spherical = spherical
@@ -383,62 +409,174 @@ class YatNMN(Module):
     else:
       eps = self.epsilon
 
-    # ── Fused path: custom_vjp saves only (x, W, dot, dist, bias, eps) ──
+    # ── Fused path: optimized/reference or exact mode-aware custom VJP ──
     if self.fused and not self.spherical:
       return _fused_yat_call(
         inputs, kernel, alpha, bias, eps,
         self._constant_alpha_value,
+        self.compute_mode, self.distance_floor, self.precision,
+        self.weight_normalized,
       )
 
     # ── Standard path ──────────────────────────────────────────────────
-    # Upcast to float32 for YAT score computation.
-    # YAT scores grow as O(dot²) — squaring causes overflow in bf16.
-    inputs_f32 = inputs.astype(jnp.float32)
-    kernel_f32 = kernel.astype(jnp.float32)
+    if self._constant_alpha_value is not None:
+      alpha_value = jnp.asarray(self._constant_alpha_value)
+    elif alpha is not None:
+      alpha_value = alpha
+    else:
+      alpha_value = jnp.ones((), dtype=inputs.dtype)
+    if bias is None:
+      bias_value = jnp.zeros((1,), dtype=inputs.dtype)
+    else:
+      bias_value = bias
+    eps_value = jnp.asarray(eps)
 
-    # Compute dot product: x · W (in f32)
-    y = self.dot_general(
-      inputs_f32,
-      kernel_f32,
-      (((inputs.ndim - 1,), (0,)), ((), ())),
-      precision=self.precision,
+    return _yat_value(
+      inputs,
+      kernel,
+      alpha_value,
+      bias_value,
+      eps_value,
+      bias is not None,
+      self.compute_mode,
+      self.distance_floor,
+      self.precision,
+      self.spherical,
+      self.weight_normalized,
+      self.dot_general,
     )
 
-    if self.spherical:
-      distances = jnp.maximum(2 - 2 * y, 0.0)
+
+def _yat_value(
+  x,
+  kernel,
+  alpha,
+  bias,
+  eps,
+  has_bias,
+  compute_mode,
+  distance_floor,
+  precision,
+  spherical=False,
+  weight_normalized=False,
+  dot_general=lax.dot_general,
+):
+  """Evaluate a YAT score using the requested numerical mode."""
+  output_dtype = x.dtype
+  dimension_numbers = (((x.ndim - 1,), (0,)), ((), ()))
+
+  if compute_mode == 'fp32':
+    x_compute = x.astype(jnp.float32)
+    kernel_compute = kernel.astype(jnp.float32)
+    accumulation_dtype = jnp.float32
+    dot = dot_general(
+      x_compute,
+      kernel_compute,
+      dimension_numbers,
+      precision=precision,
+    )
+  elif compute_mode == 'mixed':
+    x_compute = x
+    kernel_compute = kernel
+    accumulation_dtype = jnp.float32
+    dot = dot_general(
+      x_compute,
+      kernel_compute,
+      dimension_numbers,
+      precision=precision,
+      preferred_element_type=jnp.float32,
+    )
+  else:
+    # The strict-BF16 mode intentionally rounds products and reductions to BF16.
+    x_compute = x.astype(jnp.bfloat16)
+    kernel_compute = kernel.astype(jnp.bfloat16)
+    accumulation_dtype = jnp.bfloat16
+    dot = dot_general(
+      x_compute,
+      kernel_compute,
+      dimension_numbers,
+      precision=precision,
+    )
+
+  alpha_compute = alpha.astype(accumulation_dtype)
+  eps_compute = eps.astype(accumulation_dtype)
+  floor = jnp.asarray(distance_floor, dtype=accumulation_dtype)
+  bias_shape = (1,) * (dot.ndim - 1) + (-1,)
+  bias_compute = jnp.reshape(bias.astype(accumulation_dtype), bias_shape)
+
+  if spherical:
+    distances = jnp.maximum(
+      jnp.asarray(2, accumulation_dtype) - 2 * dot,
+      floor,
+    )
+    numerator = dot + bias_compute if has_bias else dot
+    result = alpha_compute * numerator ** 2 / (distances + eps_compute)
+  elif compute_mode == 'bf16':
+    # Dividing all reductions by d keeps BF16 intermediates near unit scale:
+    # d * (mean(xw) + b/d)^2 / (mean((x-w)^2) + epsilon/d).
+    width = jnp.asarray(x.shape[-1], dtype=accumulation_dtype)
+    mean_dot = dot / width
+    input_mean_square = jnp.sum(
+      x_compute * x_compute,
+      axis=-1,
+      keepdims=True,
+      dtype=accumulation_dtype,
+    ) / width
+    if weight_normalized:
+      kernel_mean_square = jnp.ones(
+        (1, kernel_compute.shape[-1]), dtype=accumulation_dtype
+      ) / width
     else:
-      inputs_squared_sum = jnp.sum(inputs_f32**2, axis=-1, keepdims=True)
+      kernel_mean_square = jnp.sum(
+        kernel_compute * kernel_compute,
+        axis=0,
+        keepdims=True,
+        dtype=accumulation_dtype,
+      ) / width
+    mean_distances = jnp.maximum(
+      input_mean_square + kernel_mean_square - 2 * mean_dot,
+      floor / width,
+    )
+    numerator = mean_dot + bias_compute / width if has_bias else mean_dot
+    result = (
+      alpha_compute * width * numerator ** 2
+      / (mean_distances + eps_compute / width)
+    )
+  else:
+    input_squared_sum = jnp.sum(
+      x_compute * x_compute,
+      axis=-1,
+      keepdims=True,
+      dtype=accumulation_dtype,
+    )
+    if weight_normalized:
+      kernel_squared_sum = jnp.ones(
+        (1, kernel_compute.shape[-1]), dtype=accumulation_dtype
+      )
+    else:
+      kernel_squared_sum = jnp.sum(
+        kernel_compute * kernel_compute,
+        axis=0,
+        keepdims=True,
+        dtype=accumulation_dtype,
+      )
+    distances = jnp.maximum(
+      input_squared_sum + kernel_squared_sum - 2 * dot,
+      floor,
+    )
+    numerator = dot + bias_compute if has_bias else dot
+    result = alpha_compute * numerator ** 2 / (distances + eps_compute)
 
-      if self.weight_normalized:
-        kernel_squared_sum = jnp.ones((1, kernel_f32.shape[-1]), dtype=jnp.float32)
-      else:
-        kernel_squared_sum = jnp.sum(kernel_f32**2, axis=0, keepdims=True)
-
-      distances = jnp.maximum(inputs_squared_sum + kernel_squared_sum - 2 * y, 0.0)
-
-    # Add bias (in f32)
-    if bias is not None:
-      y += jnp.reshape(bias.astype(jnp.float32), (1,) * (y.ndim - 1) + (-1,))
-
-    # YAT operation: (x · W)² / (||x - W||² + ε) — safe in f32
-    y = y ** 2 / (distances + eps)
-
-    # Apply alpha scaling
-    if self._constant_alpha_value is not None:
-      y = y * self._constant_alpha_value
-    elif alpha is not None:
-      y = y * alpha.astype(jnp.float32)
-
-    # Cast back to caller's dtype
-    return y.astype(inputs.dtype)
+  return result.astype(output_dtype)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
 # Fused YatNMN kernel — unified custom_vjp for reduced activation memory
 #
-# Standard autodiff saves 5+ intermediates (dot, dot_sq, x_sq, w_sq, dist, out).
-# The fused version saves only (x, kernel, alpha, bias, eps, dot, dist) and
-# recomputes dot_sq, x_sq, w_sq during backward.
+# Standard autodiff saves the score intermediates. The fused version saves only
+# its five array operands and recomputes the exact mode-specific forward graph in
+# backward. This keeps the clamp derivative and BF16 rounding identical to the
+# standard implementation.
 #
 # Supports all combinations of: bias / no-bias, learnable / constant epsilon,
 # learnable / constant / no alpha.  Boolean flags via nondiff_argnums let JAX
@@ -446,7 +584,18 @@ class YatNMN(Module):
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-def _fused_yat_call(inputs, kernel, alpha, bias, eps, constant_alpha_value):
+def _fused_yat_call(
+  inputs,
+  kernel,
+  alpha,
+  bias,
+  eps,
+  constant_alpha_value,
+  compute_mode,
+  distance_floor,
+  precision,
+  weight_normalized,
+):
   """Dispatch to unified fused forward."""
   # Alpha array + grad flag
   if constant_alpha_value is not None:
@@ -475,119 +624,212 @@ def _fused_yat_call(inputs, kernel, alpha, bias, eps, constant_alpha_value):
     e = jnp.array(eps, dtype=jnp.float32)
     has_eps_grad = False
 
-  return _fused_yat(inputs, kernel, a, b, e, has_alpha_grad, has_bias, has_eps_grad)
+  # Preserve the existing optimized analytical VJP for the default/reference
+  # configuration. Mode-aware or clamped execution uses the exact recomputing
+  # VJP below so its BF16 rounding and clamp derivative match standard autodiff.
+  if compute_mode == 'fp32' and distance_floor == 0.0:
+    return _fused_yat_fp32(
+      inputs, kernel, a, b, e, has_alpha_grad, has_bias, has_eps_grad
+    )
+
+  return _fused_yat(
+    inputs,
+    kernel,
+    a,
+    b,
+    e,
+    has_alpha_grad,
+    has_bias,
+    has_eps_grad,
+    compute_mode,
+    distance_floor,
+    precision,
+    weight_normalized,
+  )
 
 
 # ── Unified custom_vjp ──
 
 @functools.partial(jax.custom_vjp, nondiff_argnums=(5, 6, 7))
-def _fused_yat(x, kernel, alpha, bias, eps, has_alpha_grad, has_bias, has_eps_grad):
+def _fused_yat_fp32(
+  x, kernel, alpha, bias, eps, has_alpha_grad, has_bias, has_eps_grad
+):
   x_f32 = x.astype(jnp.float32)
-  w_f32 = kernel.astype(jnp.float32)
-  a_f32 = alpha.astype(jnp.float32)
-  dot = x_f32 @ w_f32
-  x_sq = jnp.sum(x_f32 ** 2, axis=-1, keepdims=True)
-  w_sq = jnp.sum(w_f32 ** 2, axis=0, keepdims=True)
-  dist = jnp.maximum(x_sq + w_sq - 2 * dot, 0.0) + eps.astype(jnp.float32)
-  num = dot + bias.astype(jnp.float32) if has_bias else dot
-  return (a_f32 * num ** 2 / dist).astype(x.dtype)
+  kernel_f32 = kernel.astype(jnp.float32)
+  alpha_f32 = alpha.astype(jnp.float32)
+  dot = x_f32 @ kernel_f32
+  input_squared_sum = jnp.sum(x_f32 ** 2, axis=-1, keepdims=True)
+  kernel_squared_sum = jnp.sum(kernel_f32 ** 2, axis=0, keepdims=True)
+  distance = jnp.maximum(
+    input_squared_sum + kernel_squared_sum - 2 * dot, 0.0
+  ) + eps.astype(jnp.float32)
+  numerator = dot + bias.astype(jnp.float32) if has_bias else dot
+  return (alpha_f32 * numerator ** 2 / distance).astype(x.dtype)
 
 
-def _fused_yat_fwd(x, kernel, alpha, bias, eps, has_alpha_grad, has_bias, has_eps_grad):
+def _fused_yat_fp32_fwd(
+  x, kernel, alpha, bias, eps, has_alpha_grad, has_bias, has_eps_grad
+):
   x_f32 = x.astype(jnp.float32)
-  w_f32 = kernel.astype(jnp.float32)
-  a_f32 = alpha.astype(jnp.float32)
-  e_f32 = eps.astype(jnp.float32)
-  dot = x_f32 @ w_f32
-  x_sq = jnp.sum(x_f32 ** 2, axis=-1, keepdims=True)
-  w_sq = jnp.sum(w_f32 ** 2, axis=0, keepdims=True)
-  dist = jnp.maximum(x_sq + w_sq - 2 * dot, 0.0) + e_f32
-  num = dot + bias.astype(jnp.float32) if has_bias else dot
-  out = (a_f32 * num ** 2 / dist).astype(x.dtype)
-  return out, (x, kernel, alpha, bias, eps, dot, dist)
+  kernel_f32 = kernel.astype(jnp.float32)
+  alpha_f32 = alpha.astype(jnp.float32)
+  eps_f32 = eps.astype(jnp.float32)
+  dot = x_f32 @ kernel_f32
+  input_squared_sum = jnp.sum(x_f32 ** 2, axis=-1, keepdims=True)
+  kernel_squared_sum = jnp.sum(kernel_f32 ** 2, axis=0, keepdims=True)
+  raw_distance = input_squared_sum + kernel_squared_sum - 2 * dot
+  distance = jnp.maximum(raw_distance, 0.0) + eps_f32
+  numerator = dot + bias.astype(jnp.float32) if has_bias else dot
+  out = (alpha_f32 * numerator ** 2 / distance).astype(x.dtype)
+  return out, (x, kernel, alpha, bias, eps, dot, raw_distance, distance)
 
 
-def _fused_yat_bwd(has_alpha_grad, has_bias, has_eps_grad, res, g):
-  x, kernel, alpha, bias, eps, dot, dist = res
-  a_f32 = alpha.astype(jnp.float32)
+def _fused_yat_fp32_bwd(has_alpha_grad, has_bias, has_eps_grad, res, g):
+  x, kernel, alpha, bias, eps, dot, raw_distance, distance = res
+  alpha_f32 = alpha.astype(jnp.float32)
   g_f32 = g.astype(jnp.float32)
+  numerator = dot + bias.astype(jnp.float32) if has_bias else dot
 
-  num = dot + bias.astype(jnp.float32) if has_bias else dot
+  # Match jnp.maximum(raw_distance, 0)'s subgradient exactly: zero below
+  # the floor, one above it, and one half at equality.
+  distance_clamp_grad = jnp.where(
+    raw_distance > 0.0,
+    1.0,
+    jnp.where(raw_distance < 0.0, 0.0, 0.5),
+  )
 
-  g_x, g_w = _fused_yat_grad_xw(x, kernel, num, dist, g, alpha_val=a_f32)
+  g_x, g_kernel = _fused_yat_fp32_grad_xw(
+    x, kernel, numerator, distance, distance_clamp_grad, g, alpha_f32
+  )
 
-  # Alpha grad
   if has_alpha_grad:
-    raw_yat = num ** 2 / dist
+    raw_yat = numerator ** 2 / distance
     g_alpha = jnp.sum(g_f32 * raw_yat).reshape(alpha.shape).astype(alpha.dtype)
   else:
     g_alpha = jnp.zeros_like(alpha)
 
-  # Bias grad
   if has_bias:
-    inv_dist = 1.0 / dist
-    g_bias = jnp.sum(g_f32 * a_f32 * 2 * num * inv_dist,
-                     axis=tuple(range(g.ndim - 1)))
+    g_bias = jnp.sum(
+      g_f32 * alpha_f32 * 2 * numerator / distance,
+      axis=tuple(range(g.ndim - 1)),
+    )
     if bias.shape != g_bias.shape:
       g_bias = jnp.sum(g_bias, keepdims=True)
     g_bias = g_bias.astype(bias.dtype)
   else:
     g_bias = jnp.zeros_like(bias)
 
-  # Epsilon grad
   if has_eps_grad:
-    inv_dist_sq = 1.0 / (dist ** 2)
-    g_eps = jnp.sum(g_f32 * (-a_f32 * num ** 2 * inv_dist_sq))
+    g_eps = jnp.sum(
+      g_f32 * (-alpha_f32 * numerator ** 2 / distance ** 2)
+    )
     g_eps = g_eps.reshape(eps.shape).astype(eps.dtype)
   else:
     g_eps = jnp.zeros_like(eps)
 
-  return g_x, g_w, g_alpha, g_bias, g_eps
+  return g_x, g_kernel, g_alpha, g_bias, g_eps
+
+
+def _fused_yat_fp32_grad_xw(
+  x, kernel, numerator, distance, distance_clamp_grad, g, alpha
+):
+  """Compute the optimized reference-mode input and kernel gradients."""
+  g_f32 = g.astype(jnp.float32)
+  x_f32 = x.astype(jnp.float32)
+  kernel_f32 = kernel.astype(jnp.float32)
+  inverse_distance = 1.0 / distance
+  g_numerator = g_f32 * alpha * 2 * numerator * inverse_distance
+  g_distance = (
+    g_f32 * -alpha * numerator ** 2 * inverse_distance ** 2
+  )
+  g_distance = g_distance * distance_clamp_grad
+  g_dot = g_numerator - 2 * g_distance
+  g_distance_sum = jnp.sum(g_distance, axis=-1, keepdims=True)
+  g_x = g_dot @ kernel_f32.T + 2 * x_f32 * g_distance_sum
+
+  x_flat = x_f32.reshape(-1, x_f32.shape[-1])
+  g_dot_flat = g_dot.reshape(-1, g_dot.shape[-1])
+  g_distance_flat = g_distance.reshape(-1, g_distance.shape[-1])
+  g_kernel = x_flat.T @ g_dot_flat
+  g_kernel += 2 * kernel_f32 * jnp.sum(
+    g_distance_flat, axis=0, keepdims=True
+  )
+  return g_x.astype(x.dtype), g_kernel.astype(kernel.dtype)
+
+
+_fused_yat_fp32.defvjp(_fused_yat_fp32_fwd, _fused_yat_fp32_bwd)
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(5, 6, 7, 8, 9, 10, 11))
+def _fused_yat(
+  x,
+  kernel,
+  alpha,
+  bias,
+  eps,
+  has_alpha_grad,
+  has_bias,
+  has_eps_grad,
+  compute_mode,
+  distance_floor,
+  precision,
+  weight_normalized,
+):
+  return _yat_value(
+    x, kernel, alpha, bias, eps, has_bias, compute_mode, distance_floor,
+    precision, False, weight_normalized,
+  )
+
+
+def _fused_yat_fwd(
+  x,
+  kernel,
+  alpha,
+  bias,
+  eps,
+  has_alpha_grad,
+  has_bias,
+  has_eps_grad,
+  compute_mode,
+  distance_floor,
+  precision,
+  weight_normalized,
+):
+  out = _yat_value(
+    x, kernel, alpha, bias, eps, has_bias, compute_mode, distance_floor,
+    precision, False, weight_normalized,
+  )
+  return out, (x, kernel, alpha, bias, eps)
+
+
+def _fused_yat_bwd(
+  has_alpha_grad,
+  has_bias,
+  has_eps_grad,
+  compute_mode,
+  distance_floor,
+  precision,
+  weight_normalized,
+  res,
+  g,
+):
+  x, kernel, alpha, bias, eps = res
+
+  def forward(x, kernel, alpha, bias, eps):
+    return _yat_value(
+      x, kernel, alpha, bias, eps, has_bias, compute_mode, distance_floor,
+      precision, False, weight_normalized,
+    )
+
+  _, pullback = jax.vjp(forward, x, kernel, alpha, bias, eps)
+  g_x, g_kernel, g_alpha, g_bias, g_eps = pullback(g)
+  if not has_alpha_grad:
+    g_alpha = jnp.zeros_like(alpha)
+  if not has_bias:
+    g_bias = jnp.zeros_like(bias)
+  if not has_eps_grad:
+    g_eps = jnp.zeros_like(eps)
+  return g_x, g_kernel, g_alpha, g_bias, g_eps
 
 
 _fused_yat.defvjp(_fused_yat_fwd, _fused_yat_bwd)
-
-
-# ── Shared gradient computation ──
-
-def _fused_yat_grad_xw(x, kernel, num, dist, g, alpha_val):
-  """Compute gradients for x and kernel.
-
-  out = alpha * num^2 / dist,  where num = dot + bias (or just dot)
-  dist = ||x||^2 + ||W||^2 - 2*(x@W) + eps
-
-  Partials (holding other intermediates constant):
-    d_out/d_num  = alpha * 2*num / dist
-    d_out/d_dist = -alpha * num^2 / dist^2
-
-  The dist→dot path (-2) is handled separately in the gradient assembly.
-  """
-  g_f32 = g.astype(jnp.float32)
-  x_f32 = x.astype(jnp.float32)
-  w_f32 = kernel.astype(jnp.float32)
-
-  num_sq = num ** 2
-  inv_dist = 1.0 / dist
-  inv_dist_sq = inv_dist ** 2
-
-  d_out_d_num = alpha_val * 2 * num * inv_dist
-  d_out_d_dist = -alpha_val * num_sq * inv_dist_sq
-
-  g_num = g_f32 * d_out_d_num
-  g_dist = g_f32 * d_out_d_dist
-
-  # Total dot gradient = through numerator (d_num/d_dot=1) + through dist (d_dist/d_dot=-2)
-  g_dot_total = g_num + g_dist * (-2)
-
-  # Grad x: through dot + through x_sq in dist
-  g_dist_summed = jnp.sum(g_dist, axis=-1, keepdims=True)
-  g_x = g_dot_total @ w_f32.T + g_dist_summed * (2 * x_f32)
-
-  # Grad kernel: through dot + through w_sq in dist
-  x_flat = x_f32.reshape(-1, x_f32.shape[-1])
-  g_dot_flat = g_dot_total.reshape(-1, g_dot_total.shape[-1])
-  g_dist_flat = g_dist.reshape(-1, g_dist.shape[-1])
-  g_w = x_flat.T @ g_dot_flat
-  g_w += 2 * w_f32 * jnp.sum(g_dist_flat, axis=0, keepdims=True)
-
-  return g_x.astype(x.dtype), g_w.astype(kernel.dtype)

--- a/tests/test_nnx/test_yatnmn_precision.py
+++ b/tests/test_nnx/test_yatnmn_precision.py
@@ -1,0 +1,323 @@
+"""Numerical-mode tests for the Flax NNX YatNMN layer."""
+
+import numpy as np
+import pytest
+
+try:
+    import jax
+    import jax.numpy as jnp
+    from flax import nnx
+    from jax import lax
+    from nmn.nnx.layers import YatNMN
+    HAS_JAX = True
+except ImportError:
+    HAS_JAX = False
+
+
+pytestmark = pytest.mark.skipif(not HAS_JAX, reason="JAX/Flax not available")
+
+
+def _layer(width, mode, *, fused=False, epsilon=1e-3, distance_floor=0.0,
+           dot_general=None):
+    if dot_general is None:
+        dot_general = lax.dot_general
+    return YatNMN(
+        width,
+        24,
+        dtype=jnp.bfloat16,
+        param_dtype=jnp.bfloat16,
+        compute_mode=mode,
+        fused=fused,
+        epsilon=epsilon,
+        distance_floor=distance_floor,
+        learnable_epsilon=True,
+        dot_general=dot_general,
+        rngs=nnx.Rngs(42),
+    )
+
+
+def _loss(model, x):
+    return jnp.mean(model(x).astype(jnp.float32) ** 2)
+
+
+@pytest.mark.parametrize("mode", ["fp32", "mixed", "bf16"])
+def test_fused_and_standard_modes_have_exact_forward_and_gradient_parity(mode):
+    standard = _layer(32, mode, fused=False, distance_floor=1e-3)
+    fused = _layer(32, mode, fused=True, distance_floor=1e-3)
+    x = jax.random.normal(jax.random.key(1), (3, 32), dtype=jnp.bfloat16)
+
+    np.testing.assert_array_equal(standard(x), fused(x))
+
+    _, (standard_grads, standard_input_grad) = jax.value_and_grad(
+        _loss, argnums=(0, 1)
+    )(standard, x)
+    _, (fused_grads, fused_input_grad) = jax.value_and_grad(
+        _loss, argnums=(0, 1)
+    )(fused, x)
+    np.testing.assert_array_equal(
+        standard_input_grad,
+        fused_input_grad,
+        err_msg=f"input gradient differs in {mode} mode",
+    )
+    for name in ("kernel", "bias", "alpha", "epsilon_param"):
+        np.testing.assert_array_equal(
+            getattr(standard_grads, name)[...],
+            getattr(fused_grads, name)[...],
+            err_msg=f"{name} gradient differs in {mode} mode",
+        )
+
+
+def test_default_fused_gradient_matches_standard_when_distance_clamp_is_active():
+    width = 64
+    standard = YatNMN(
+        width, 1, fused=False, use_bias=False, use_alpha=False,
+        epsilon=1e-5, rngs=nnx.Rngs(0),
+    )
+    fused = YatNMN(
+        width, 1, fused=True, use_bias=False, use_alpha=False,
+        epsilon=1e-5, rngs=nnx.Rngs(0),
+    )
+    x = jax.random.normal(jax.random.key(2), (1, width)) * 10.0
+    standard.kernel[...] = x.T
+    fused.kernel[...] = x.T
+
+    raw_distance = (
+        jnp.sum(x * x, axis=-1, keepdims=True)
+        + jnp.sum(x.T * x.T, axis=0, keepdims=True)
+        - 2.0 * (x @ x.T)
+    )
+    assert float(raw_distance[0, 0]) < 0.0
+    np.testing.assert_array_equal(standard(x), fused(x))
+
+    standard_grad = jax.grad(lambda value: jnp.sum(standard(value)))(x)
+    fused_grad = jax.grad(lambda value: jnp.sum(fused(value)))(x)
+    np.testing.assert_array_equal(standard_grad, fused_grad)
+    assert jnp.isfinite(fused_grad).all()
+
+
+@pytest.mark.parametrize("param_dtype", [jnp.float16, jnp.bfloat16])
+def test_low_precision_learnable_epsilon_initializes_finite(param_dtype):
+    layer = YatNMN(
+        8,
+        4,
+        param_dtype=param_dtype,
+        learnable_epsilon=True,
+        epsilon=1e-5,
+        rngs=nnx.Rngs(0),
+    )
+
+    raw_epsilon = layer.epsilon_param[...]
+    effective_epsilon = jax.nn.softplus(raw_epsilon.astype(jnp.float32))
+    assert jnp.isfinite(raw_epsilon).all()
+    assert jnp.isfinite(effective_epsilon).all()
+    np.testing.assert_allclose(effective_epsilon, 1e-5, rtol=0.02)
+
+
+@pytest.mark.parametrize(
+    ("width", "scale", "epsilon"),
+    [
+        (32, 0.1, 1e-5),
+        (128, 1.0, 1e-3),
+        (512, 10.0, 1.0),
+    ],
+)
+@pytest.mark.parametrize(
+    ("mode", "forward_tolerance", "gradient_tolerance", "min_cosine"),
+    [
+        ("mixed", 0.01, 0.03, 0.999),
+        ("bf16", 0.04, 0.10, 0.995),
+    ],
+)
+def test_reduced_precision_modes_stay_close_to_fp32(
+    width,
+    scale,
+    epsilon,
+    mode,
+    forward_tolerance,
+    gradient_tolerance,
+    min_cosine,
+):
+    x_bf16 = jax.random.normal(
+        jax.random.key(width), (3, width), dtype=jnp.bfloat16
+    ) * jnp.asarray(scale, dtype=jnp.bfloat16)
+
+    # BF16 parameters and quantized inputs isolate score-computation error from
+    # parameter/input quantization when comparing with the FP32 reference.
+    reference = YatNMN(
+        width,
+        24,
+        dtype=jnp.float32,
+        param_dtype=jnp.bfloat16,
+        compute_mode="fp32",
+        epsilon=epsilon,
+        rngs=nnx.Rngs(42),
+    )
+    candidate = YatNMN(
+        width,
+        24,
+        dtype=jnp.bfloat16,
+        param_dtype=jnp.bfloat16,
+        compute_mode=mode,
+        epsilon=epsilon,
+        rngs=nnx.Rngs(42),
+    )
+
+    x_fp32 = x_bf16.astype(jnp.float32)
+    reference_output = reference(x_fp32)
+    candidate_output = candidate(x_bf16).astype(jnp.float32)
+    reference_grad = jax.grad(lambda x: _loss(reference, x))(x_fp32)
+    candidate_grad = jax.grad(lambda x: _loss(candidate, x))(x_bf16).astype(
+        jnp.float32
+    )
+
+    assert jnp.isfinite(candidate_output).all()
+    assert jnp.isfinite(candidate_grad).all()
+    forward_error = jnp.linalg.norm(candidate_output - reference_output)
+    forward_error /= jnp.maximum(jnp.linalg.norm(reference_output), 1e-12)
+    gradient_error = jnp.linalg.norm(candidate_grad - reference_grad)
+    gradient_error /= jnp.maximum(jnp.linalg.norm(reference_grad), 1e-12)
+    gradient_cosine = jnp.vdot(candidate_grad.ravel(), reference_grad.ravel())
+    gradient_cosine /= (
+        jnp.linalg.norm(candidate_grad) * jnp.linalg.norm(reference_grad)
+    )
+
+    assert float(forward_error) < forward_tolerance
+    assert float(gradient_error) < gradient_tolerance
+    assert float(gradient_cosine) > min_cosine
+
+
+@pytest.mark.parametrize(
+    ("low_dtype", "forward_tolerance", "gradient_tolerance"),
+    [
+        (jnp.float16, 0.002, 0.003),
+        (jnp.bfloat16, 0.01, 0.02),
+    ],
+)
+def test_mixed_mode_supports_float16_and_bfloat16_with_fp32_parity(
+    low_dtype, forward_tolerance, gradient_tolerance
+):
+    width = 32
+    x_low = jax.random.normal(jax.random.key(1), (3, width), dtype=low_dtype)
+    reference = YatNMN(
+        width,
+        24,
+        dtype=jnp.float32,
+        param_dtype=low_dtype,
+        compute_mode="fp32",
+        epsilon=1e-3,
+        rngs=nnx.Rngs(42),
+    )
+    candidate = YatNMN(
+        width,
+        24,
+        dtype=low_dtype,
+        param_dtype=low_dtype,
+        compute_mode="mixed",
+        epsilon=1e-3,
+        rngs=nnx.Rngs(42),
+    )
+
+    x_fp32 = x_low.astype(jnp.float32)
+    reference_output = reference(x_fp32)
+    candidate_output = candidate(x_low).astype(jnp.float32)
+    reference_grad = jax.grad(lambda x: _loss(reference, x))(x_fp32)
+    candidate_grad = jax.grad(lambda x: _loss(candidate, x))(x_low).astype(
+        jnp.float32
+    )
+
+    forward_error = jnp.linalg.norm(candidate_output - reference_output)
+    forward_error /= jnp.maximum(jnp.linalg.norm(reference_output), 1e-12)
+    gradient_error = jnp.linalg.norm(candidate_grad - reference_grad)
+    gradient_error /= jnp.maximum(jnp.linalg.norm(reference_grad), 1e-12)
+
+    assert jnp.isfinite(candidate_output).all()
+    assert jnp.isfinite(candidate_grad).all()
+    assert float(forward_error) < forward_tolerance
+    assert float(gradient_error) < gradient_tolerance
+
+
+def test_mixed_mode_uses_bf16_dot_operands_with_fp32_output():
+    calls = []
+
+    def recording_dot_general(lhs, rhs, dimension_numbers, **kwargs):
+        calls.append((lhs.dtype, rhs.dtype, kwargs.get("preferred_element_type")))
+        return lax.dot_general(lhs, rhs, dimension_numbers, **kwargs)
+
+    layer = _layer(16, "mixed", dot_general=recording_dot_general)
+    x = jnp.ones((2, 16), dtype=jnp.bfloat16)
+    layer(x)
+
+    assert calls == [(jnp.bfloat16, jnp.bfloat16, jnp.float32)]
+
+
+def test_mixed_lowering_keeps_bf16_dot_operands():
+    layer = _layer(16, "mixed")
+    x = jnp.ones((2, 16), dtype=jnp.bfloat16)
+    lowered = jax.jit(lambda inputs: layer(inputs)).lower(x).as_text()
+    dot_lines = [line for line in lowered.splitlines() if "dot_general" in line]
+
+    assert any(
+        "(tensor<2x16xbf16>, tensor<16x24xbf16>) -> tensor<2x24xf32>" in line
+        for line in dot_lines
+    ), "mixed mode did not lower to BF16 dot operands with an FP32 result"
+
+
+def test_bf16_mode_uses_strict_bf16_dot_operands():
+    calls = []
+
+    def recording_dot_general(lhs, rhs, dimension_numbers, **kwargs):
+        calls.append((lhs.dtype, rhs.dtype, kwargs.get("preferred_element_type")))
+        return lax.dot_general(lhs, rhs, dimension_numbers, **kwargs)
+
+    layer = _layer(16, "bf16", dot_general=recording_dot_general)
+    x = jnp.ones((2, 16), dtype=jnp.bfloat16)
+    layer(x)
+
+    assert calls == [(jnp.bfloat16, jnp.bfloat16, None)]
+
+
+@pytest.mark.parametrize("fused", [False, True])
+def test_bf16_distance_floor_keeps_near_collision_finite(fused):
+    width = 64
+    layer = YatNMN(
+        width,
+        1,
+        dtype=jnp.bfloat16,
+        param_dtype=jnp.bfloat16,
+        compute_mode="bf16",
+        fused=fused,
+        epsilon=1e-5,
+        distance_floor=1e-2,
+        learnable_epsilon=True,
+        rngs=nnx.Rngs(0),
+    )
+    x = jax.random.normal(jax.random.key(7), (1, width), dtype=jnp.bfloat16)
+    layer.kernel[...] = x.T
+
+    output = layer(x)
+    _, grads = jax.value_and_grad(_loss)(layer, x)
+
+    assert jnp.isfinite(output).all()
+    for leaf in jax.tree.leaves(grads):
+        if hasattr(leaf, "dtype"):
+            assert jnp.isfinite(leaf).all()
+
+
+def test_fp32_explicit_mode_preserves_default_behavior():
+    default = YatNMN(16, 8, rngs=nnx.Rngs(5))
+    explicit = YatNMN(16, 8, compute_mode="fp32", rngs=nnx.Rngs(5))
+    x = jax.random.normal(jax.random.key(6), (2, 16))
+
+    np.testing.assert_array_equal(default(x), explicit(x))
+
+
+@pytest.mark.parametrize("mode", ["float16", "auto", ""])
+def test_invalid_compute_mode_is_rejected(mode):
+    with pytest.raises(ValueError, match="compute_mode"):
+        YatNMN(4, 2, compute_mode=mode, rngs=nnx.Rngs(0))
+
+
+@pytest.mark.parametrize("distance_floor", [-1e-3, np.inf, np.nan])
+def test_invalid_distance_floor_is_rejected(distance_floor):
+    with pytest.raises(ValueError, match="distance_floor"):
+        YatNMN(4, 2, distance_floor=distance_floor, rngs=nnx.Rngs(0))


### PR DESCRIPTION
Closes #47. Adds explicit fp32, mixed, and bf16 YatNMN compute modes while preserving fp32 as the default. Mixed mode uses low-precision operands with fp32 accumulation; strict bf16 uses dimension-scaled distance math and configurable floors. Standard and fused paths share the same numerical contract, including clamp-consistent gradients. Adds 26 focused forward/input-gradient/parameter-gradient parity and stability tests plus precision documentation. Full NNX suite: 313 passed, 1 skipped.