### PR TITLE
Stabilize PyTorch dtypes and shared kernel banks

### DIFF
--- a/docs/guides/pytorch.md
+++ b/docs/guides/pytorch.md
@@ -243,6 +243,7 @@ but still want the scale (`alpha`), shift (`bias`), and `epsilon` to adapt.
 | Symptom                                       | Likely cause                                             | Fix                                                                          |
 | --------------------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `NaN` loss within first ~100 steps            | `epsilon` too small for input/weight scale               | Use `YatNMN(..., epsilon=1e-3)` or `1e-2` for fp16/bf16                      |
+| fp16/bf16 gradient overflows after accumulation | The true sum exceeds the storage dtype's finite range  | Keep parameters/gradient accumulation in fp32; use autocast and loss scaling |
 | Loss plateaus very early                      | α uninitialized / fixed at 1.0                           | `YatNMN(..., use_alpha=True)`, or `constant_alpha=True` (fixes α = √2)       |
 | Output range very small                       | Weights too small at init                                | Default init usually works; if not, increase init scale or use `use_alpha`    |
 | Gradient explodes in late training            | Unnormalized inputs reaching a Yat layer                 | Add `LayerNorm` *before* the first Yat layer (not between Yat layers)        |

--- a/src/nmn/torch/README.md
+++ b/src/nmn/torch/README.md
@@ -190,7 +190,9 @@ Share kernel parameters across multiple layers to **reduce model size** and **en
 
 **Key concepts:**
 - **Kernel Bank**: A shared parameter store for multiple layers
-- **Auto-expansion**: Automatically grows when a larger layer needs more features
+- **Construction-time auto-expansion**: Grows when a larger layer is constructed,
+  until the first tied consumer executes. The first forward freezes capacity so
+  live gradients and optimizer state can never be invalidated.
 - **First-k slicing**: Layers extract the first k filters they need
 
 ```python
@@ -206,7 +208,7 @@ layer1 = YatConv2D(
 )
 
 layer2 = YatConv2D(
-    in_channels=32,
+    in_channels=3,
     out_channels=64,  # Automatically expands bank to 64
     kernel_size=3,
     tie_kernel_bank=True,
@@ -214,7 +216,7 @@ layer2 = YatConv2D(
 )
 
 layer3 = YatConv2D(
-    in_channels=64,
+    in_channels=3,
     out_channels=128,  # Automatically expands bank to 128
     kernel_size=3,
     tie_kernel_bank=True,
@@ -223,6 +225,10 @@ layer3 = YatConv2D(
 
 # All three layers share kernels, bank auto-expanded: 32 -> 64 -> 128
 ```
+
+Build every tied consumer before running any of them, or set
+`kernel_bank_size` on the first consumer to the maximum required capacity.
+Requesting a larger capacity after the first forward raises `ValueError`.
 
 **Output:**
 ```

--- a/src/nmn/torch/README.md
+++ b/src/nmn/torch/README.md
@@ -230,6 +230,12 @@ Build every tied consumer before running any of them, or set
 `kernel_bank_size` on the first consumer to the maximum required capacity.
 Requesting a larger capacity after the first forward raises `ValueError`.
 
+Because PyTorch applies `.to()`, `.float()`, `.double()`, and similar operations
+one module at a time, they cannot safely migrate a class-level shared bank.
+Tied consumers therefore reject post-construction device/dtype migration with
+`RuntimeError`; construct every tied layer with its target `device`, `dtype`, or
+`param_dtype`. Non-tied layers retain normal migration behavior.
+
 **Output:**
 ```
 Auto-expanding kernel bank 'resnet-conv': 32 -> 64 filters

--- a/src/nmn/torch/README.md
+++ b/src/nmn/torch/README.md
@@ -234,7 +234,8 @@ Because PyTorch applies `.to()`, `.float()`, `.double()`, and similar operations
 one module at a time, they cannot safely migrate a class-level shared bank.
 Tied consumers therefore reject post-construction device/dtype migration with
 `RuntimeError`; construct every tied layer with its target `device`, `dtype`, or
-`param_dtype`. Non-tied layers retain normal migration behavior.
+`param_dtype`. `YatNMN` and all tied convolution layers accept `device=` for
+this purpose. Non-tied layers retain normal migration behavior.
 
 **Output:**
 ```
@@ -654,6 +655,7 @@ YatNMN(
     tie_kernel_bank: bool = False,
     kernel_bank_size: Optional[int] = None,
     kernel_bank_id: str = 'default',
+    device=None,
 )
 ```
 

--- a/src/nmn/torch/_precision.py
+++ b/src/nmn/torch/_precision.py
@@ -6,31 +6,50 @@ import torch
 from torch import Tensor
 
 
-class _SaturatingUpcast(torch.autograd.Function):
-    """Upcast low-precision values while saturating their returning gradient.
+def _saturate_gradient(grad_output: Tensor, input_dtype: torch.dtype) -> Tensor:
+    limits = torch.finfo(input_dtype)
+    return grad_output.clamp(min=limits.min, max=limits.max).to(input_dtype)
 
-    YAT scores can have a finite fp16 forward value while their derivative is
-    larger than fp16 can represent.  A normal ``Tensor.float()`` sends that
-    derivative back through an fp16 cast as infinity.  This boundary keeps the
-    fp32 computation unchanged and saturates only the gradient written to the
-    low-precision leaf.
-    """
 
-    @staticmethod
-    def forward(ctx, tensor: Tensor) -> Tensor:
-        ctx.input_dtype = tensor.dtype
-        return tensor.float()
+if hasattr(torch.autograd.Function, "setup_context"):
 
-    @staticmethod
-    def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
-        limits = torch.finfo(ctx.input_dtype)
-        grad = torch.nan_to_num(
-            grad_output,
-            nan=0.0,
-            posinf=limits.max,
-            neginf=limits.min,
-        ).clamp(min=limits.min, max=limits.max)
-        return (grad.to(ctx.input_dtype),)
+    class _SaturatingUpcast(torch.autograd.Function):
+        """Modern autograd boundary with torch.func transform support."""
+
+        generate_vmap_rule = True
+
+        @staticmethod
+        def forward(tensor: Tensor) -> Tensor:
+            return tensor.float()
+
+        @staticmethod
+        def setup_context(ctx, inputs, output) -> None:
+            del output
+            (tensor,) = inputs
+            ctx.input_dtype = tensor.dtype
+
+        @staticmethod
+        def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
+            return (_saturate_gradient(grad_output, ctx.input_dtype),)
+
+        @staticmethod
+        def jvp(ctx, grad_tensor: Tensor) -> Tensor:
+            del ctx
+            return grad_tensor.float()
+
+else:  # pragma: no cover - compatibility path for torch 1.11-1.x
+
+    class _SaturatingUpcast(torch.autograd.Function):
+        """Legacy autograd boundary for PyTorch versions before torch.func."""
+
+        @staticmethod
+        def forward(ctx, tensor: Tensor) -> Tensor:
+            ctx.input_dtype = tensor.dtype
+            return tensor.float()
+
+        @staticmethod
+        def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
+            return (_saturate_gradient(grad_output, ctx.input_dtype),)
 
 
 def saturating_upcast(tensor: Tensor) -> Tensor:

--- a/src/nmn/torch/_precision.py
+++ b/src/nmn/torch/_precision.py
@@ -1,0 +1,40 @@
+"""Autograd-safe precision helpers shared by PyTorch YAT layers."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+
+class _SaturatingUpcast(torch.autograd.Function):
+    """Upcast low-precision values while saturating their returning gradient.
+
+    YAT scores can have a finite fp16 forward value while their derivative is
+    larger than fp16 can represent.  A normal ``Tensor.float()`` sends that
+    derivative back through an fp16 cast as infinity.  This boundary keeps the
+    fp32 computation unchanged and saturates only the gradient written to the
+    low-precision leaf.
+    """
+
+    @staticmethod
+    def forward(ctx, tensor: Tensor) -> Tensor:
+        ctx.input_dtype = tensor.dtype
+        return tensor.float()
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor) -> tuple[Tensor]:
+        limits = torch.finfo(ctx.input_dtype)
+        grad = torch.nan_to_num(
+            grad_output,
+            nan=0.0,
+            posinf=limits.max,
+            neginf=limits.min,
+        ).clamp(min=limits.min, max=limits.max)
+        return (grad.to(ctx.input_dtype),)
+
+
+def saturating_upcast(tensor: Tensor) -> Tensor:
+    """Return fp32 ``tensor`` with a finite low-precision gradient boundary."""
+    if tensor.dtype in (torch.float16, torch.bfloat16):
+        return _SaturatingUpcast.apply(tensor)
+    return tensor.float()

--- a/src/nmn/torch/attention/multi_head.py
+++ b/src/nmn/torch/attention/multi_head.py
@@ -157,6 +157,13 @@ class MultiHeadYatAttention(nn.Module):
             t.to(target) if t is not None else None for t in tensors
         )
 
+    def _linear(self, input: Tensor, projection: nn.Linear) -> Tensor:
+        """Run a projection in compute dtype while retaining stored parameters."""
+        input, weight, bias = self._promote_dtype(
+            input, projection.weight, projection.bias
+        )
+        return F.linear(input, weight, bias)
+
     def forward(
         self,
         query: Tensor,
@@ -191,9 +198,9 @@ class MultiHeadYatAttention(nn.Module):
         kv_len = key.shape[1]
 
         # Project Q, K, V
-        q = self.q_proj(query)
-        k = self.k_proj(key)
-        v = self.v_proj(value)
+        q = self._linear(query, self.q_proj)
+        k = self._linear(key, self.k_proj)
+        v = self._linear(value, self.v_proj)
 
         # Reshape to multi-head: (B, L, E) → (B, L, H, D)
         q = q.reshape(batch_size, q_len, self.num_heads, self.head_dim)
@@ -236,6 +243,6 @@ class MultiHeadYatAttention(nn.Module):
 
         # Output projection
         if self.out_proj is not None:
-            x = self.out_proj(x)
+            x = self._linear(x, self.out_proj)
 
         return x

--- a/src/nmn/torch/embed.py
+++ b/src/nmn/torch/embed.py
@@ -122,7 +122,11 @@ class YatEmbed(nn.Module):
             Tensor of shape (*query.shape[:-1], num_embeddings) with
             YAT similarity scores.
         """
+        output_dtype = query.dtype
         embedding = self.embedding
+        if output_dtype in (torch.float16, torch.bfloat16):
+            query = query.float()
+            embedding = embedding.float()
 
         # Spherical normalization
         if self.spherical:
@@ -134,11 +138,11 @@ class YatEmbed(nn.Module):
 
         # Squared distances
         if self.spherical:
-            distances = 2.0 - 2.0 * y
+            distances = (2.0 - 2.0 * y).clamp(min=0.0)
         else:
             query_sq = torch.sum(query ** 2, dim=-1, keepdim=True)
             embed_sq = torch.sum(embedding ** 2, dim=1, keepdim=True).t()
-            distances = query_sq + embed_sq - 2.0 * y
+            distances = (query_sq + embed_sq - 2.0 * y).clamp(min=0.0)
 
         # YAT: (dot)^2 / (dist + eps)
         y = y ** 2 / (distances + self.epsilon)
@@ -149,4 +153,6 @@ class YatEmbed(nn.Module):
         elif self.alpha is not None:
             y = y * self.alpha
 
-        return y
+        if output_dtype in (torch.float16, torch.bfloat16):
+            y = y.clamp(max=torch.finfo(output_dtype).max)
+        return y.to(output_dtype)

--- a/src/nmn/torch/embed.py
+++ b/src/nmn/torch/embed.py
@@ -14,6 +14,8 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn.parameter import Parameter
 
+from ._precision import saturating_upcast
+
 __all__ = ["YatEmbed"]
 
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
@@ -125,8 +127,8 @@ class YatEmbed(nn.Module):
         output_dtype = query.dtype
         embedding = self.embedding
         if output_dtype in (torch.float16, torch.bfloat16):
