### PR TITLE
fix(nnx): correct Pallas tiled attention parity

### DIFF
--- a/src/nmn/nnx/layers/attention/pallas_yat_attention.py
+++ b/src/nmn/nnx/layers/attention/pallas_yat_attention.py
@@ -30,8 +30,6 @@ from __future__ import annotations
 
 import functools
 import math
-from typing import Optional
-
 import jax
 from jax import lax
 from jax.experimental import pallas as pl
@@ -56,19 +54,20 @@ def _yat_l1_fwd_kernel(
   kv_seq_len = k_ref.shape[0]
   start_q = pl.program_id(0)
   head_dim_padded = q_ref.shape[-1]
+  value_dim = v_ref.shape[-1]
 
   q = q_ref[...]                                       # [block_q, head_dim_padded]
   q_sq = jnp.sum(q * q, axis=-1)                       # [block_q]
 
   l_i = jnp.zeros(block_q, dtype=jnp.float32)
-  o = jnp.zeros((block_q, head_dim_padded), dtype=jnp.float32)
+  o = jnp.zeros((block_q, value_dim), dtype=jnp.float32)
 
   def body(start_k, carry):
     o_prev, l_prev = carry
     curr_k_slice = pl.dslice(start_k * block_k, block_k)
 
     k = k_ref[curr_k_slice, :]                          # [block_k, head_dim_padded]
-    v = v_ref[curr_k_slice, :]                          # [block_k, head_dim_padded]
+    v = v_ref[curr_k_slice, :]                          # [block_k, value_dim]
 
     dot = pl.dot(q, k.T)                                # [block_q, block_k]
     k_sq = jnp.sum(k * k, axis=-1)                     # [block_k]
@@ -88,7 +87,10 @@ def _yat_l1_fwd_kernel(
     return o_next, l_next
 
   if causal:
-    upper_bound = lax.div(block_q * (start_q + 1) + block_k - 1, block_k)
+    upper_bound = jnp.minimum(
+        lax.div(block_q * (start_q + 1) + block_k - 1, block_k),
+        pl.cdiv(kv_seq_len, block_k),
+    )
   else:
     upper_bound = pl.cdiv(kv_seq_len, block_k)
 
@@ -104,7 +106,7 @@ def _yat_l1_fwd_kernel(
 # ═══════════════════════════════════════════════════════════════════════
 
 def _yat_l1_bwd_dkv_kernel(
-    q_ref, k_ref, v_ref, l_ref, do_ref,
+    q_ref, k_ref, v_ref, l_ref, out_ref, do_ref,
     dk_ref, dv_ref,
     *,
     epsilon: float,
@@ -117,6 +119,7 @@ def _yat_l1_bwd_dkv_kernel(
   q_seq_len = q_ref.shape[0]
   start_k = pl.program_id(0)
   head_dim_padded = k_ref.shape[-1]
+  value_dim = v_ref.shape[-1]
 
   curr_k_slice = pl.dslice(start_k * block_k, block_k)
   k = k_ref[curr_k_slice, :]                           # [block_k, head_dim_padded]
@@ -124,7 +127,7 @@ def _yat_l1_bwd_dkv_kernel(
   k_sq = jnp.sum(k * k, axis=-1)                       # [block_k]
 
   dk = jnp.zeros((block_k, head_dim_padded), dtype=jnp.float32)
-  dv = jnp.zeros((block_k, head_dim_padded), dtype=jnp.float32)
+  dv = jnp.zeros((block_k, value_dim), dtype=jnp.float32)
 
   def body(start_q, carry):
     dk_prev, dv_prev = carry
@@ -132,6 +135,7 @@ def _yat_l1_bwd_dkv_kernel(
 
     q = q_ref[curr_q_slice, :]                          # [block_q, head_dim_padded]
     do = do_ref[curr_q_slice, :]
+    out = out_ref[curr_q_slice, :]
     l = l_ref[curr_q_slice]                             # [block_q]
 
     q_sq = jnp.sum(q * q, axis=-1)
@@ -148,10 +152,11 @@ def _yat_l1_bwd_dkv_kernel(
     l_safe = jnp.maximum(l, 1e-12)
     W = scores / l_safe[:, None]
 
-    # dW = dO @ V^T, then dS = (dW - sum(dW*W)) / L
+    # dW = dO @ V^T.  The normalization correction must be global
+    # across all K/V tiles: sum_j(dW_j * W_j) == dO dot output.
     dW = pl.dot(do, v.T)                                # [block_q, block_k]
-    dW_dot_W = jnp.sum(dW * W, axis=-1, keepdims=True)
-    dS = (dW - dW_dot_W) / l_safe[:, None]
+    delta = jnp.sum(do * out, axis=-1, keepdims=True)
+    dS = (dW - delta) / l_safe[:, None]
 
     if causal:
       dS = jnp.where(mask, dS, 0.0)
@@ -185,7 +190,7 @@ def _yat_l1_bwd_dkv_kernel(
 # ═══════════════════════════════════════════════════════════════════════
 
 def _yat_l1_bwd_dq_kernel(
-    q_ref, k_ref, v_ref, l_ref, do_ref,
+    q_ref, k_ref, v_ref, l_ref, out_ref, do_ref,
     dq_ref,
     *,
     epsilon: float,
@@ -202,6 +207,7 @@ def _yat_l1_bwd_dq_kernel(
   curr_q_slice = pl.dslice(start_q * block_q, block_q)
   q = q_ref[curr_q_slice, :]
   do = do_ref[curr_q_slice, :]
+  out = out_ref[curr_q_slice, :]
   l = l_ref[curr_q_slice]
   q_sq = jnp.sum(q * q, axis=-1)
 
@@ -227,8 +233,8 @@ def _yat_l1_bwd_dq_kernel(
     W = scores / l_safe[:, None]
 
     dW = pl.dot(do, v.T)
-    dW_dot_W = jnp.sum(dW * W, axis=-1, keepdims=True)
-    dS = (dW - dW_dot_W) / l_safe[:, None]
+    delta = jnp.sum(do * out, axis=-1, keepdims=True)
+    dS = (dW - delta) / l_safe[:, None]
 
     if causal:
       dS = jnp.where(mask, dS, 0.0)
@@ -247,7 +253,10 @@ def _yat_l1_bwd_dq_kernel(
     return dq_next
 
   if causal:
-    upper_bound = pl.cdiv((start_q + 1) * block_q, block_k)
+    upper_bound = jnp.minimum(
+        pl.cdiv((start_q + 1) * block_q, block_k),
+        pl.cdiv(kv_seq_len, block_k),
+    )
   else:
     upper_bound = pl.cdiv(kv_seq_len, block_k)
 
@@ -277,43 +286,88 @@ def pallas_yat_l1_attention(
       k: [..., kv_len, num_heads, head_dim]
       v: [..., kv_len, num_heads, v_dim]
       epsilon: Denominator stability constant.
-      causal: Apply causal mask.
-      block_q: Q tile size (must divide q_len).
-      block_k: K/V tile size (must divide kv_len).
+      causal: Apply a top-left causal mask (a query at position ``i`` may
+        attend to key positions ``j <= i``), including cross-attention where
+        ``q_len`` and ``kv_len`` differ.
+      block_q: Q tile size. Ragged sequence tails are padded internally.
+      block_k: K/V tile size. Ragged sequence tails are padded internally.
       interpret: If True, run on CPU via JAX tracing (for testing).
 
   Returns:
       Output of shape [..., q_len, num_heads, v_dim].
   """
-  # Reshape: [B, seq, H, D] — collapse leading batch dims
-  orig_shape = q.shape
-  batch_dims = q.ndim - 3
-  if batch_dims == 0:
-    q = q[None]
-    k = k[None]
-    v = v[None]
-  elif batch_dims > 1:
-    flat = math.prod(orig_shape[:batch_dims])
-    q = q.reshape(flat, *orig_shape[-3:])
-    k = k.reshape(flat, *k.shape[-3:])
-    v = v.reshape(flat, *v.shape[-3:])
+  _validate_inputs(q, k, v, block_q, block_k)
+  q, k, v, batch_shape = _flatten_batch(q, k, v)
 
   out = _pallas_yat_l1_fwd(q, k, v, epsilon, causal, block_q, block_k, interpret)
+  return _restore_batch(out, batch_shape)
 
-  if batch_dims == 0:
-    out = out[0]
-  elif batch_dims > 1:
-    out = out.reshape(*orig_shape[:batch_dims], *out.shape[-3:])
-  return out
+
+def _validate_inputs(q, k, v, block_q, block_k):
+  if q.ndim < 3 or k.ndim < 3 or v.ndim < 3:
+    raise ValueError("q, k, and v must have shape [..., sequence, heads, features]")
+  if q.shape[:-3] != k.shape[:-3] or q.shape[:-3] != v.shape[:-3]:
+    raise ValueError("q, k, and v batch dimensions must match")
+  if q.shape[-1] != k.shape[-1]:
+    raise ValueError("q and k head_dim must match")
+  if q.shape[-2] != k.shape[-2] or q.shape[-2] != v.shape[-2]:
+    raise ValueError("q, k, and v number of heads must match")
+  if k.shape[-3] != v.shape[-3]:
+    raise ValueError("k and v sequence lengths must match")
+  if q.shape[-3] == 0 or k.shape[-3] == 0:
+    raise ValueError("q and k sequence lengths must be non-zero")
+  if block_q <= 0 or block_k <= 0:
+    raise ValueError("block_q and block_k must be positive")
+  if q.dtype != k.dtype:
+    raise ValueError("q and k dtypes must match")
+
+
+def _flatten_batch(q, k, v):
+  batch_shape = q.shape[:-3]
+  if not batch_shape:
+    return q[None], k[None], v[None], batch_shape
+  if len(batch_shape) == 1:
+    return q, k, v, batch_shape
+  flat = math.prod(batch_shape)
+  return (
+      q.reshape(flat, *q.shape[-3:]),
+      k.reshape(flat, *k.shape[-3:]),
+      v.reshape(flat, *v.shape[-3:]),
+      batch_shape,
+  )
+
+
+def _restore_batch(x, batch_shape):
+  if not batch_shape:
+    return x[0]
+  if len(batch_shape) > 1:
+    return x.reshape(*batch_shape, *x.shape[-3:])
+  return x
+
+
+def _pad_sequences(q, k, v, block_q, block_k):
+  q_len, kv_len = q.shape[1], k.shape[1]
+  q_pad = (-q_len) % block_q
+  kv_pad = (-kv_len) % block_k
+  q = jnp.pad(q, ((0, 0), (0, q_pad), (0, 0), (0, 0)))
+  k = jnp.pad(k, ((0, 0), (0, kv_pad), (0, 0), (0, 0)))
+  v = jnp.pad(v, ((0, 0), (0, kv_pad), (0, 0), (0, 0)))
+  return q, k, v, q_len, kv_len
 
 
 def _pallas_yat_l1_fwd(q, k, v, epsilon, causal, block_q, block_k, interpret):
-  batch_size, q_seq_len, num_heads, head_dim = q.shape
-  kv_seq_len = k.shape[1]
-  scale = math.sqrt(float(head_dim))
+  block_q = min(block_q, q.shape[1])
+  block_k = min(block_k, k.shape[1])
+  q, k, v, q_len, _ = _pad_sequences(q, k, v, block_q, block_k)
+  out, _ = _pallas_yat_l1_fwd_padded(
+      q, k, v, epsilon, causal, block_q, block_k, interpret)
+  return out[:, :q_len]
 
-  block_q = min(block_q, q_seq_len)
-  block_k = min(block_k, kv_seq_len)
+
+def _pallas_yat_l1_fwd_padded(q, k, v, epsilon, causal, block_q, block_k, interpret):
+  batch_size, q_seq_len, num_heads, head_dim = q.shape
+  kv_seq_len, value_dim = k.shape[1], v.shape[-1]
+  scale = math.sqrt(float(head_dim))
 
   kernel = functools.partial(
       _yat_l1_fwd_kernel,
@@ -327,14 +381,14 @@ def _pallas_yat_l1_fwd(q, k, v, epsilon, causal, block_q, block_k, interpret):
   in_specs = [
       pl.BlockSpec((None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)),
       pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
-      pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
+      pl.BlockSpec((None, kv_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
   ]
   out_specs = [
-      pl.BlockSpec((None, block_q, None, head_dim), lambda i, j, k: (j, i, k, 0)),
+      pl.BlockSpec((None, block_q, None, value_dim), lambda i, j, k: (j, i, k, 0)),
       pl.BlockSpec((None, None, block_q), lambda i, j, k: (j, k, i)),
   ]
   out_shapes = [
-      jax.ShapeDtypeStruct(q.shape, q.dtype),
+      jax.ShapeDtypeStruct((batch_size, q_seq_len, num_heads, value_dim), v.dtype),
       jax.ShapeDtypeStruct((batch_size, num_heads, q_seq_len), jnp.float32),
   ]
 
@@ -347,56 +401,23 @@ def _pallas_yat_l1_fwd(q, k, v, epsilon, causal, block_q, block_k, interpret):
       interpret=interpret,
       name="yat_l1_fwd",
   )(q, k, v)
-  return out
+  return out, l
 
 
 def _pallas_yat_l1_fwd_with_residuals(q, k, v, epsilon, causal, block_q, block_k, interpret):
-  batch_size, q_seq_len, num_heads, head_dim = q.shape
-  kv_seq_len = k.shape[1]
-  scale = math.sqrt(float(head_dim))
-
-  block_q_actual = min(block_q, q_seq_len)
-  block_k_actual = min(block_k, kv_seq_len)
-
-  kernel = functools.partial(
-      _yat_l1_fwd_kernel,
-      epsilon=epsilon, scale=scale,
-      block_q=block_q_actual, block_k=block_k_actual,
-      head_dim=head_dim, causal=causal,
-  )
-
-  grid = (pl.cdiv(q_seq_len, block_q_actual), batch_size, num_heads)
-
-  in_specs = [
-      pl.BlockSpec((None, block_q_actual, None, head_dim), lambda i, j, k: (j, i, k, 0)),
-      pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
-      pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
-  ]
-  out_specs = [
-      pl.BlockSpec((None, block_q_actual, None, head_dim), lambda i, j, k: (j, i, k, 0)),
-      pl.BlockSpec((None, None, block_q_actual), lambda i, j, k: (j, k, i)),
-  ]
-  out_shapes = [
-      jax.ShapeDtypeStruct(q.shape, q.dtype),
-      jax.ShapeDtypeStruct((batch_size, num_heads, q_seq_len), jnp.float32),
-  ]
-
-  out, l = pl.pallas_call(
-      kernel,
-      grid=grid,
-      in_specs=in_specs,
-      out_specs=out_specs,
-      out_shape=out_shapes,
-      interpret=interpret,
-      name="yat_l1_fwd",
-  )(q, k, v)
-  return out, (q, k, v, l, out)
+  block_q_actual = min(block_q, q.shape[1])
+  block_k_actual = min(block_k, k.shape[1])
+  q, k, v, q_len, kv_len = _pad_sequences(
+      q, k, v, block_q_actual, block_k_actual)
+  out, l = _pallas_yat_l1_fwd_padded(
+      q, k, v, epsilon, causal, block_q_actual, block_k_actual, interpret)
+  return out[:, :q_len], (q, k, v, l, out, q_len, kv_len)
 
 
 def _pallas_yat_l1_bwd(epsilon, causal, block_q, block_k, interpret, res, do):
   q, k, v, l, out = res
   batch_size, q_seq_len, num_heads, head_dim = q.shape
-  kv_seq_len = k.shape[1]
+  kv_seq_len, value_dim = k.shape[1], v.shape[-1]
   scale = math.sqrt(float(head_dim))
 
   block_q_actual = min(block_q, q_seq_len)
@@ -417,13 +438,14 @@ def _pallas_yat_l1_bwd(epsilon, causal, block_q, block_k, interpret, res, do):
       in_specs=[
           pl.BlockSpec((None, q_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
           pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
-          pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, kv_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
           pl.BlockSpec((None, None, q_seq_len), lambda _, j, k: (j, k, 0)),
-          pl.BlockSpec((None, q_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, q_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, q_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
       ],
       out_specs=[
           pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
-          pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, kv_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
       ],
       out_shape=[
           jax.ShapeDtypeStruct(k.shape, k.dtype),
@@ -431,7 +453,7 @@ def _pallas_yat_l1_bwd(epsilon, causal, block_q, block_k, interpret, res, do):
       ],
       interpret=interpret,
       name="yat_l1_bwd_dkv",
-  )(q, k, v, l, do)
+  )(q, k, v, l, out, do)
 
   # ── dQ kernel ──
   dq_kernel = functools.partial(
@@ -446,64 +468,47 @@ def _pallas_yat_l1_bwd(epsilon, causal, block_q, block_k, interpret, res, do):
       in_specs=[
           pl.BlockSpec((None, q_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
           pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
-          pl.BlockSpec((None, kv_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, kv_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
           pl.BlockSpec((None, None, q_seq_len), lambda _, j, k: (j, k, 0)),
-          pl.BlockSpec((None, q_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, q_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
+          pl.BlockSpec((None, q_seq_len, None, value_dim), lambda _, j, k: (j, 0, k, 0)),
       ],
       out_specs=pl.BlockSpec((None, q_seq_len, None, head_dim), lambda _, j, k: (j, 0, k, 0)),
       out_shape=jax.ShapeDtypeStruct(q.shape, q.dtype),
       interpret=interpret,
       name="yat_l1_bwd_dq",
-  )(q, k, v, l, do)
+  )(q, k, v, l, out, do)
 
   return dq, dk, dv
 
 
 def _pallas_vjp_fwd(q, k, v, epsilon, causal, block_q, block_k, interpret):
-  # Reshape batch dims
-  orig_shape = q.shape
-  batch_dims = q.ndim - 3
-  if batch_dims == 0:
-    q, k, v = q[None], k[None], v[None]
-  elif batch_dims > 1:
-    flat = math.prod(orig_shape[:batch_dims])
-    q = q.reshape(flat, *orig_shape[-3:])
-    k = k.reshape(flat, *k.shape[-3:])
-    v = v.reshape(flat, *v.shape[-3:])
+  _validate_inputs(q, k, v, block_q, block_k)
+  q, k, v, batch_shape = _flatten_batch(q, k, v)
 
   out, residuals = _pallas_yat_l1_fwd_with_residuals(
       q, k, v, epsilon, causal, block_q, block_k, interpret)
 
-  if batch_dims == 0:
-    final_out = out[0]
-  elif batch_dims > 1:
-    final_out = out.reshape(*orig_shape[:batch_dims], *out.shape[-3:])
-  else:
-    final_out = out
-
-  return final_out, (residuals, orig_shape)
+  return _restore_batch(out, batch_shape), (residuals, batch_shape)
 
 
 def _pallas_vjp_bwd(epsilon, causal, block_q, block_k, interpret, res, do):
-  (q, k, v, l, out), orig_shape = res
-  batch_dims = len(orig_shape) - 3
+  (q, k, v, l, out, q_len, kv_len), batch_shape = res
 
-  if batch_dims == 0:
+  if not batch_shape:
     do = do[None]
-  elif batch_dims > 1:
-    flat = math.prod(orig_shape[:batch_dims])
+  elif len(batch_shape) > 1:
+    flat = math.prod(batch_shape)
     do = do.reshape(flat, *do.shape[-3:])
+  do = jnp.pad(do, ((0, 0), (0, q.shape[1] - q_len), (0, 0), (0, 0)))
 
   dq, dk, dv = _pallas_yat_l1_bwd(epsilon, causal, block_q, block_k, interpret, (q, k, v, l, out), do)
-
-  if batch_dims == 0:
-    dq, dk, dv = dq[0], dk[0], dv[0]
-  elif batch_dims > 1:
-    dq = dq.reshape(*orig_shape[:batch_dims], *dq.shape[-3:])
-    dk = dk.reshape(*orig_shape[:batch_dims], *dk.shape[-3:])
-    dv = dv.reshape(*orig_shape[:batch_dims], *dv.shape[-3:])
-
-  return dq, dk, dv
+  dq, dk, dv = dq[:, :q_len], dk[:, :kv_len], dv[:, :kv_len]
+  return (
+      _restore_batch(dq, batch_shape),
+      _restore_batch(dk, batch_shape),
+      _restore_batch(dv, batch_shape),
+  )
 
 
 pallas_yat_l1_attention.defvjp(_pallas_vjp_fwd, _pallas_vjp_bwd)

--- a/tests/test_nnx/test_pallas_yat_attention.py
+++ b/tests/test_nnx/test_pallas_yat_attention.py
@@ -1,88 +1,120 @@
-"""Tests for Pallas-fused YAT L1 attention.
+"""Numerical parity tests for Pallas-fused YAT L1 attention."""
 
-Compares the tiled Pallas kernel (interpret=True for CPU) against
-the custom_vjp reference implementation.
-"""
+import math
 
+import numpy as np
 import pytest
 
 try:
     import jax
     import jax.numpy as jnp
     from nmn.nnx.layers.attention.pallas_yat_attention import pallas_yat_l1_attention
-    from nmn.nnx.layers.attention.fused_yat_attention import fused_yat_l1_attention
     HAS_JAX = True
 except ImportError:
     HAS_JAX = False
 
 pytestmark = pytest.mark.skipif(not HAS_JAX, reason="JAX/Flax not available")
 
-BQ, BK = 8, 8
-
 
 def _rand(shape, key=0):
-    return jax.random.normal(jax.random.PRNGKey(key), shape)
+    return jax.random.normal(jax.random.key(key), shape)
 
 
-class TestPallasForward:
-
-    def test_basic(self):
-        q, k, v = _rand((2, 16, 4, 16)), _rand((2, 16, 4, 16), 1), _rand((2, 16, 4, 16), 2)
-        out_p = pallas_yat_l1_attention(q, k, v, block_q=BQ, block_k=BK, interpret=True)
-        out_r = fused_yat_l1_attention(q, k, v)
-        assert jnp.allclose(out_p, out_r, atol=1e-5)
-
-    def test_causal(self):
-        q, k, v = _rand((2, 16, 4, 16)), _rand((2, 16, 4, 16), 1), _rand((2, 16, 4, 16), 2)
-        mask = jnp.tril(jnp.ones((16, 16), dtype=jnp.bool_))
-        out_p = pallas_yat_l1_attention(q, k, v, causal=True, block_q=BQ, block_k=BK, interpret=True)
-        out_r = fused_yat_l1_attention(q, k, v, mask=mask)
-        assert jnp.allclose(out_p, out_r, atol=1e-5)
-
-    def test_no_batch(self):
-        q, k, v = _rand((16, 4, 16)), _rand((16, 4, 16), 1), _rand((16, 4, 16), 2)
-        out = pallas_yat_l1_attention(q, k, v, block_q=BQ, block_k=BK, interpret=True)
-        assert out.shape == (16, 4, 16)
-        assert jnp.isfinite(out).all()
-
-    def test_different_eps(self):
-        q, k, v = _rand((2, 16, 4, 16)), _rand((2, 16, 4, 16), 1), _rand((2, 16, 4, 16), 2)
-        for eps in [1e-3, 1e-5, 0.1]:
-            out_p = pallas_yat_l1_attention(q, k, v, epsilon=eps, block_q=BQ, block_k=BK, interpret=True)
-            out_r = fused_yat_l1_attention(q, k, v, epsilon=eps)
-            assert jnp.allclose(out_p, out_r, atol=1e-5), f"eps={eps}"
+def _reference(q, k, v, *, epsilon=1e-5, causal=False):
+    """Plain-JAX oracle, deliberately independent of either fused custom VJP."""
+    q32, k32, v32 = q.astype(jnp.float32), k.astype(jnp.float32), v.astype(jnp.float32)
+    dot = jnp.einsum("...qhd,...khd->...hqk", q32, k32)
+    q_sq = jnp.einsum("...qhd,...qhd->...hq", q32, q32)[..., :, :, None]
+    k_sq = jnp.einsum("...khd,...khd->...hk", k32, k32)[..., :, None, :]
+    dist = jnp.maximum(q_sq + k_sq - 2.0 * dot, 0.0) + epsilon
+    scores = jnp.square(dot) / (dist * math.sqrt(q.shape[-1]))
+    if causal:
+        q_pos = jnp.arange(q.shape[-3])[:, None]
+        k_pos = jnp.arange(k.shape[-3])[None, :]
+        scores = jnp.where(q_pos >= k_pos, scores, 0.0)
+    weights = scores / jnp.maximum(scores.sum(axis=-1, keepdims=True), 1e-12)
+    return jnp.einsum("...hqk,...khd->...qhd", weights, v32).astype(v.dtype)
 
 
-class TestPallasBackward:
+def _cosine(a, b):
+    a, b = np.asarray(a).ravel(), np.asarray(b).ravel()
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-30))
 
-    def _compare_grads(self, causal=False, atol=5e-3):
-        q, k, v = _rand((2, 16, 4, 16)), _rand((2, 16, 4, 16), 1), _rand((2, 16, 4, 16), 2)
-        mask = jnp.tril(jnp.ones((16, 16), dtype=jnp.bool_)) if causal else None
 
-        def loss_p(q, k, v):
-            return jnp.mean(pallas_yat_l1_attention(
-                q, k, v, causal=causal, block_q=BQ, block_k=BK, interpret=True) ** 2)
-        def loss_r(q, k, v):
-            return jnp.mean(fused_yat_l1_attention(q, k, v, mask=mask) ** 2)
+CASES = [
+    pytest.param(2, 2, 4, 4, False, 4, 4, id="tiny-single-tile"),
+    pytest.param(7, 11, 4, 3, False, 4, 4, id="ragged-multitile-v-smaller"),
+    pytest.param(7, 11, 4, 6, False, 4, 4, id="ragged-multitile-v-larger"),
+    pytest.param(5, 9, 4, 3, True, 4, 4, id="causal-q-shorter-than-kv"),
+    pytest.param(9, 5, 4, 6, True, 4, 4, id="causal-q-longer-than-kv"),
+    pytest.param(8, 13, 4, 5, True, 3, 5, id="unequal-ragged-tiles"),
+]
 
-        gp = jax.grad(loss_p, argnums=(0, 1, 2))(q, k, v)
-        gr = jax.grad(loss_r, argnums=(0, 1, 2))(q, k, v)
 
-        for name, a, b in zip(["dQ", "dK", "dV"], gp, gr):
-            err = float(jnp.abs(a - b).max())
-            assert err < atol, f"{name} err {err:.2e} > {atol}"
+@pytest.mark.parametrize("q_len,kv_len,head_dim,v_dim,causal,block_q,block_k", CASES)
+def test_forward_matches_plain_jax(
+    q_len, kv_len, head_dim, v_dim, causal, block_q, block_k,
+):
+    q = _rand((1, q_len, 2, head_dim), 0)
+    k = _rand((1, kv_len, 2, head_dim), 1)
+    v = _rand((1, kv_len, 2, v_dim), 2)
+    actual = pallas_yat_l1_attention(
+        q, k, v, causal=causal, block_q=block_q, block_k=block_k, interpret=True)
+    expected = _reference(q, k, v, causal=causal)
+    np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+    assert actual.shape == (1, q_len, 2, v_dim)
 
-    def test_basic_grads(self):
-        self._compare_grads()
 
-    def test_causal_grads(self):
-        self._compare_grads(causal=True)
+@pytest.mark.parametrize("q_len,kv_len,head_dim,v_dim,causal,block_q,block_k", CASES)
+def test_gradients_match_plain_jax(
+    q_len, kv_len, head_dim, v_dim, causal, block_q, block_k,
+):
+    q = _rand((1, q_len, 2, head_dim), 3)
+    k = _rand((1, kv_len, 2, head_dim), 4)
+    v = _rand((1, kv_len, 2, v_dim), 5)
+    cotangent = _rand((1, q_len, 2, v_dim), 6)
 
-    def test_grads_finite(self):
-        q, k, v = _rand((2, 16, 4, 16)), _rand((2, 16, 4, 16), 1), _rand((2, 16, 4, 16), 2)
-        def loss(q, k, v):
-            return jnp.mean(pallas_yat_l1_attention(
-                q, k, v, block_q=BQ, block_k=BK, interpret=True) ** 2)
-        grads = jax.grad(loss, argnums=(0, 1, 2))(q, k, v)
-        for g in grads:
-            assert jnp.isfinite(g).all()
+    def pallas_loss(q, k, v):
+        return jnp.vdot(
+            pallas_yat_l1_attention(
+                q, k, v, causal=causal, block_q=block_q, block_k=block_k,
+                interpret=True),
+            cotangent,
+        )
+
+    def reference_loss(q, k, v):
+        return jnp.vdot(_reference(q, k, v, causal=causal), cotangent)
+
+    actual = jax.grad(pallas_loss, argnums=(0, 1, 2))(q, k, v)
+    expected = jax.grad(reference_loss, argnums=(0, 1, 2))(q, k, v)
+    for name, got, want in zip(("dQ", "dK", "dV"), actual, expected):
+        np.testing.assert_allclose(got, want, rtol=2e-4, atol=2e-4, err_msg=name)
+        assert _cosine(got, want) > 0.99999, name
+
+
+def test_no_batch_and_multiple_batch_dimensions():
+    q = _rand((7, 2, 4), 7)
+    k = _rand((11, 2, 4), 8)
+    v = _rand((11, 2, 3), 9)
+    out = pallas_yat_l1_attention(q, k, v, block_q=4, block_k=4, interpret=True)
+    np.testing.assert_allclose(out, _reference(q, k, v), rtol=2e-5, atol=2e-5)
+
+    q2 = jnp.broadcast_to(q, (2, 3) + q.shape)
+    k2 = jnp.broadcast_to(k, (2, 3) + k.shape)
+    v2 = jnp.broadcast_to(v, (2, 3) + v.shape)
+    out2 = pallas_yat_l1_attention(q2, k2, v2, block_q=4, block_k=4, interpret=True)
+    np.testing.assert_allclose(out2, _reference(q2, k2, v2), rtol=2e-5, atol=2e-5)
+
+
+@pytest.mark.parametrize(
+    "q_shape,k_shape,v_shape,message",
+    [
+        ((1, 4, 2, 3), (1, 4, 2, 4), (1, 4, 2, 5), "head_dim"),
+        ((1, 4, 2, 3), (1, 5, 2, 3), (1, 4, 2, 5), "sequence"),
+        ((1, 4, 2, 3), (1, 4, 3, 3), (1, 4, 2, 5), "heads"),
+    ],
+)
+def test_shape_validation(q_shape, k_shape, v_shape, message):
+    with pytest.raises(ValueError, match=message):
+        pallas_yat_l1_attention(
+            jnp.ones(q_shape), jnp.ones(k_shape), jnp.ones(v_shape), interpret=True)


### PR DESCRIPTION
Fixes #48
Fixes #49
Fixes #50

Corrects global L1-normalization gradients across multiple K/V tiles, pads and crops ragged sequences with bounded causal loops, and separates head and value dimensions throughout the Pallas forward/backward kernels.

Verification:
- 16 independent plain-JAX oracle parity tests (forward, dQ, dK, dV)
- adversarial multi-tile, ragged, unequal-length, causal, and v_dim cases
- full local NNX suite: 320 passed, 1 skipped
- independent review approved CPU interpret=True semantics

Hardware caveat: local validation used CPU Pallas interpret=True. TPU/GPU lowering and execution remain unverified and should be hardware-gated.