### PR TITLE
Fix doctor backend probe isolation

### DIFF
--- a/src/nmn/__init__.py
+++ b/src/nmn/__init__.py
@@ -24,8 +24,9 @@ def doctor():
     """
     from nmn import cli
 
-    print(cli._render_doctor())
-    return cli._doctor_report()
+    report = cli._doctor_report()
+    print(cli._render_doctor(report))
+    return report
 
 
 __all__ = [

--- a/src/nmn/cli.py
+++ b/src/nmn/cli.py
@@ -2,8 +2,9 @@
 
 This module is deliberately *import-light*: importing ``nmn.cli`` must NOT
 import any heavy framework (torch / jax / flax / tensorflow / keras / mlx).
-Only the :func:`doctor` command attempts framework imports, each guarded in a
-``try``/``except`` so a missing backend never raises.
+Only the :func:`doctor` command attempts framework imports.  Each backend is
+probed in a bounded child process so a missing, hanging, or natively crashing
+backend cannot take down the CLI.
 
 Entry points::
 
@@ -17,10 +18,11 @@ terminal and greppable by coding agents.
 from __future__ import annotations
 
 import argparse
-import importlib
+import json
 import platform
+import subprocess
 import sys
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 # ---------------------------------------------------------------------------
 # Static metadata (kept here so the CLI needs no heavy imports)
@@ -97,6 +99,24 @@ _ALIASES = {
     "tensorflow": "tf",
     "mlx": "mlx",
 }
+
+# Backend imports are deliberately performed in a fresh interpreter.  Some
+# optional runtimes initialise native accelerators at import time and can abort
+# the process before Python gets a chance to raise an exception.  The marker
+# lets us ignore any informational output emitted by a backend during import.
+_DOCTOR_PROBE_MARKER = "__NMN_DOCTOR_RESULT__="
+_DOCTOR_PROBE_TIMEOUT_SECONDS = 15.0
+_DOCTOR_PROBE_SCRIPT = f"""\
+import importlib
+import json
+import sys
+
+version = None
+for module_name in json.loads(sys.argv[1]):
+    module = importlib.import_module(module_name)
+    version = getattr(module, "__version__", "unknown")
+print({_DOCTOR_PROBE_MARKER!r} + json.dumps(str(version)))
+"""
 
 
 def _version() -> str:
@@ -312,26 +332,57 @@ Lazy YatNMN (freeze ONLY the kernel; bias / alpha / epsilon stay trainable):
 """
 
 
+def _probe_backend(probes: Sequence[str]) -> Optional[str]:
+    """Return a backend version from an isolated import probe.
+
+    ``None`` covers every unavailable state: a normal import error, another
+    Python exception, a non-zero child exit, a signal/native abort, malformed
+    probe output, or an import that exceeds the timeout.  Diagnostics should
+    never make the parent process less reliable than the package it diagnoses.
+    """
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _DOCTOR_PROBE_SCRIPT, json.dumps(list(probes))],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_DOCTOR_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if completed.returncode != 0:
+        return None
+
+    for line in reversed(completed.stdout.splitlines()):
+        if not line.startswith(_DOCTOR_PROBE_MARKER):
+            continue
+        try:
+            version = json.loads(line[len(_DOCTOR_PROBE_MARKER) :])
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+        return version if isinstance(version, str) else None
+    return None
+
+
 def _doctor_report() -> Dict[str, Optional[str]]:
     """Probe each backend; return {framework: version_or_None}. Never raises."""
     result: Dict[str, Optional[str]] = {}
+    # NNX and Linen intentionally share the same JAX/Flax dependency probe.
+    # Reuse identical results so diagnostics do not initialise the same heavy
+    # runtime in two separate processes.
+    cache: Dict[tuple[str, ...], Optional[str]] = {}
     for key, meta in FRAMEWORKS.items():
-        version: Optional[str] = None
-        ok = True
-        for mod_name in meta["probes"]:
-            try:
-                mod = importlib.import_module(mod_name)
-                version = getattr(mod, "__version__", "unknown")
-            except Exception:
-                ok = False
-                version = None
-                break
-        result[key] = version if ok else None
+        probes = tuple(meta["probes"])
+        if probes not in cache:
+            cache[probes] = _probe_backend(probes)
+        result[key] = cache[probes]
     return result
 
 
-def _render_doctor() -> str:
-    report = _doctor_report()
+def _render_doctor(report: Optional[Dict[str, Optional[str]]] = None) -> str:
+    if report is None:
+        report = _doctor_report()
     lines: List[str] = []
     lines.append(f"nmn {_version()}")
     lines.append(f"Python {platform.python_version()} ({sys.executable})")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import importlib
+import json
+import os
+import signal
+import subprocess
 import sys
 
 import pytest
@@ -259,6 +263,125 @@ def test_doctor_lists_all_backends(capsys):
     assert "Python" in out
 
 