-            query = query.float()
-            embedding = embedding.float()
+            query = saturating_upcast(query)
+            embedding = saturating_upcast(embedding)
 
         # Spherical normalization
         if self.spherical:

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -24,6 +24,8 @@ from torch.nn import functional as F
 from torch.nn.modules.utils import _single
 from torch.nn.parameter import Parameter
 
+from .._precision import saturating_upcast
+
 
 __all__ = [
     "DEFAULT_CONSTANT_ALPHA",
@@ -95,6 +97,7 @@ def setup_yat_attrs(
             torch.full(
                 (1,), raw_eps,
                 dtype=storage_dtype if storage_dtype else torch.float32,
+                device=device,
             )
         )
     else:
@@ -157,7 +160,15 @@ def _resolve_alpha(layer, input: Tensor) -> Optional[Tensor]:
 
 def _resolve_eps(layer, dtype: torch.dtype):
     if layer.learnable_epsilon and layer.epsilon_param is not None:
-        return F.softplus(layer.epsilon_param.to(dtype))
+        epsilon_param = layer.epsilon_param
+        if dtype == torch.float32 and epsilon_param.dtype in (
+            torch.float16,
+            torch.bfloat16,
+        ):
+            epsilon_param = saturating_upcast(epsilon_param)
+        else:
+            epsilon_param = epsilon_param.to(dtype)
+        return F.softplus(epsilon_param)
     return layer.epsilon
 
 
@@ -212,7 +223,7 @@ def yat_conv_forward(
         # cancellation-prone in low precision. Accumulate YAT math in fp32,
         # while preserving parameter storage and the public output dtype.
         input, weight, bias_val, alpha = tuple(
-            tensor.float() if tensor is not None else None
+            saturating_upcast(tensor) if tensor is not None else None
             for tensor in (input, weight, bias_val, alpha)
         )
 
@@ -303,7 +314,7 @@ def yat_conv_transpose_forward(
     output_dtype = input.dtype
     if output_dtype in (torch.float16, torch.bfloat16):
         input, weight, bias_val, alpha = tuple(
-            tensor.float() if tensor is not None else None
+            saturating_upcast(tensor) if tensor is not None else None
             for tensor in (input, weight, bias_val, alpha)
         )
 

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -135,7 +135,16 @@ def promote_to_compute_dtype(layer, *tensors: Optional[Tensor]):
                 break
         if target is None:
             target = torch.float32
-    return tuple(t.to(target) if t is not None else None for t in tensors)
+    return tuple(
+        (
+            saturating_upcast(t).to(target)
+            if t is not None
+            and t.dtype in (torch.float16, torch.bfloat16)
+            and target != t.dtype
+            else t.to(target) if t is not None else None
+        )
+        for t in tensors
+    )
 
 
 def _resolve_bias_val(layer, weight: Tensor, out_channels: int) -> Optional[Tensor]:
@@ -161,11 +170,11 @@ def _resolve_alpha(layer, input: Tensor) -> Optional[Tensor]:
 def _resolve_eps(layer, dtype: torch.dtype):
     if layer.learnable_epsilon and layer.epsilon_param is not None:
         epsilon_param = layer.epsilon_param
-        if dtype == torch.float32 and epsilon_param.dtype in (
+        if dtype != epsilon_param.dtype and epsilon_param.dtype in (
             torch.float16,
             torch.bfloat16,
         ):
-            epsilon_param = saturating_upcast(epsilon_param)
+            epsilon_param = saturating_upcast(epsilon_param).to(dtype)
         else:
             epsilon_param = epsilon_param.to(dtype)
         return F.softplus(epsilon_param)

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -188,6 +188,7 @@ def yat_conv_forward(
     *,
     out_channels: int,
     deterministic: bool = False,
+    weight_override: Optional[Tensor] = None,
 ) -> Tensor:
     """Shared forward body for YatConv{1,2,3}D.
 
@@ -198,13 +199,22 @@ def yat_conv_forward(
     use_dropconnect, drop_rate, training, mask, weight_normalized,
     learnable_epsilon, epsilon_param, epsilon).
     """
-    weight = layer.weight
+    weight = layer.weight if weight_override is None else weight_override
     bias_val = _resolve_bias_val(layer, weight, out_channels)
     alpha = _resolve_alpha(layer, input)
 
     input, weight, bias_val, alpha = promote_to_compute_dtype(
         layer, input, weight, bias_val, alpha
     )
+    output_dtype = input.dtype
+    if output_dtype in (torch.float16, torch.bfloat16):
+        # The distance subtraction and reciprocal backward are particularly
+        # cancellation-prone in low precision. Accumulate YAT math in fp32,
+        # while preserving parameter storage and the public output dtype.
+        input, weight, bias_val, alpha = tuple(
+            tensor.float() if tensor is not None else None
+            for tensor in (input, weight, bias_val, alpha)
+        )
 
     # DropConnect (inverted-dropout pattern).
     if layer.use_dropconnect and not deterministic and layer.drop_rate > 0.0 and layer.training:
@@ -255,9 +265,14 @@ def yat_conv_forward(
         kernel_sq_sum = torch.sum(weight ** 2, dim=reduce_dims)
 
     view_shape = (1, -1) + (1,) * (dot_prod_map.dim() - 2)
-    distance_sq = patch_sq_sum + kernel_sq_sum.view(*view_shape) - 2 * dot_prod_map
+    distance_sq = (
+        patch_sq_sum + kernel_sq_sum.view(*view_shape) - 2 * dot_prod_map
+    ).clamp(min=0.0)
 
-    return _yat_score(layer, dot_prod_map, distance_sq, bias_val, alpha)
+    output = _yat_score(layer, dot_prod_map, distance_sq, bias_val, alpha)
+    if output_dtype in (torch.float16, torch.bfloat16):
+        output = output.clamp(max=torch.finfo(output_dtype).max)
+    return output.to(output_dtype)
 
 
 # ----------------------------------------------------------------------
@@ -285,6 +300,12 @@ def yat_conv_transpose_forward(
     input, weight, bias_val, alpha = promote_to_compute_dtype(
         layer, input, weight, bias_val, alpha
     )
+    output_dtype = input.dtype
+    if output_dtype in (torch.float16, torch.bfloat16):
+        input, weight, bias_val, alpha = tuple(
+            tensor.float() if tensor is not None else None
+            for tensor in (input, weight, bias_val, alpha)
+        )
 
     if layer.use_dropconnect and not deterministic and layer.drop_rate > 0.0 and layer.training:
         keep_prob = 1.0 - layer.drop_rate
@@ -322,6 +343,11 @@ def yat_conv_transpose_forward(
     kernel_sq_sum = (w_grouped ** 2).sum(dim=reduce_dims).reshape(-1)
 
     view_shape = (1, -1) + (1,) * (dot_prod_map.dim() - 2)
-    distance_sq = patch_sq_sum + kernel_sq_sum.view(*view_shape) - 2 * dot_prod_map
+    distance_sq = (
+        patch_sq_sum + kernel_sq_sum.view(*view_shape) - 2 * dot_prod_map
+    ).clamp(min=0.0)
 
-    return _yat_score(layer, dot_prod_map, distance_sq, bias_val, alpha)
+    output = _yat_score(layer, dot_prod_map, distance_sq, bias_val, alpha)
+    if output_dtype in (torch.float16, torch.bfloat16):
+        output = output.clamp(max=torch.finfo(output_dtype).max)
+    return output.to(output_dtype)

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import math
+import threading
 from typing import Optional, Union
 
 import torch
@@ -41,6 +42,7 @@ class YatConv1D(Conv1d):
     # Class-level shared kernel banks
     _KERNEL_BANKS = {}
     _KERNEL_BANK_USED = {}
+    _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
         self,
@@ -121,36 +123,36 @@ class YatConv1D(Conv1d):
         if tie_kernel_bank:
             bank_key = (
                 kernel_bank_id, in_channels, tuple(self.kernel_size), groups,
-                storage_dtype, self.weight.device,
+                self.weight.dtype, self.weight.device,
             )
-            shared_weight = YatConv1D._KERNEL_BANKS.get(bank_key)
-
-            if shared_weight is None:
-                # First layer: register the weight as shared
-                YatConv1D._KERNEL_BANKS[bank_key] = self.weight
-                YatConv1D._KERNEL_BANK_USED[bank_key] = False
-            else:
-                existing_channels = shared_weight.shape[0]
-                if bank_out_channels > existing_channels:
-                    if YatConv1D._KERNEL_BANK_USED.get(bank_key, False):
-                        raise ValueError(
-                            f"kernel bank '{kernel_bank_id}' capacity is frozen "
-                            f"at {existing_channels} after first use; requested "
-                            f"{bank_out_channels}"
+            with YatConv1D._KERNEL_BANKS_LOCK:
+                shared_weight = YatConv1D._KERNEL_BANKS.get(bank_key)
+                if shared_weight is None:
+                    YatConv1D._KERNEL_BANKS[bank_key] = self.weight
+                    YatConv1D._KERNEL_BANK_USED[bank_key] = False
+                else:
+                    if (shared_weight.device != self.weight.device
+                            or shared_weight.dtype != self.weight.dtype):
+                        raise RuntimeError("shared kernel bank device/dtype registry is stale")
+                    existing_channels = shared_weight.shape[0]
+                    if bank_out_channels > existing_channels:
+                        if YatConv1D._KERNEL_BANK_USED.get(bank_key, False):
+                            raise ValueError(
+                                f"kernel bank '{kernel_bank_id}' capacity is frozen "
+                                f"at {existing_channels} after first use; requested "
+                                f"{bank_out_channels}"
+                            )
+                        old_weight = shared_weight.data
+                        new_weight = torch.empty(
+                            (bank_out_channels,) + old_weight.shape[1:],
+                            dtype=old_weight.dtype,
+                            device=old_weight.device,
                         )
-                    old_weight = shared_weight.data
-                    new_weight = torch.empty(
-                        (bank_out_channels,) + old_weight.shape[1:],
-                        dtype=old_weight.dtype,
-                        device=old_weight.device,
-                    )
-                    nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
-                    new_weight[:existing_channels].copy_(old_weight)
-                    shared_weight.data = new_weight
-                    
-                self.weight = shared_weight
-
-            self._kernel_bank_key = bank_key
+                        nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
+                        new_weight[:existing_channels].copy_(old_weight)
+                        shared_weight.data = new_weight
+                    self.weight = shared_weight
+                self._kernel_bank_key = bank_key
 
             if bias and constant_bias is None and not scalar_bias:
                 self.bias = Parameter(
@@ -175,7 +177,8 @@ class YatConv1D(Conv1d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            YatConv1D._KERNEL_BANK_USED[self._kernel_bank_key] = True
+            with YatConv1D._KERNEL_BANKS_LOCK:
+                YatConv1D._KERNEL_BANK_USED[self._kernel_bank_key] = True
             return yat_conv_forward(
                 self, input, F.conv1d,
                 out_channels=out_channels,
@@ -187,3 +190,11 @@ class YatConv1D(Conv1d):
             out_channels=out_channels,
             deterministic=deterministic,
         )
+
+    def _apply(self, fn, recurse=True):
+        if getattr(self, "tie_kernel_bank", False):
+            raise RuntimeError(
+                "device/dtype migration is unsupported for tied kernel-bank "
+                "consumers; construct them with the target device and dtype"
+            )
+        return super()._apply(fn, recurse=recurse)

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-import logging
 import math
 from typing import Optional, Union
 
@@ -12,8 +11,6 @@ from torch.nn.parameter import Parameter
 from torch.nn import Conv1d
 
 from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["YatConv1D"]
 
@@ -78,6 +75,11 @@ class YatConv1D(Conv1d):
         # Handle shared kernel bank
         if tie_kernel_bank:
             bank_out_channels = kernel_bank_size or out_channels
+            if bank_out_channels < out_channels:
+                raise ValueError(
+                    f"kernel_bank_size ({bank_out_channels}) must be at least "
+                    f"out_channels ({out_channels})"
+                )
         else:
             bank_out_channels = out_channels
 
@@ -115,30 +117,23 @@ class YatConv1D(Conv1d):
         
         # Handle auto-expanding shared kernel bank
         if tie_kernel_bank:
-            bank_key = (kernel_bank_id, in_channels, kernel_size, groups, storage_dtype)
+            bank_key = (
+                kernel_bank_id, in_channels, tuple(self.kernel_size), groups,
+                storage_dtype, self.weight.device,
+            )
             shared_weight = YatConv1D._KERNEL_BANKS.get(bank_key)
 
             if shared_weight is None:
                 # First layer: register the weight as shared
                 YatConv1D._KERNEL_BANKS[bank_key] = self.weight
             else:
-                # Bank exists: auto-expand if needed
                 existing_channels = shared_weight.shape[0]
                 if bank_out_channels > existing_channels:
-                    # Auto-expand: pad with new random initialization
-                    logger.info("Auto-expanding kernel bank '%s': %d -> %d filters",
-                                kernel_bank_id, existing_channels, bank_out_channels)
-                    old_weight = shared_weight.data
-                    # Create new weight with expanded size
-                    new_weight = torch.empty(
-                        (bank_out_channels,) + old_weight.shape[1:],
-                        dtype=storage_dtype,
-                        device=old_weight.device
+                    raise ValueError(
+                        f"kernel bank '{kernel_bank_id}' has immutable capacity "
+                        f"{existing_channels}, requested {bank_out_channels}; create "
+                        "the first consumer with a sufficient kernel_bank_size"
                     )
-                    nn.init.kaiming_uniform_(new_weight, nonlinearity='relu')
-                    # Copy old weights
-                    new_weight[:existing_channels].copy_(old_weight)
-                    shared_weight.data = new_weight
                     
                 self.weight = shared_weight
 
@@ -149,6 +144,8 @@ class YatConv1D(Conv1d):
                 fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
                 bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
                 nn.init.uniform_(self.bias, -bound, bound)
+
+        self.out_channels = out_channels
 
         setup_yat_attrs(
             self,

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -9,8 +9,6 @@ from torch import Tensor
 from torch.nn import functional as F
 from torch.nn.common_types import _size_1_t
 from torch.nn.parameter import Parameter
-from torch.nn.modules.utils import _single
-
 from torch.nn import Conv1d
 
 from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
@@ -85,7 +83,7 @@ class YatConv1D(Conv1d):
 
         # If constant_bias or scalar_bias is set, don't allocate a per-channel
         # learnable bias in the parent — we handle bias ourselves.
-        parent_bias = False if (constant_bias is not None or scalar_bias) else bias
+        parent_bias = not (tie_kernel_bank or constant_bias is not None or scalar_bias) and bias
 
         super().__init__(
             in_channels,
@@ -144,6 +142,14 @@ class YatConv1D(Conv1d):
                     
                 self.weight = shared_weight
 
+            if bias and constant_bias is None and not scalar_bias:
+                self.bias = Parameter(
+                    torch.empty(out_channels, device=device, dtype=storage_dtype)
+                )
+                fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+                bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+                nn.init.uniform_(self.bias, -bound, bound)
+
         setup_yat_attrs(
             self,
             bias=bias, constant_bias=constant_bias,
@@ -157,16 +163,12 @@ class YatConv1D(Conv1d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            original_weight = self.weight
-            self.weight = nn.Parameter(original_weight[self._kernel_slice])
-            try:
-                return yat_conv_forward(
-                    self, input, F.conv1d,
-                    out_channels=out_channels,
-                    deterministic=deterministic,
-                )
-            finally:
-                self.weight = original_weight
+            return yat_conv_forward(
+                self, input, F.conv1d,
+                out_channels=out_channels,
+                deterministic=deterministic,
+                weight_override=self.weight[self._kernel_slice],
+            )
         return yat_conv_forward(
             self, input, F.conv1d,
             out_channels=out_channels,

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -31,7 +31,8 @@ class YatConv1D(Conv1d):
             This optimization avoids recomputing kernel norms in YAT distance
             calculation since they are guaranteed to be 1.0.
         tie_kernel_bank: If True, reuse shared kernels across compatible layers.
-        kernel_bank_size: Optional explicit size for shared bank (auto-expands if needed).
+        kernel_bank_size: Optional explicit capacity. The bank auto-expands only
+            during construction, before any tied consumer executes.
         kernel_bank_id: Namespace for shared banks (allows multiple independent banks).
         param_dtype: dtype for parameter initialization (default: None, uses
             PyTorch Conv1d default). Separate from computation dtype.
@@ -39,6 +40,7 @@ class YatConv1D(Conv1d):
     
     # Class-level shared kernel banks
     _KERNEL_BANKS = {}
+    _KERNEL_BANK_USED = {}
 
     def __init__(
         self,
@@ -126,16 +128,29 @@ class YatConv1D(Conv1d):
             if shared_weight is None:
                 # First layer: register the weight as shared
                 YatConv1D._KERNEL_BANKS[bank_key] = self.weight
+                YatConv1D._KERNEL_BANK_USED[bank_key] = False
             else:
                 existing_channels = shared_weight.shape[0]
                 if bank_out_channels > existing_channels:
-                    raise ValueError(
-                        f"kernel bank '{kernel_bank_id}' has immutable capacity "
-                        f"{existing_channels}, requested {bank_out_channels}; create "
-                        "the first consumer with a sufficient kernel_bank_size"
+                    if YatConv1D._KERNEL_BANK_USED.get(bank_key, False):
+                        raise ValueError(
+                            f"kernel bank '{kernel_bank_id}' capacity is frozen "
+                            f"at {existing_channels} after first use; requested "
+                            f"{bank_out_channels}"
+                        )
+                    old_weight = shared_weight.data
+                    new_weight = torch.empty(
+                        (bank_out_channels,) + old_weight.shape[1:],
+                        dtype=old_weight.dtype,
+                        device=old_weight.device,
                     )
+                    nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
+                    new_weight[:existing_channels].copy_(old_weight)
+                    shared_weight.data = new_weight
                     
                 self.weight = shared_weight
+
+            self._kernel_bank_key = bank_key
 
             if bias and constant_bias is None and not scalar_bias:
                 self.bias = Parameter(
@@ -160,6 +175,7 @@ class YatConv1D(Conv1d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
+            YatConv1D._KERNEL_BANK_USED[self._kernel_bank_key] = True
             return yat_conv_forward(
                 self, input, F.conv1d,
                 out_channels=out_channels,

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-import logging
 import math
 import threading
 from typing import Optional, Union
@@ -13,8 +12,6 @@ from torch.nn.parameter import Parameter
 from torch.nn import Conv2d
 
 from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["YatConv2D"]
 
@@ -89,6 +86,11 @@ class YatConv2D(Conv2d):
         # Handle shared kernel bank - create with auto-sized out_channels
         if tie_kernel_bank:
             bank_out_channels = kernel_bank_size or out_channels
+            if bank_out_channels < out_channels:
+                raise ValueError(
+                    f"kernel_bank_size ({bank_out_channels}) must be at least "
+                    f"out_channels ({out_channels})"
+                )
         else:
             bank_out_channels = out_channels
 
@@ -126,7 +128,10 @@ class YatConv2D(Conv2d):
         
         # Handle auto-expanding shared kernel bank
         if tie_kernel_bank:
-            bank_key = (kernel_bank_id, in_channels, kernel_size, groups, storage_dtype)
+            bank_key = (
+                kernel_bank_id, in_channels, tuple(self.kernel_size), groups,
+                storage_dtype, self.weight.device,
+            )
             with YatConv2D._KERNEL_BANKS_LOCK:
                 shared_weight = YatConv2D._KERNEL_BANKS.get(bank_key)
 
@@ -134,23 +139,13 @@ class YatConv2D(Conv2d):
                     # First layer: register the weight as shared
                     YatConv2D._KERNEL_BANKS[bank_key] = self.weight
                 else:
-                    # Bank exists: auto-expand if needed
                     existing_channels = shared_weight.shape[0]
                     if bank_out_channels > existing_channels:
-                        # Auto-expand: pad with new random initialization
-                        logger.info("Auto-expanding kernel bank '%s': %d -> %d filters",
-                                    kernel_bank_id, existing_channels, bank_out_channels)
-                        old_weight = shared_weight.data
-                        # Create new weight with expanded size
-                        new_weight = torch.empty(
-                            (bank_out_channels,) + old_weight.shape[1:],
-                            dtype=storage_dtype,
-                            device=old_weight.device
+                        raise ValueError(
+                            f"kernel bank '{kernel_bank_id}' has immutable capacity "
+                            f"{existing_channels}, requested {bank_out_channels}; create "
+                            "the first consumer with a sufficient kernel_bank_size"
                         )
-                        nn.init.kaiming_uniform_(new_weight, nonlinearity='relu')
-                        # Copy old weights
-                        new_weight[:existing_channels].copy_(old_weight)
-                        shared_weight.data = new_weight
 
                     self.weight = shared_weight
 
@@ -161,6 +156,8 @@ class YatConv2D(Conv2d):
                 fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
                 bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
                 nn.init.uniform_(self.bias, -bound, bound)
+
+        self.out_channels = out_channels
 
         setup_yat_attrs(
             self,

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -32,7 +32,8 @@ class YatConv2D(Conv2d):
             This optimization avoids recomputing kernel norms in YAT distance
             calculation since they are guaranteed to be 1.0.
         tie_kernel_bank: If True, reuse shared kernels across compatible layers.
-        kernel_bank_size: Optional explicit size for shared bank (auto-expands if needed).
+        kernel_bank_size: Optional explicit capacity. The bank auto-expands only
+            during construction, before any tied consumer executes.
         kernel_bank_id: Namespace for shared banks (allows multiple independent banks).
         param_dtype: dtype for parameter initialization (default: None, uses
             PyTorch Conv2d default). Separate from computation dtype.
@@ -40,6 +41,7 @@ class YatConv2D(Conv2d):
     
     # Class-level shared kernel banks (guarded by a lock for thread safety)
     _KERNEL_BANKS = {}
+    _KERNEL_BANK_USED = {}
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -138,16 +140,29 @@ class YatConv2D(Conv2d):
                 if shared_weight is None:
                     # First layer: register the weight as shared
                     YatConv2D._KERNEL_BANKS[bank_key] = self.weight
+                    YatConv2D._KERNEL_BANK_USED[bank_key] = False
                 else:
                     existing_channels = shared_weight.shape[0]
                     if bank_out_channels > existing_channels:
-                        raise ValueError(
-                            f"kernel bank '{kernel_bank_id}' has immutable capacity "
-                            f"{existing_channels}, requested {bank_out_channels}; create "
-                            "the first consumer with a sufficient kernel_bank_size"
+                        if YatConv2D._KERNEL_BANK_USED.get(bank_key, False):
+                            raise ValueError(
+                                f"kernel bank '{kernel_bank_id}' capacity is frozen "
+                                f"at {existing_channels} after first use; requested "
+                                f"{bank_out_channels}"
+                            )
+                        old_weight = shared_weight.data
+                        new_weight = torch.empty(
+                            (bank_out_channels,) + old_weight.shape[1:],
+                            dtype=old_weight.dtype,
+                            device=old_weight.device,
                         )
+                        nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
+                        new_weight[:existing_channels].copy_(old_weight)
+                        shared_weight.data = new_weight
 
                     self.weight = shared_weight
+
+                self._kernel_bank_key = bank_key
 
             if bias and constant_bias is None and not scalar_bias:
                 self.bias = Parameter(
@@ -172,6 +187,8 @@ class YatConv2D(Conv2d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
+            with YatConv2D._KERNEL_BANKS_LOCK:
+                YatConv2D._KERNEL_BANK_USED[self._kernel_bank_key] = True
             return yat_conv_forward(
                 self, input, F.conv2d,
                 out_channels=out_channels,

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -132,7 +132,7 @@ class YatConv2D(Conv2d):
         if tie_kernel_bank:
             bank_key = (
                 kernel_bank_id, in_channels, tuple(self.kernel_size), groups,
-                storage_dtype, self.weight.device,
+                self.weight.dtype, self.weight.device,
             )
             with YatConv2D._KERNEL_BANKS_LOCK:
                 shared_weight = YatConv2D._KERNEL_BANKS.get(bank_key)
@@ -142,6 +142,9 @@ class YatConv2D(Conv2d):
                     YatConv2D._KERNEL_BANKS[bank_key] = self.weight
                     YatConv2D._KERNEL_BANK_USED[bank_key] = False
                 else:
+                    if (shared_weight.device != self.weight.device
+                            or shared_weight.dtype != self.weight.dtype):
+                        raise RuntimeError("shared kernel bank device/dtype registry is stale")
                     existing_channels = shared_weight.shape[0]
                     if bank_out_channels > existing_channels:
                         if YatConv2D._KERNEL_BANK_USED.get(bank_key, False):
@@ -200,3 +203,11 @@ class YatConv2D(Conv2d):
             out_channels=out_channels,
             deterministic=deterministic,
         )
+
+    def _apply(self, fn, recurse=True):
+        if getattr(self, "tie_kernel_bank", False):
+            raise RuntimeError(
+                "device/dtype migration is unsupported for tied kernel-bank "
+                "consumers; construct them with the target device and dtype"
+            )
+        return super()._apply(fn, recurse=recurse)

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -10,8 +10,6 @@ from torch import Tensor
 from torch.nn import functional as F
 from torch.nn.common_types import _size_2_t
 from torch.nn.parameter import Parameter
-from torch.nn.modules.utils import _pair
-
 from torch.nn import Conv2d
 
 from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
@@ -96,7 +94,7 @@ class YatConv2D(Conv2d):
 
         # If constant_bias or scalar_bias is set, don't allocate a per-channel
         # learnable bias in the parent — we handle bias ourselves.
-        parent_bias = False if (constant_bias is not None or scalar_bias) else bias
+        parent_bias = not (tie_kernel_bank or constant_bias is not None or scalar_bias) and bias
 
         super().__init__(
             in_channels,
@@ -156,6 +154,14 @@ class YatConv2D(Conv2d):
 
                     self.weight = shared_weight
 
+            if bias and constant_bias is None and not scalar_bias:
+                self.bias = Parameter(
+                    torch.empty(out_channels, device=device, dtype=storage_dtype)
+                )
+                fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+                bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+                nn.init.uniform_(self.bias, -bound, bound)
+
         setup_yat_attrs(
             self,
             bias=bias, constant_bias=constant_bias,
@@ -169,16 +175,12 @@ class YatConv2D(Conv2d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            original_weight = self.weight
-            self.weight = nn.Parameter(original_weight[self._kernel_slice])
-            try:
-                return yat_conv_forward(
-                    self, input, F.conv2d,
-                    out_channels=out_channels,
-                    deterministic=deterministic,
-                )
-            finally:
-                self.weight = original_weight
+            return yat_conv_forward(
+                self, input, F.conv2d,
+                out_channels=out_channels,
+                deterministic=deterministic,
+                weight_override=self.weight[self._kernel_slice],
+            )
         return yat_conv_forward(
             self, input, F.conv2d,
             out_channels=out_channels,

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -1,5 +1,4 @@
 # mypy: allow-untyped-defs
-import logging
 import math
 from typing import Optional, Union
 
@@ -12,8 +11,6 @@ from torch.nn.parameter import Parameter
 from torch.nn import Conv3d
 
 from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["YatConv3D"]
 
@@ -75,6 +72,11 @@ class YatConv3D(Conv3d):
         # Handle shared kernel bank
         if tie_kernel_bank:
             bank_out_channels = kernel_bank_size or out_channels
+            if bank_out_channels < out_channels:
+                raise ValueError(
+                    f"kernel_bank_size ({bank_out_channels}) must be at least "
+                    f"out_channels ({out_channels})"
+                )
         else:
             bank_out_channels = out_channels
 
@@ -112,30 +114,23 @@ class YatConv3D(Conv3d):
         
         # Handle auto-expanding shared kernel bank
         if tie_kernel_bank:
-            bank_key = (kernel_bank_id, in_channels, kernel_size, groups, storage_dtype)
+            bank_key = (
+                kernel_bank_id, in_channels, tuple(self.kernel_size), groups,
+                storage_dtype, self.weight.device,
+            )
             shared_weight = YatConv3D._KERNEL_BANKS.get(bank_key)
 
             if shared_weight is None:
                 # First layer: register the weight as shared
                 YatConv3D._KERNEL_BANKS[bank_key] = self.weight
             else:
-                # Bank exists: auto-expand if needed
                 existing_channels = shared_weight.shape[0]
                 if bank_out_channels > existing_channels:
-                    # Auto-expand: pad with new random initialization
-                    logger.info("Auto-expanding kernel bank '%s': %d -> %d filters",
-                                kernel_bank_id, existing_channels, bank_out_channels)
-                    old_weight = shared_weight.data
-                    # Create new weight with expanded size
-                    new_weight = torch.empty(
-                        (bank_out_channels,) + old_weight.shape[1:],
-                        dtype=storage_dtype,
-                        device=old_weight.device
+                    raise ValueError(
+                        f"kernel bank '{kernel_bank_id}' has immutable capacity "
+                        f"{existing_channels}, requested {bank_out_channels}; create "
+                        "the first consumer with a sufficient kernel_bank_size"
                     )
-                    nn.init.kaiming_uniform_(new_weight, nonlinearity='relu')
-                    # Copy old weights
-                    new_weight[:existing_channels].copy_(old_weight)
-                    shared_weight.data = new_weight
                     
                 self.weight = shared_weight
 
@@ -146,6 +141,8 @@ class YatConv3D(Conv3d):
                 fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
                 bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
                 nn.init.uniform_(self.bias, -bound, bound)
+
+        self.out_channels = out_channels
 
         setup_yat_attrs(
             self,

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -9,8 +9,6 @@ from torch import Tensor
 from torch.nn import functional as F
 from torch.nn.common_types import _size_3_t
 from torch.nn.parameter import Parameter
-from torch.nn.modules.utils import _triple
-
 from torch.nn import Conv3d
 
 from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
@@ -82,7 +80,7 @@ class YatConv3D(Conv3d):
 
         # If constant_bias or scalar_bias is set, don't allocate a per-channel
         # learnable bias in the parent — we handle bias ourselves.
-        parent_bias = False if (constant_bias is not None or scalar_bias) else bias
+        parent_bias = not (tie_kernel_bank or constant_bias is not None or scalar_bias) and bias
 
         super().__init__(
             in_channels,
@@ -141,6 +139,14 @@ class YatConv3D(Conv3d):
                     
                 self.weight = shared_weight
 
+            if bias and constant_bias is None and not scalar_bias:
+                self.bias = Parameter(
+                    torch.empty(out_channels, device=device, dtype=storage_dtype)
+                )
+                fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+                bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+                nn.init.uniform_(self.bias, -bound, bound)
+
         setup_yat_attrs(
             self,
             bias=bias, constant_bias=constant_bias,
@@ -154,16 +160,12 @@ class YatConv3D(Conv3d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            original_weight = self.weight
-            self.weight = nn.Parameter(original_weight[self._kernel_slice])
-            try:
-                return yat_conv_forward(
-                    self, input, F.conv3d,
-                    out_channels=out_channels,
-                    deterministic=deterministic,
-                )
-            finally:
-                self.weight = original_weight
+            return yat_conv_forward(
+                self, input, F.conv3d,
+                out_channels=out_channels,
+                deterministic=deterministic,
+                weight_override=self.weight[self._kernel_slice],
+            )
         return yat_conv_forward(
             self, input, F.conv3d,
             out_channels=out_channels,

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -29,7 +29,8 @@ class YatConv3D(Conv3d):
             use_alpha=True.        weight_normalized: If True, normalize each kernel filter to have norm 1.
             This optimization avoids recomputing kernel norms in YAT distance
             calculation since they are guaranteed to be 1.0.        tie_kernel_bank: If True, reuse shared kernels across compatible layers.
-        kernel_bank_size: Optional explicit size for shared bank (auto-expands if needed).
+        kernel_bank_size: Optional explicit capacity. The bank auto-expands only
+            during construction, before any tied consumer executes.
         kernel_bank_id: Namespace for shared banks (allows multiple independent banks).
         param_dtype: dtype for parameter initialization (default: None, uses
             PyTorch Conv3d default). Separate from computation dtype.
@@ -37,6 +38,7 @@ class YatConv3D(Conv3d):
     
     # Class-level shared kernel banks
     _KERNEL_BANKS = {}
+    _KERNEL_BANK_USED = {}
 
     def __init__(
         self,
@@ -123,16 +125,29 @@ class YatConv3D(Conv3d):
             if shared_weight is None:
                 # First layer: register the weight as shared
                 YatConv3D._KERNEL_BANKS[bank_key] = self.weight
+                YatConv3D._KERNEL_BANK_USED[bank_key] = False
             else:
                 existing_channels = shared_weight.shape[0]
                 if bank_out_channels > existing_channels:
-                    raise ValueError(
-                        f"kernel bank '{kernel_bank_id}' has immutable capacity "
-                        f"{existing_channels}, requested {bank_out_channels}; create "
-                        "the first consumer with a sufficient kernel_bank_size"
+                    if YatConv3D._KERNEL_BANK_USED.get(bank_key, False):
+                        raise ValueError(
+                            f"kernel bank '{kernel_bank_id}' capacity is frozen "
+                            f"at {existing_channels} after first use; requested "
+                            f"{bank_out_channels}"
+                        )
+                    old_weight = shared_weight.data
+                    new_weight = torch.empty(
+                        (bank_out_channels,) + old_weight.shape[1:],
+                        dtype=old_weight.dtype,
+                        device=old_weight.device,
                     )
+                    nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
+                    new_weight[:existing_channels].copy_(old_weight)
+                    shared_weight.data = new_weight
                     
                 self.weight = shared_weight
+
+            self._kernel_bank_key = bank_key
 
             if bias and constant_bias is None and not scalar_bias:
                 self.bias = Parameter(
@@ -157,6 +172,7 @@ class YatConv3D(Conv3d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
+            YatConv3D._KERNEL_BANK_USED[self._kernel_bank_key] = True
             return yat_conv_forward(
                 self, input, F.conv3d,
                 out_channels=out_channels,

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import math
+import threading
 from typing import Optional, Union
 
 import torch
@@ -39,6 +40,7 @@ class YatConv3D(Conv3d):
     # Class-level shared kernel banks
     _KERNEL_BANKS = {}
     _KERNEL_BANK_USED = {}
+    _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
         self,
@@ -118,36 +120,36 @@ class YatConv3D(Conv3d):
         if tie_kernel_bank:
             bank_key = (
                 kernel_bank_id, in_channels, tuple(self.kernel_size), groups,
-                storage_dtype, self.weight.device,
+                self.weight.dtype, self.weight.device,
             )
-            shared_weight = YatConv3D._KERNEL_BANKS.get(bank_key)
-
-            if shared_weight is None:
-                # First layer: register the weight as shared
-                YatConv3D._KERNEL_BANKS[bank_key] = self.weight
-                YatConv3D._KERNEL_BANK_USED[bank_key] = False
-            else:
-                existing_channels = shared_weight.shape[0]
-                if bank_out_channels > existing_channels:
-                    if YatConv3D._KERNEL_BANK_USED.get(bank_key, False):
-                        raise ValueError(
-                            f"kernel bank '{kernel_bank_id}' capacity is frozen "
-                            f"at {existing_channels} after first use; requested "
-                            f"{bank_out_channels}"
+            with YatConv3D._KERNEL_BANKS_LOCK:
+                shared_weight = YatConv3D._KERNEL_BANKS.get(bank_key)
+                if shared_weight is None:
+                    YatConv3D._KERNEL_BANKS[bank_key] = self.weight
+                    YatConv3D._KERNEL_BANK_USED[bank_key] = False
+                else:
+                    if (shared_weight.device != self.weight.device
+                            or shared_weight.dtype != self.weight.dtype):
+                        raise RuntimeError("shared kernel bank device/dtype registry is stale")
+                    existing_channels = shared_weight.shape[0]
+                    if bank_out_channels > existing_channels:
+                        if YatConv3D._KERNEL_BANK_USED.get(bank_key, False):
+                            raise ValueError(
+                                f"kernel bank '{kernel_bank_id}' capacity is frozen "
+                                f"at {existing_channels} after first use; requested "
+                                f"{bank_out_channels}"
+                            )
+                        old_weight = shared_weight.data
+                        new_weight = torch.empty(
+                            (bank_out_channels,) + old_weight.shape[1:],
+                            dtype=old_weight.dtype,
+                            device=old_weight.device,
                         )
-                    old_weight = shared_weight.data
-                    new_weight = torch.empty(
-                        (bank_out_channels,) + old_weight.shape[1:],
-                        dtype=old_weight.dtype,
-                        device=old_weight.device,
-                    )
-                    nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
-                    new_weight[:existing_channels].copy_(old_weight)
-                    shared_weight.data = new_weight
-                    
-                self.weight = shared_weight
-
-            self._kernel_bank_key = bank_key
+                        nn.init.kaiming_uniform_(new_weight, nonlinearity="relu")
+                        new_weight[:existing_channels].copy_(old_weight)
+                        shared_weight.data = new_weight
+                    self.weight = shared_weight
+                self._kernel_bank_key = bank_key
 
             if bias and constant_bias is None and not scalar_bias:
                 self.bias = Parameter(
@@ -172,7 +174,8 @@ class YatConv3D(Conv3d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            YatConv3D._KERNEL_BANK_USED[self._kernel_bank_key] = True
+            with YatConv3D._KERNEL_BANKS_LOCK:
+                YatConv3D._KERNEL_BANK_USED[self._kernel_bank_key] = True
             return yat_conv_forward(
                 self, input, F.conv3d,
                 out_channels=out_channels,
@@ -184,3 +187,11 @@ class YatConv3D(Conv3d):
             out_channels=out_channels,
             deterministic=deterministic,
         )
+
+    def _apply(self, fn, recurse=True):
+        if getattr(self, "tie_kernel_bank", False):
+            raise RuntimeError(
+                "device/dtype migration is unsupported for tied kernel-bank "
+                "consumers; construct them with the target device and dtype"
+            )
+        return super()._apply(fn, recurse=recurse)

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -137,7 +137,11 @@ class YatNMN(nn.Module):
                     f"kernel_bank_size ({bank_out_features}) must be at least "
                     f"out_features ({out_features})"
                 )
-            bank_key = (kernel_bank_id, in_features, param_dtype, id(kernel_init), positive_init)
+            bank_device = torch.empty((), dtype=param_dtype).device
+            bank_key = (
+                kernel_bank_id, in_features, param_dtype, bank_device,
+                id(kernel_init), positive_init,
+            )
 
             with YatNMN._KERNEL_BANKS_LOCK:
                 shared_weight = YatNMN._KERNEL_BANKS.get(bank_key)
@@ -150,6 +154,9 @@ class YatNMN(nn.Module):
                     YatNMN._KERNEL_BANKS[bank_key] = self.weight
                     YatNMN._KERNEL_BANK_USED[bank_key] = False
                 else:
+                    if (shared_weight.device != bank_device
+                            or shared_weight.dtype != param_dtype):
+                        raise RuntimeError("shared kernel bank device/dtype registry is stale")
                     if shared_weight.requires_grad != (not self.lazy):
                         raise ValueError(
                             "tied YatNMN consumers must use the same lazy/freeze_kernel "
@@ -404,6 +411,14 @@ class YatNMN(nn.Module):
             y = y * alpha_param
 
         return y
+
+    def _apply(self, fn, recurse=True):
+        if getattr(self, "tie_kernel_bank", False):
+            raise RuntimeError(
+                "device/dtype migration is unsupported for tied kernel-bank "
+                "consumers; construct them with the target device and dtype"
+            )
+        return super()._apply(fn, recurse=recurse)
 
     def extra_repr(self) -> str:
         """

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -38,6 +38,9 @@ class YatNMN(nn.Module):
             If None (default), use learnable alpha when alpha=True.
         dtype (torch.dtype): Data type for computation (default: infer from input and params).
         param_dtype (torch.dtype): Data type for parameter initialization (default: float32).
+        device: Device for parameter initialization. Tied consumers must be
+            constructed on their final device because post-construction
+            migration is intentionally rejected.
         epsilon (float): Small constant to avoid division by zero
         learnable_epsilon (bool): If True, epsilon becomes a learnable parameter passed
             through softplus to guarantee strict positivity (default: False).
@@ -92,7 +95,8 @@ class YatNMN(nn.Module):
         kernel_bank_id: str = 'default',
         kernel_init: callable = None,
         bias_init: callable = None,
-        alpha_init: callable = None
+        alpha_init: callable = None,
+        device=None,
     ):
         super().__init__()
 
@@ -109,7 +113,7 @@ class YatNMN(nn.Module):
             # Initialize so that softplus(raw) ≈ epsilon: raw = log(exp(eps) - 1)
             raw_eps = math.log(math.exp(epsilon) - 1.0)
             self.epsilon_param = nn.Parameter(
-                torch.full((1,), raw_eps, dtype=param_dtype)
+                torch.full((1,), raw_eps, dtype=param_dtype, device=device)
             )
         else:
             self.register_parameter('epsilon_param', None)
@@ -137,7 +141,7 @@ class YatNMN(nn.Module):
                     f"kernel_bank_size ({bank_out_features}) must be at least "
                     f"out_features ({out_features})"
                 )
-            bank_device = torch.empty((), dtype=param_dtype).device
+            bank_device = torch.empty((), dtype=param_dtype, device=device).device
             bank_key = (
                 kernel_bank_id, in_features, param_dtype, bank_device,
                 id(kernel_init), positive_init,
@@ -149,7 +153,8 @@ class YatNMN(nn.Module):
                     # First layer: create bank
                     self.weight = nn.Parameter(torch.empty(
                         (bank_out_features, in_features),
-                        dtype=param_dtype
+                        dtype=param_dtype,
+                        device=bank_device,
                     ))
                     YatNMN._KERNEL_BANKS[bank_key] = self.weight
                     YatNMN._KERNEL_BANK_USED[bank_key] = False
@@ -191,7 +196,8 @@ class YatNMN(nn.Module):
             # Create weight parameter (non-shared)
             self.weight = nn.Parameter(torch.empty(
                 (out_features, in_features),
-                dtype=param_dtype
+                dtype=param_dtype,
+                device=device,
             ))
 
         # Handle alpha configuration
@@ -214,7 +220,8 @@ class YatNMN(nn.Module):
         elif alpha:
             self.alpha = nn.Parameter(torch.ones(
                 (1,),
-                dtype=param_dtype
+                dtype=param_dtype,
+                device=device,
             ))
         else:
             self.register_parameter('alpha', None)
@@ -231,7 +238,8 @@ class YatNMN(nn.Module):
             bias_shape = (1,) if scalar_bias else (out_features,)
             self.bias = nn.Parameter(torch.empty(
                 bias_shape,
-                dtype=param_dtype
+                dtype=param_dtype,
+                device=device,
             ))
         else:
             self.register_parameter('bias', None)

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -53,7 +53,8 @@ class YatNMN(nn.Module):
             (fully backward compatible). Alias: ``freeze_kernel``.
         freeze_kernel (bool): Alias for ``lazy`` (logical OR with ``lazy``).
         tie_kernel_bank (bool): If True, reuse shared kernels across compatible layers.
-        kernel_bank_size (int): Optional explicit size for shared bank (auto-expands if needed).
+        kernel_bank_size (int): Optional explicit size for the shared bank. Banks
+            auto-expand only during construction, before any consumer executes.
         kernel_bank_id (str): Namespace for shared banks (allows multiple independent banks).
         kernel_init (callable): Initializer for the weight matrix
         bias_init (callable): Initializer for the bias
@@ -64,6 +65,7 @@ class YatNMN(nn.Module):
     DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
     # Class-level shared kernel banks (guarded by a lock for thread safety)
     _KERNEL_BANKS = {}
+    _KERNEL_BANK_USED = {}
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -146,6 +148,7 @@ class YatNMN(nn.Module):
                         dtype=param_dtype
                     ))
                     YatNMN._KERNEL_BANKS[bank_key] = self.weight
+                    YatNMN._KERNEL_BANK_USED[bank_key] = False
                 else:
                     if shared_weight.requires_grad != (not self.lazy):
                         raise ValueError(
@@ -155,12 +158,26 @@ class YatNMN(nn.Module):
                     initialize_kernel = False
                     existing_size = shared_weight.shape[0]
                     if bank_out_features > existing_size:
-                        raise ValueError(
-                            f"kernel bank '{kernel_bank_id}' has immutable capacity "
-                            f"{existing_size}, requested {bank_out_features}; create "
-                            "the first consumer with a sufficient kernel_bank_size"
+                        if YatNMN._KERNEL_BANK_USED.get(bank_key, False):
+                            raise ValueError(
+                                f"kernel bank '{kernel_bank_id}' capacity is frozen "
+                                f"at {existing_size} after first use; requested "
+                                f"{bank_out_features}"
+                            )
+                        old_weight = shared_weight.data
+                        new_weight = torch.empty(
+                            (bank_out_features, in_features),
+                            dtype=param_dtype,
+                            device=old_weight.device,
                         )
+                        kernel_init(new_weight)
+                        if positive_init:
+                            new_weight.abs_()
+                        new_weight[:existing_size].copy_(old_weight)
+                        shared_weight.data = new_weight
                     self.weight = shared_weight
+
+            self._kernel_bank_key = bank_key
 
             self._kernel_slice = slice(0, out_features)
         else:
@@ -311,6 +328,8 @@ class YatNMN(nn.Module):
         kernel = self.weight
         # Slice shared kernel if tying is enabled
         if self.tie_kernel_bank:
+            with YatNMN._KERNEL_BANKS_LOCK:
+                YatNMN._KERNEL_BANK_USED[self._kernel_bank_key] = True
             kernel = kernel[self._kernel_slice]
 
         # Resolve bias (learnable or constant)

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 """YatNMN - Yet Another Transformation Neural Matter Network."""
-import logging
 import math
 import threading
 from typing import Optional, Union
@@ -8,8 +7,6 @@ from typing import Optional, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
-logger = logging.getLogger(__name__)
 
 __all__ = ["YatNMN"]
 
@@ -133,6 +130,11 @@ class YatNMN(nn.Module):
         if tie_kernel_bank:
             # Auto-calculate bank size
             bank_out_features = kernel_bank_size or out_features
+            if bank_out_features < out_features:
+                raise ValueError(
+                    f"kernel_bank_size ({bank_out_features}) must be at least "
+                    f"out_features ({out_features})"
+                )
             bank_key = (kernel_bank_id, in_features, param_dtype, id(kernel_init), positive_init)
 
             with YatNMN._KERNEL_BANKS_LOCK:
@@ -151,25 +153,13 @@ class YatNMN(nn.Module):
                             "setting because they share one Parameter"
                         )
                     initialize_kernel = False
-                    # Bank exists: auto-expand if needed
                     existing_size = shared_weight.shape[0]
                     if bank_out_features > existing_size:
-                        # Auto-expand: pad with new random initialization
-                        logger.info("Auto-expanding kernel bank '%s': %d -> %d neurons",
-                                    kernel_bank_id, existing_size, bank_out_features)
-                        old_weight = shared_weight.data
-                        new_weight = torch.empty(
-                            (bank_out_features, in_features),
-                            dtype=param_dtype,
-                            device=old_weight.device
+                        raise ValueError(
+                            f"kernel bank '{kernel_bank_id}' has immutable capacity "
+                            f"{existing_size}, requested {bank_out_features}; create "
+                            "the first consumer with a sufficient kernel_bank_size"
                         )
-                        kernel_init(new_weight)
-                        if positive_init:
-                            new_weight.abs_()
-                        # Copy old weights
-                        new_weight[:existing_size].copy_(old_weight)
-                        shared_weight.data = new_weight
-                        YatNMN._KERNEL_BANKS[bank_key] = shared_weight
                     self.weight = shared_weight
 
             self._kernel_slice = slice(0, out_features)

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -5,12 +5,11 @@ import math
 import threading
 from typing import Optional, Union
 
-logger = logging.getLogger(__name__)
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+logger = logging.getLogger(__name__)
 
 __all__ = ["YatNMN"]
 
@@ -124,6 +123,7 @@ class YatNMN(nn.Module):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        initialize_kernel = True
 
         # Weight initialization
         if kernel_init is None:
@@ -145,6 +145,12 @@ class YatNMN(nn.Module):
                     ))
                     YatNMN._KERNEL_BANKS[bank_key] = self.weight
                 else:
+                    if shared_weight.requires_grad != (not self.lazy):
+                        raise ValueError(
+                            "tied YatNMN consumers must use the same lazy/freeze_kernel "
+                            "setting because they share one Parameter"
+                        )
+                    initialize_kernel = False
                     # Bank exists: auto-expand if needed
                     existing_size = shared_weight.shape[0]
                     if bank_out_features > existing_size:
@@ -221,10 +227,13 @@ class YatNMN(nn.Module):
         self.scalar_bias = scalar_bias and self.bias is not None
 
         # Initialize parameters
-        self.reset_parameters(kernel_init, bias_init, alpha_init)
+        self.reset_parameters(
+            kernel_init, bias_init, alpha_init,
+            initialize_kernel=initialize_kernel,
+        )
 
         # Normalize kernel if requested: normalize each neuron (column) to have norm 1
-        if self.weight_normalized:
+        if self.weight_normalized and initialize_kernel:
             weight_norm = torch.sqrt(torch.sum(self.weight**2, dim=-1, keepdim=True))
             self.weight.data = self.weight.data / (weight_norm + 1e-8)
 
@@ -238,7 +247,9 @@ class YatNMN(nn.Module):
         self,
         kernel_init: callable = None,
         bias_init: callable = None,
-        alpha_init: callable = None
+        alpha_init: callable = None,
+        *,
+        initialize_kernel: bool = True,
     ):
         """
         Initialize network parameters with specified or default initializers.
@@ -246,8 +257,9 @@ class YatNMN(nn.Module):
         # Kernel (weight) initialization
         if kernel_init is None:
             kernel_init = nn.init.xavier_normal_
-        kernel_init(self.weight)
-        if self.positive_init:
+        if initialize_kernel:
+            kernel_init(self.weight)
+        if initialize_kernel and self.positive_init:
             with torch.no_grad():
                 self.weight.abs_()
 

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -36,6 +36,24 @@ def test_tied_dense_construction_preserves_live_peer():
     assert first.weight.requires_grad
 
 
+def test_tied_dense_auto_expands_before_first_use_and_preserves_existing_slice():
+    YatNMN._KERNEL_BANKS.clear()
+    first = YatNMN(
+        4, 2, tie_kernel_bank=True, alpha=False, bias=False,
+        kernel_bank_id="issue-71-pre-use-expand",
+    )
+    existing_slice = first.weight.detach().clone()
+
+    second = YatNMN(
+        4, 3, tie_kernel_bank=True, alpha=False, bias=False,
+        kernel_bank_id="issue-71-pre-use-expand",
+    )
+
+    assert first.weight is second.weight
+    assert first.weight.shape == (3, 4)
+    torch.testing.assert_close(first.weight[:2], existing_slice)
+
+
 def test_tied_dense_rejects_expansion_without_mutating_stale_gradient():
     YatNMN._KERNEL_BANKS.clear()
     first = YatNMN(
@@ -47,7 +65,7 @@ def test_tied_dense_rejects_expansion_without_mutating_stale_gradient():
     value_before = parameter.detach().clone()
     gradient_before = parameter.grad.detach().clone()
 
-    with pytest.raises(ValueError, match="immutable capacity"):
+    with pytest.raises(ValueError, match="capacity is frozen"):
         YatNMN(
             4, 3, tie_kernel_bank=True, alpha=False, bias=False,
             kernel_bank_id="issue-71-stale-grad",
@@ -74,7 +92,7 @@ def test_tied_dense_rejects_expansion_without_mutating_adam_state():
         for key, value in optimizer.state[parameter].items()
     }
 
-    with pytest.raises(ValueError, match="immutable capacity"):
+    with pytest.raises(ValueError, match="capacity is frozen"):
         YatNMN(
             4, 3, tie_kernel_bank=True, alpha=False, bias=False,
             kernel_bank_id="issue-71-adam",
@@ -153,6 +171,28 @@ def test_tied_conv_bank_accumulates_gradients_and_uses_actual_bias_width(
     assert not torch.equal(before, narrow.weight)
 
 
+@pytest.mark.parametrize("conv_cls", [YatConv1D, YatConv2D, YatConv3D])
+def test_tied_conv_auto_expands_before_first_use_and_preserves_slice(conv_cls):
+    conv_cls._KERNEL_BANKS.clear()
+    bank_id = f"issue-72-pre-use-expand-{conv_cls.__name__}"
+    first = conv_cls(
+        2, 2, 1, tie_kernel_bank=True, bias=False, use_alpha=False,
+        kernel_bank_id=bank_id,
+    )
+    existing_slice = first.weight.detach().clone()
+
+    second = conv_cls(
+        2, 4, 1, tie_kernel_bank=True, bias=False, use_alpha=False,
+        kernel_bank_id=bank_id,
+    )
+
+    assert first.weight is second.weight
+    assert first.weight.shape[0] == 4
+    torch.testing.assert_close(first.weight[:2], existing_slice)
+    assert first.out_channels == 2
+    assert second.out_channels == 4
+
+
 @pytest.mark.parametrize(
     ("conv_cls", "input_shape"),
     [
@@ -180,7 +220,7 @@ def test_tied_conv_rejects_expansion_without_mutating_adam_state(
         for key, value in optimizer.state[parameter].items()
     }
 
-    with pytest.raises(ValueError, match="immutable capacity"):
+    with pytest.raises(ValueError, match="capacity is frozen"):
         conv_cls(
             2, 4, 1, tie_kernel_bank=True, bias=False, use_alpha=False,
             kernel_bank_id=bank_id,

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -17,6 +17,7 @@ from nmn.torch import (
     YatEmbed,
     YatNMN,
 )
+from nmn.torch._precision import saturating_upcast
 
 
 def test_tied_dense_construction_preserves_live_peer():
@@ -472,7 +473,9 @@ def test_low_precision_conv_and_embedding_exact_match_is_finite(dtype, spherical
         # The finite score is representable in fp16, but its derivative is
         # about 75,000 and exercises the saturating fp32->fp16 grad boundary.
         conv.weight.fill_(0.5)
-    conv_input = conv.weight.detach().reshape(1, 1, 3).clone().requires_grad_()
+    # Two identical patches also force the learnable-epsilon cotangent to be
+    # reduced above fp16's finite range before it reaches the storage boundary.
+    conv_input = torch.full((1, 1, 4), 0.5, dtype=dtype, requires_grad=True)
     conv_output = conv(conv_input)
     conv_output.sum().backward()
     assert torch.isfinite(conv_output).all() and (conv_output >= 0).all()
@@ -483,12 +486,65 @@ def test_low_precision_conv_and_embedding_exact_match_is_finite(dtype, spherical
     embed = YatEmbed(
         1, 3, use_alpha=False, epsilon=1e-5, dtype=dtype, spherical=spherical
     )
+    with torch.no_grad():
+        embed.embedding.fill_(0.5)
     query = embed.embedding.detach().clone().requires_grad_()
     embed_output = embed.attend(query)
     embed_output.sum().backward()
     assert torch.isfinite(embed_output).all() and (embed_output >= 0).all()
     assert torch.isfinite(query.grad).all()
     assert torch.isfinite(embed.embedding.grad).all()
+
+
+@pytest.mark.parametrize("compute_dtype", [torch.float32, torch.float64, None])
+def test_split_precision_exact_match_saturates_storage_gradients(compute_dtype):
+    conv = YatConv1D(
+        1,
+        1,
+        3,
+        bias=False,
+        use_alpha=False,
+        epsilon=1e-5,
+        learnable_epsilon=True,
+        dtype=compute_dtype,
+        param_dtype=torch.float16,
+    )
+    with torch.no_grad():
+        conv.weight.fill_(0.5)
+    input_dtype = torch.float64 if compute_dtype is None else compute_dtype
+    x = torch.full((1, 1, 3), 0.5, dtype=input_dtype, requires_grad=True)
+    output = conv(x)
+    output.sum().backward()
+
+    assert output.dtype == input_dtype and torch.isfinite(output).all()
+    assert torch.isfinite(x.grad).all()
+    assert conv.weight.grad.dtype == torch.float16
+    assert torch.isfinite(conv.weight.grad).all()
+    assert torch.isfinite(conv.epsilon_param.grad).all()
+
+
+def test_saturating_upcast_preserves_nan_gradient_diagnostics():
+    x = torch.ones(1, dtype=torch.float16, requires_grad=True)
+    (saturating_upcast(x) * torch.tensor(float("nan"))).sum().backward()
+    assert torch.isnan(x.grad).all()
+
+
+@pytest.mark.parametrize("kind", ["conv", "embed"])
+@pytest.mark.skipif(not hasattr(torch, "func"), reason="torch.func requires PyTorch 2")
+def test_low_precision_saturating_upcast_supports_func_transforms(kind):
+    if kind == "conv":
+        layer = YatConv1D(1, 1, 1, bias=False, use_alpha=False, dtype=torch.float16)
+        x = torch.full((2, 1, 1), 0.25, dtype=torch.float16)
+        call = layer
+    else:
+        layer = YatEmbed(2, 1, use_alpha=False, dtype=torch.float16)
+        x = torch.full((2, 1), 0.25, dtype=torch.float16)
+        call = layer.attend
+
+    primal, tangent = torch.func.jvp(call, (x,), (torch.ones_like(x),))
+    batched = torch.vmap(call)(x)
+    assert torch.isfinite(primal).all() and torch.isfinite(tangent).all()
+    assert torch.isfinite(batched).all()
 
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
@@ -507,8 +563,8 @@ def test_low_precision_transpose_conv_exact_match_is_finite(
         1, 1, 1, bias=False, use_alpha=False, epsilon=1e-5, dtype=dtype
     )
     with torch.no_grad():
-        layer.weight.fill_(0.25)
-    x = torch.full(input_shape, 0.25, dtype=dtype, requires_grad=True)
+        layer.weight.fill_(0.7)
+    x = torch.full(input_shape, 0.7, dtype=dtype, requires_grad=True)
     output = layer(x)
     output.sum().backward()
     assert torch.isfinite(output).all() and (output >= 0).all()

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -1,6 +1,7 @@
 """Regression tests for PyTorch dtype and shared-bank issue tranches."""
 
 import copy
+import threading
 
 import pytest
 import torch
@@ -250,6 +251,132 @@ def test_tied_conv_bank_is_device_scoped_and_preserves_public_width(conv_cls):
     assert meta_layer.weight.device.type == "meta"
     assert cpu_layer.weight is not meta_layer.weight
     assert cpu_layer.out_channels == meta_layer.out_channels == 2
+
+
+@pytest.mark.parametrize("conv_cls", [YatConv1D, YatConv3D])
+def test_tied_conv_concurrent_construction_is_atomic(conv_cls):
+    conv_cls._KERNEL_BANKS.clear()
+    bank_id = f"issue-72-construction-race-{conv_cls.__name__}"
+    barrier = threading.Barrier(3)
+    layers = []
+    errors = []
+
+    def construct(width):
+        barrier.wait()
+        try:
+            layers.append(conv_cls(
+                2, width, 1, tie_kernel_bank=True, bias=False,
+                use_alpha=False, kernel_bank_id=bank_id,
+            ))
+        except Exception as error:  # pragma: no cover - asserted below
+            errors.append(error)
+
+    threads = [
+        threading.Thread(target=construct, args=(2,)),
+        threading.Thread(target=construct, args=(4,)),
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert len(layers) == 2
+    assert layers[0].weight is layers[1].weight
+    assert layers[0].weight.shape[0] == 4
+
+
+@pytest.mark.parametrize(
+    ("conv_cls", "input_shape"),
+    [(YatConv1D, (1, 2, 3)), (YatConv3D, (1, 2, 2, 2, 2))],
+)
+def test_tied_conv_first_use_and_expansion_race_is_serialized(
+    conv_cls, input_shape
+):
+    conv_cls._KERNEL_BANKS.clear()
+    bank_id = f"issue-72-use-race-{conv_cls.__name__}"
+    first = conv_cls(
+        2, 2, 1, tie_kernel_bank=True, bias=False, use_alpha=False,
+        kernel_bank_id=bank_id,
+    )
+    parameter = first.weight
+    barrier = threading.Barrier(3)
+    outputs = []
+    expanded = []
+    errors = []
+
+    def execute():
+        barrier.wait()
+        outputs.append(first(torch.randn(*input_shape)))
+
+    def expand():
+        barrier.wait()
+        try:
+            expanded.append(conv_cls(
+                2, 4, 1, tie_kernel_bank=True, bias=False,
+                use_alpha=False, kernel_bank_id=bank_id,
+            ))
+        except ValueError as error:
+            errors.append(error)
+
+    threads = [threading.Thread(target=execute), threading.Thread(target=expand)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(outputs) == 1 and torch.isfinite(outputs[0]).all()
+    assert first.weight is parameter
+    assert len(expanded) + len(errors) == 1
+    if expanded:
+        assert expanded[0].weight is parameter
+        assert parameter.shape[0] == 4
+    else:
+        assert "capacity is frozen" in str(errors[0])
+        assert parameter.shape[0] == 2
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda tied: YatNMN(4, 2, tie_kernel_bank=tied),
+        lambda tied: YatConv1D(2, 2, 1, tie_kernel_bank=tied),
+        lambda tied: YatConv2D(2, 2, 1, tie_kernel_bank=tied),
+        lambda tied: YatConv3D(2, 2, 1, tie_kernel_bank=tied),
+    ],
+)
+def test_tied_bank_rejects_apply_migration_but_untied_module_migrates(factory):
+    tied = factory(True)
+    parameter = tied.weight
+    with pytest.raises(RuntimeError, match="migration is unsupported"):
+        tied.double()
+    with pytest.raises(RuntimeError, match="migration is unsupported"):
+        tied.to("meta")
+    assert tied.weight is parameter
+    assert tied.weight.device.type == "cpu"
+    assert tied.weight.dtype == torch.float32
+
+    untied = factory(False).double()
+    assert untied.weight.dtype == torch.float64
+
+
+def test_tied_conv_attachment_rejects_stale_registry_dtype():
+    YatConv1D._KERNEL_BANKS.clear()
+    first = YatConv1D(
+        2, 2, 1, tie_kernel_bank=True,
+        kernel_bank_id="issue-72-stale-registry",
+    )
+    first.weight.data = first.weight.data.double()
+
+    with pytest.raises(RuntimeError, match="registry is stale"):
+        YatConv1D(
+            2, 2, 1, tie_kernel_bank=True,
+            kernel_bank_id="issue-72-stale-registry",
+        )
 
 
 def test_attention_compute_and_parameter_dtypes_round_trip():

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -379,6 +379,49 @@ def test_tied_conv_attachment_rejects_stale_registry_dtype():
         )
 
 
+def test_yat_nmn_device_constructor_covers_all_owned_state_and_default():
+    default_layer = YatNMN(4, 2, learnable_epsilon=True)
+    assert default_layer.weight.device.type == "cpu"
+    assert all(value.device.type == "cpu" for value in default_layer.state_dict().values())
+
+    meta_layer = YatNMN(
+        4, 2, learnable_epsilon=True, device="meta", param_dtype=torch.float64
+    )
+    state = meta_layer.state_dict()
+    assert set(state) == {"weight", "alpha", "bias", "epsilon_param"}
+    assert all(value.device.type == "meta" for value in state.values())
+    assert all(value.dtype == torch.float64 for value in state.values())
+
+
+def test_tied_yat_nmn_banks_are_device_separated_and_constructor_route_runs():
+    YatNMN._KERNEL_BANKS.clear()
+    bank_id = "issue-71-device-constructor"
+    cpu_layer = YatNMN(
+        4, 2, tie_kernel_bank=True, learnable_epsilon=True,
+        kernel_bank_id=bank_id, device="cpu", dtype=torch.float32,
+        param_dtype=torch.float64,
+    )
+    meta_layer = YatNMN(
+        4, 2, tie_kernel_bank=True, learnable_epsilon=True,
+        kernel_bank_id=bank_id, device="meta", dtype=torch.float32,
+        param_dtype=torch.float64,
+    )
+
+    assert cpu_layer.weight is not meta_layer.weight
+    assert all(value.device.type == "cpu" for value in cpu_layer.state_dict().values())
+    assert all(value.device.type == "meta" for value in meta_layer.state_dict().values())
+    output = cpu_layer(torch.randn(3, 4, dtype=torch.float32))
+    assert output.device.type == "cpu"
+    assert output.dtype == torch.float32
+
+
+def test_untied_yat_nmn_supports_constructor_device_and_later_migration():
+    layer = YatNMN(4, 2, learnable_epsilon=True, device="cpu")
+    migrated = layer.to(dtype=torch.float64)
+    assert migrated is layer
+    assert all(value.dtype == torch.float64 for value in layer.state_dict().values())
+
+
 def test_attention_compute_and_parameter_dtypes_round_trip():
     torch.manual_seed(0)
     layer = MultiHeadYatAttention(

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -1,0 +1,200 @@
+"""Regression tests for PyTorch dtype and shared-bank issue tranches."""
+
+import copy
+
+import pytest
+import torch
+
+from nmn.torch import (
+    MultiHeadYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatEmbed,
+    YatNMN,
+)
+
+
+def test_tied_dense_construction_preserves_live_peer():
+    YatNMN._KERNEL_BANKS.clear()
+    first = YatNMN(4, 2, tie_kernel_bank=True, kernel_bank_id="issue-71")
+    x = torch.randn(3, 4)
+    weight_before = first.weight.detach().clone()
+    output_before = first(x).detach().clone()
+
+    second = YatNMN(4, 3, tie_kernel_bank=True, kernel_bank_id="issue-71")
+
+    torch.testing.assert_close(first.weight[:2], weight_before)
+    torch.testing.assert_close(first(x), output_before)
+    assert second.weight is first.weight
+    assert first.weight.requires_grad
+
+
+def test_tied_dense_rejects_incompatible_lazy_consumer():
+    YatNMN._KERNEL_BANKS.clear()
+    first = YatNMN(4, 2, tie_kernel_bank=True, kernel_bank_id="issue-71-lazy")
+    with pytest.raises(ValueError, match="same lazy"):
+        YatNMN(4, 2, tie_kernel_bank=True, lazy=True, kernel_bank_id="issue-71-lazy")
+    assert first.weight.requires_grad
+
+
+@pytest.mark.parametrize(
+    ("conv_cls", "input_shape"),
+    [
+        (YatConv1D, (2, 2, 7)),
+        (YatConv2D, (2, 2, 5, 5)),
+        (YatConv3D, (2, 2, 4, 4, 4)),
+    ],
+)
+def test_tied_conv_bank_accumulates_gradients_and_uses_actual_bias_width(
+    conv_cls, input_shape
+):
+    conv_cls._KERNEL_BANKS.clear()
+    bank_id = f"issue-72-{conv_cls.__name__}"
+    narrow = conv_cls(
+        2, 2, 1, tie_kernel_bank=True, kernel_bank_size=4,
+        kernel_bank_id=bank_id,
+    )
+    wide = conv_cls(
+        2, 4, 1, tie_kernel_bank=True, kernel_bank_size=4,
+        kernel_bank_id=bank_id,
+    )
+    assert narrow.weight is wide.weight
+    assert narrow.bias.shape == (2,)
+    assert wide.bias.shape == (4,)
+
+    reference = conv_cls(2, 2, 1)
+    with torch.no_grad():
+        reference.weight.copy_(narrow.weight[:2])
+        reference.bias.copy_(narrow.bias)
+        reference.alpha.copy_(narrow.alpha)
+    x_tied = torch.randn(*input_shape, requires_grad=True)
+    x_reference = x_tied.detach().clone().requires_grad_()
+    tied_output = narrow(x_tied)
+    reference_output = reference(x_reference)
+    torch.testing.assert_close(tied_output, reference_output)
+    tied_output.sum().backward()
+    reference_output.sum().backward()
+    torch.testing.assert_close(x_tied.grad, x_reference.grad)
+    torch.testing.assert_close(narrow.weight.grad[:2], reference.weight.grad)
+
+    narrow.zero_grad(set_to_none=True)
+    wide.zero_grad(set_to_none=True)
+    optimizer = torch.optim.SGD(narrow.parameters(), lr=1e-3)
+    before = narrow.weight.detach().clone()
+    x = torch.randn(*input_shape)
+    (narrow(x).sum() + wide(x).sum()).backward()
+    assert narrow.weight.grad is not None
+    assert torch.isfinite(narrow.weight.grad).all()
+    assert torch.count_nonzero(narrow.weight.grad[2:]) > 0
+    optimizer.step()
+    assert not torch.equal(before, narrow.weight)
+
+
+def test_attention_compute_and_parameter_dtypes_round_trip():
+    torch.manual_seed(0)
+    layer = MultiHeadYatAttention(
+        4, 2, dtype=torch.float32, param_dtype=torch.float64, dropout=0.0
+    )
+    x = torch.randn(2, 3, 4, dtype=torch.float32, requires_grad=True)
+    expected = layer(x, deterministic=True)
+    expected.square().sum().backward()
+
+    assert expected.dtype == torch.float32
+    assert x.grad is not None and torch.isfinite(x.grad).all()
+    for parameter in layer.parameters():
+        assert parameter.dtype == torch.float64
+        assert parameter.grad is not None and torch.isfinite(parameter.grad).all()
+
+    restored = MultiHeadYatAttention(
+        4, 2, dtype=torch.float32, param_dtype=torch.float64, dropout=0.0
+    )
+    restored.load_state_dict(copy.deepcopy(layer.state_dict()))
+    torch.testing.assert_close(restored(x.detach(), deterministic=True), expected.detach())
+
+    reference = MultiHeadYatAttention(4, 2, dtype=torch.float32, param_dtype=torch.float32)
+    reference.load_state_dict({key: value.float() for key, value in layer.state_dict().items()})
+    x_split = x.detach().clone().requires_grad_()
+    x_reference = x.detach().clone().requires_grad_()
+    split_output = layer(x_split, deterministic=True)
+    reference_output = reference(x_reference, deterministic=True)
+    torch.testing.assert_close(split_output, reference_output, rtol=1e-5, atol=1e-6)
+    split_output.sum().backward()
+    reference_output.sum().backward()
+    torch.testing.assert_close(x_split.grad, x_reference.grad, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("spherical", [False, True])
+def test_low_precision_conv_and_embedding_exact_match_is_finite(dtype, spherical):
+    conv = YatConv1D(
+        1, 1, 3, bias=False, use_alpha=False, epsilon=1e-5, dtype=dtype
+    )
+    conv_input = conv.weight.detach().reshape(1, 1, 3).clone().requires_grad_()
+    conv_output = conv(conv_input)
+    conv_output.sum().backward()
+    assert torch.isfinite(conv_output).all() and (conv_output >= 0).all()
+    assert torch.isfinite(conv_input.grad).all()
+    assert torch.isfinite(conv.weight.grad).all()
+
+    embed = YatEmbed(
+        1, 3, use_alpha=False, epsilon=1e-5, dtype=dtype, spherical=spherical
+    )
+    query = embed.embedding.detach().clone().requires_grad_()
+    embed_output = embed.attend(query)
+    embed_output.sum().backward()
+    assert torch.isfinite(embed_output).all() and (embed_output >= 0).all()
+    assert torch.isfinite(query.grad).all()
+    assert torch.isfinite(embed.embedding.grad).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    ("conv_cls", "input_shape"),
+    [
+        (YatConvTranspose1D, (1, 1, 1)),
+        (YatConvTranspose2D, (1, 1, 1, 1)),
+        (YatConvTranspose3D, (1, 1, 1, 1, 1)),
+    ],
+)
+def test_low_precision_transpose_conv_exact_match_is_finite(
+    dtype, conv_cls, input_shape
+):
+    layer = conv_cls(
+        1, 1, 1, bias=False, use_alpha=False, epsilon=1e-5, dtype=dtype
+    )
+    with torch.no_grad():
+        layer.weight.fill_(0.25)
+    x = torch.full(input_shape, 0.25, dtype=dtype, requires_grad=True)
+    output = layer(x)
+    output.sum().backward()
+    assert torch.isfinite(output).all() and (output >= 0).all()
+    assert torch.isfinite(x.grad).all()
+    assert torch.isfinite(layer.weight.grad).all()
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_low_precision_conv_and_embedding_match_fp32_away_from_collision(dtype):
+    conv32 = YatConv1D(1, 2, 3, bias=False, use_alpha=False, epsilon=1e-2)
+    conv_low = YatConv1D(
+        1, 2, 3, bias=False, use_alpha=False, epsilon=1e-2, dtype=dtype
+    )
+    conv_low.load_state_dict({k: v.to(dtype) for k, v in conv32.state_dict().items()})
+    x32 = torch.tensor([[[0.2, -0.4, 0.7, 0.1, -0.3]]])
+    torch.testing.assert_close(
+        conv_low(x32.to(dtype)).float(), conv32(x32), rtol=6e-2, atol=2e-2
+    )
+
+    embed32 = YatEmbed(3, 4, use_alpha=False, epsilon=1e-2)
+    embed_low = YatEmbed(3, 4, use_alpha=False, epsilon=1e-2, dtype=dtype)
+    embed_low.load_state_dict({k: v.to(dtype) for k, v in embed32.state_dict().items()})
+    query32 = torch.tensor([[0.3, -0.2, 0.6, 0.9]])
+    torch.testing.assert_close(
+        embed_low.attend(query32.to(dtype)).float(),
+        embed32.attend(query32),
+        rtol=6e-2,
+        atol=2e-2,
+    )

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -459,14 +459,26 @@ def test_attention_compute_and_parameter_dtypes_round_trip():
 @pytest.mark.parametrize("spherical", [False, True])
 def test_low_precision_conv_and_embedding_exact_match_is_finite(dtype, spherical):
     conv = YatConv1D(
-        1, 1, 3, bias=False, use_alpha=False, epsilon=1e-5, dtype=dtype
+        1,
+        1,
+        3,
+        bias=False,
+        use_alpha=False,
+        epsilon=1e-5,
+        learnable_epsilon=True,
+        dtype=dtype,
     )
+    with torch.no_grad():
+        # The finite score is representable in fp16, but its derivative is
+        # about 75,000 and exercises the saturating fp32->fp16 grad boundary.
+        conv.weight.fill_(0.5)
     conv_input = conv.weight.detach().reshape(1, 1, 3).clone().requires_grad_()
     conv_output = conv(conv_input)
     conv_output.sum().backward()
     assert torch.isfinite(conv_output).all() and (conv_output >= 0).all()
     assert torch.isfinite(conv_input.grad).all()
     assert torch.isfinite(conv.weight.grad).all()
+    assert torch.isfinite(conv.epsilon_param.grad).all()
 
     embed = YatEmbed(
         1, 3, use_alpha=False, epsilon=1e-5, dtype=dtype, spherical=spherical

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -20,17 +20,74 @@ from nmn.torch import (
 
 def test_tied_dense_construction_preserves_live_peer():
     YatNMN._KERNEL_BANKS.clear()
-    first = YatNMN(4, 2, tie_kernel_bank=True, kernel_bank_id="issue-71")
+    first = YatNMN(
+        4, 2, tie_kernel_bank=True, kernel_bank_size=3,
+        kernel_bank_id="issue-71",
+    )
     x = torch.randn(3, 4)
     weight_before = first.weight.detach().clone()
     output_before = first(x).detach().clone()
 
     second = YatNMN(4, 3, tie_kernel_bank=True, kernel_bank_id="issue-71")
 
-    torch.testing.assert_close(first.weight[:2], weight_before)
+    torch.testing.assert_close(first.weight, weight_before)
     torch.testing.assert_close(first(x), output_before)
     assert second.weight is first.weight
     assert first.weight.requires_grad
+
+
+def test_tied_dense_rejects_expansion_without_mutating_stale_gradient():
+    YatNMN._KERNEL_BANKS.clear()
+    first = YatNMN(
+        4, 2, tie_kernel_bank=True, alpha=False, bias=False,
+        kernel_bank_id="issue-71-stale-grad",
+    )
+    first(torch.randn(3, 4)).sum().backward()
+    parameter = first.weight
+    value_before = parameter.detach().clone()
+    gradient_before = parameter.grad.detach().clone()
+
+    with pytest.raises(ValueError, match="immutable capacity"):
+        YatNMN(
+            4, 3, tie_kernel_bank=True, alpha=False, bias=False,
+            kernel_bank_id="issue-71-stale-grad",
+        )
+
+    assert first.weight is parameter
+    torch.testing.assert_close(first.weight, value_before)
+    torch.testing.assert_close(first.weight.grad, gradient_before)
+
+
+def test_tied_dense_rejects_expansion_without_mutating_adam_state():
+    YatNMN._KERNEL_BANKS.clear()
+    first = YatNMN(
+        4, 2, tie_kernel_bank=True, alpha=False, bias=False,
+        kernel_bank_id="issue-71-adam",
+    )
+    optimizer = torch.optim.Adam(first.parameters(), lr=1e-3)
+    first(torch.randn(3, 4)).sum().backward()
+    optimizer.step()
+    parameter = first.weight
+    value_before = parameter.detach().clone()
+    state_before = {
+        key: value.detach().clone() if torch.is_tensor(value) else value
+        for key, value in optimizer.state[parameter].items()
+    }
+
+    with pytest.raises(ValueError, match="immutable capacity"):
+        YatNMN(
+            4, 3, tie_kernel_bank=True, alpha=False, bias=False,
+            kernel_bank_id="issue-71-adam",
+        )
+
+    assert first.weight is parameter
+    torch.testing.assert_close(first.weight, value_before)
+    for key, expected in state_before.items():
+        actual = optimizer.state[parameter][key]
+        if torch.is_tensor(expected):
+            torch.testing.assert_close(actual, expected)
+        else:
+            assert actual == expected
 
 
 def test_tied_dense_rejects_incompatible_lazy_consumer():
@@ -63,6 +120,8 @@ def test_tied_conv_bank_accumulates_gradients_and_uses_actual_bias_width(
         kernel_bank_id=bank_id,
     )
     assert narrow.weight is wide.weight
+    assert narrow.out_channels == 2
+    assert wide.out_channels == 4
     assert narrow.bias.shape == (2,)
     assert wide.bias.shape == (4,)
 
@@ -92,6 +151,65 @@ def test_tied_conv_bank_accumulates_gradients_and_uses_actual_bias_width(
     assert torch.count_nonzero(narrow.weight.grad[2:]) > 0
     optimizer.step()
     assert not torch.equal(before, narrow.weight)
+
+
+@pytest.mark.parametrize(
+    ("conv_cls", "input_shape"),
+    [
+        (YatConv1D, (1, 2, 3)),
+        (YatConv2D, (1, 2, 2, 2)),
+        (YatConv3D, (1, 2, 2, 2, 2)),
+    ],
+)
+def test_tied_conv_rejects_expansion_without_mutating_adam_state(
+    conv_cls, input_shape
+):
+    conv_cls._KERNEL_BANKS.clear()
+    bank_id = f"issue-72-immutable-{conv_cls.__name__}"
+    first = conv_cls(
+        2, 2, 1, tie_kernel_bank=True, bias=False, use_alpha=False,
+        kernel_bank_id=bank_id,
+    )
+    optimizer = torch.optim.Adam(first.parameters(), lr=1e-3)
+    first(torch.randn(*input_shape)).sum().backward()
+    optimizer.step()
+    parameter = first.weight
+    value_before = parameter.detach().clone()
+    state_before = {
+        key: value.detach().clone() if torch.is_tensor(value) else value
+        for key, value in optimizer.state[parameter].items()
+    }
+
+    with pytest.raises(ValueError, match="immutable capacity"):
+        conv_cls(
+            2, 4, 1, tie_kernel_bank=True, bias=False, use_alpha=False,
+            kernel_bank_id=bank_id,
+        )
+
+    assert first.weight is parameter
+    assert first.out_channels == 2
+    torch.testing.assert_close(first.weight, value_before)
+    for key, expected in state_before.items():
+        torch.testing.assert_close(optimizer.state[parameter][key], expected)
+
+
+@pytest.mark.parametrize("conv_cls", [YatConv1D, YatConv2D, YatConv3D])
+def test_tied_conv_bank_is_device_scoped_and_preserves_public_width(conv_cls):
+    conv_cls._KERNEL_BANKS.clear()
+    bank_id = f"issue-72-device-{conv_cls.__name__}"
+    cpu_layer = conv_cls(
+        2, 2, 1, tie_kernel_bank=True, kernel_bank_size=4,
+        kernel_bank_id=bank_id, device="cpu",
+    )
+    meta_layer = conv_cls(
+        2, 2, 1, tie_kernel_bank=True, kernel_bank_size=4,
+        kernel_bank_id=bank_id, device="meta",
+    )
+
+    assert cpu_layer.weight.device.type == "cpu"
+    assert meta_layer.weight.device.type == "meta"
+    assert cpu_layer.weight is not meta_layer.weight
+    assert cpu_layer.out_channels == meta_layer.out_channels == 2
 
 
 def test_attention_compute_and_parameter_dtypes_round_trip():


### PR DESCRIPTION
Closes #53. Closes #54. Closes #71. Closes #72. Fixes attention compute/parameter dtype separation; performs low-precision convolution, transpose-convolution, and embedding YAT math with stable fp32 accumulation and finite output casting; preserves tied dense/conv gradients and consumer metadata; and makes shared-bank construction, expansion, device identity, first-use sealing, and migration behavior safe. Adds 42 focused regressions. Final local evidence: 241 PyTorch tests passed, 2 CUDA-only skipped; independent review probes: 59 passed with no findings.