+# ---------------------------------------------------------------------------
+# Doctor isolation: optional backends cannot crash or hang the caller.
+# ---------------------------------------------------------------------------
+
+def _probe_result(*, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=[sys.executable],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_doctor_probe_success_ignores_backend_output(monkeypatch):
+    marker = cli._DOCTOR_PROBE_MARKER
+    completed = _probe_result(
+        stdout=f"backend initialization message\n{marker}{json.dumps('2.4.1')}\n"
+    )
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return completed
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    assert cli._probe_backend(["first", "second.core"]) == "2.4.1"
+    command, kwargs = calls[0]
+    assert command[:3] == [sys.executable, "-c", cli._DOCTOR_PROBE_SCRIPT]
+    assert json.loads(command[3]) == ["first", "second.core"]
+    assert kwargs["timeout"] == cli._DOCTOR_PROBE_TIMEOUT_SECONDS
+    assert kwargs["capture_output"] is True
+    assert kwargs["check"] is False
+
+
+def test_doctor_probe_missing_import_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *args, **kwargs: _probe_result(
+            returncode=1,
+            stderr="ModuleNotFoundError: No module named 'optional_backend'",
+        ),
+    )
+    assert cli._probe_backend(["optional_backend"]) is None
+
+
+def test_doctor_probe_python_exception_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *args, **kwargs: _probe_result(
+            returncode=1, stderr="RuntimeError: backend initialization failed"
+        ),
+    )
+    assert cli._probe_backend(["broken_backend"]) is None
+
+
+def test_doctor_probe_timeout_is_unavailable(monkeypatch):
+    def time_out(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(cli.subprocess, "run", time_out)
+    assert cli._probe_backend(["hanging_backend"]) is None
+
+
+def test_doctor_probe_nonzero_exit_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *args, **kwargs: _probe_result(returncode=23),
+    )
+    assert cli._probe_backend(["exiting_backend"]) is None
+
+
+def test_doctor_probe_native_abort_is_unavailable(monkeypatch):
+    # On POSIX, a negative return code identifies the terminating signal.  A
+    # native extension abort therefore remains data in the parent pytest
+    # process rather than aborting pytest itself.
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *args, **kwargs: _probe_result(returncode=-signal.SIGABRT),
+    )
+    assert cli._probe_backend(["aborting_backend"]) is None
+
+
+def test_doctor_probe_really_isolates_signal_termination(tmp_path, monkeypatch):
+    probe = tmp_path / "signal_backend.py"
+    probe.write_text(
+        "import os\nimport signal\nos.kill(os.getpid(), signal.SIGTERM)\n",
+        encoding="utf-8",
+    )
+    existing = os.environ.get("PYTHONPATH")
+    pythonpath = str(tmp_path)
+    if existing:
+        pythonpath += os.pathsep + existing
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
+
+    assert cli._probe_backend(["signal_backend"]) is None
+
+
+def test_doctor_report_preserves_public_shape(monkeypatch):
+    versions = iter(["1", "2", "4", None, "6"])
+    monkeypatch.setattr(cli, "_probe_backend", lambda probes: next(versions))
+
+    report = cli._doctor_report()
+
+    assert list(report) == ["torch", "nnx", "linen", "keras", "tf", "mlx"]
+    assert report == {
+        "torch": "1",
+        "nnx": "2",
+        "linen": "2",
+        "keras": "4",
+        "tf": None,
+        "mlx": "6",
+    }
+
+
 def test_examples_points_to_examples_md(capsys):
     assert cli.main(["examples"]) == 0
     out = capsys.readouterr().out
@@ -288,3 +411,36 @@ def test_nmn_doctor_returns_dict(capsys):
     # values are either a version string or None; never raises on missing.
     for value in report.values():
         assert value is None or isinstance(value, str)
+
+
+def test_nmn_doctor_probes_once_and_renders_same_report(monkeypatch, capsys):
+    import nmn
+
+    # ``test_cli_import_is_light`` deliberately reloads this module, so patch
+    # the currently registered instance used by ``nmn.doctor``.
+    active_cli = nmn.cli
+
+    expected = {
+        "torch": "2.0",
+        "nnx": None,
+        "linen": None,
+        "keras": None,
+        "tf": None,
+        "mlx": None,
+    }
+    calls = 0
+
+    def fake_report():
+        nonlocal calls
+        calls += 1
+        return expected
+
+    monkeypatch.setattr(active_cli, "_doctor_report", fake_report)
+
+    assert nmn.doctor() is expected
+    output = capsys.readouterr().out
+    assert calls == 1
+    assert "torch  PyTorch" in output
+    assert "OK       version 2.0" in output
+    assert "nnx    Flax NNX" in output
+    assert "MISSING" in output


### PR DESCRIPTION
Closes #60. Runs optional-backend probes in bounded child processes so missing imports, Python exceptions, timeouts, nonzero exits, signals, and native aborts are reported without terminating nmn doctor. Adds deterministic regression coverage and preserves the programmatic return contract.