### PR TITLE
fix(nnx): stabilize attention parity and decoding

### DIFF
--- a/src/nmn/nnx/layers/attention/fused_yat_attention.py
+++ b/src/nmn/nnx/layers/attention/fused_yat_attention.py
@@ -85,6 +85,15 @@ def fused_yat_l1_attention(
 
 # ── Helpers to compute YAT scores from Q, K ────────────────────────────
 
+def _unbroadcast_to(gradient: Array, target: Array) -> Array:
+  """Sum a broadcasted gradient back to ``target.shape`` exactly."""
+  while gradient.ndim > target.ndim:
+    gradient = jnp.sum(gradient, axis=0)
+  for axis, size in enumerate(target.shape):
+    if size == 1 and gradient.shape[axis] != 1:
+      gradient = jnp.sum(gradient, axis=axis, keepdims=True)
+  return gradient.reshape(target.shape).astype(target.dtype)
+
 def _yat_scores(q_f32, k_f32, bias, epsilon, mask, has_bias, has_mask, scale):
   """Compute raw YAT scores and the L1 normalizer.
 
@@ -234,22 +243,15 @@ def _fused_yat_l1_attn_bwd(has_bias, has_mask, has_eps_grad, scale, precision,
 
   # ── dBias: d(scores)/d(bias) = 2*num / (dist*scale) ──────────────
   if has_bias:
-    g_bias = jnp.sum(dS * 2 * num * inv_dist_scale,
-                     axis=tuple(range(batch_dims)))
-    # Reduce to match bias.shape via broadcasting rules
-    while g_bias.ndim > bias.ndim:
-      g_bias = jnp.sum(g_bias, axis=0)
-    for i in range(bias.ndim):
-      if bias.shape[i] == 1 and g_bias.shape[i] != 1:
-        g_bias = jnp.sum(g_bias, axis=i, keepdims=True)
-    g_bias = g_bias.astype(bias.dtype)
+    g_bias = _unbroadcast_to(dS * 2 * num * inv_dist_scale, bias)
   else:
     g_bias = jnp.zeros_like(bias)
 
   # ── dEpsilon: d(scores)/d(eps) = -num² / (dist² * scale) ─────────
   if has_eps_grad:
-    g_eps = jnp.sum(dS * (-(num ** 2) * inv_dist_scale_sq))
-    g_eps = g_eps.reshape(epsilon.shape).astype(epsilon.dtype)
+    g_eps = _unbroadcast_to(
+        dS * (-(num ** 2) * inv_dist_scale_sq), epsilon
+    )
   else:
     g_eps = jnp.zeros_like(epsilon)
 
@@ -483,21 +485,15 @@ def _fused_yat_l1_self_attn_bwd(has_bias, has_eps_grad, scale, precision, res, g
 
   # dBias
   if has_bias:
-    g_bias = jnp.sum(dS * 2 * num * inv_dist_scale,
-                     axis=tuple(range(batch_dims)))
-    while g_bias.ndim > bias.ndim:
-      g_bias = jnp.sum(g_bias, axis=0)
-    for i in range(bias.ndim):
-      if bias.shape[i] == 1 and g_bias.shape[i] != 1:
-        g_bias = jnp.sum(g_bias, axis=i, keepdims=True)
-    g_bias = g_bias.astype(bias.dtype)
+    g_bias = _unbroadcast_to(dS * 2 * num * inv_dist_scale, bias)
   else:
     g_bias = jnp.zeros_like(bias)
 
   # dEpsilon
   if has_eps_grad:
-    g_eps = jnp.sum(dS * (-(num ** 2) * inv_dist_scale_sq))
-    g_eps = g_eps.reshape(epsilon.shape).astype(epsilon.dtype)
+    g_eps = _unbroadcast_to(
+        dS * (-(num ** 2) * inv_dist_scale_sq), epsilon
+    )
   else:
     g_eps = jnp.zeros_like(epsilon)
 

--- a/src/nmn/nnx/layers/attention/fused_yat_attention.py
+++ b/src/nmn/nnx/layers/attention/fused_yat_attention.py
@@ -88,7 +88,8 @@ def fused_yat_l1_attention(
 def _yat_scores(q_f32, k_f32, bias, epsilon, mask, has_bias, has_mask, scale):
   """Compute raw YAT scores and the L1 normalizer.
 
-  Returns (scores, L, dist) where L = sum(scores, axis=-1, keepdims=True).
+  Returns (scores, L, dist, dot, num, clamp_grad) where
+  L = sum(scores, axis=-1, keepdims=True).
   ``dist`` = squared_dist + eps (the denominator), kept for backward.
   """
   dot = jnp.einsum("...qhd,...khd->...hqk", q_f32, k_f32)
@@ -103,6 +104,11 @@ def _yat_scores(q_f32, k_f32, bias, epsilon, mask, has_bias, has_mask, scale):
   k_sq_t = jnp.swapaxes(k_sq_t, -2, -1)
 
   raw_dist = q_sq_t + k_sq_t - 2.0 * dot
+  # Match the subgradient chosen by jnp.maximum(raw_dist, 0): one on the
+  # positive branch, zero on the negative branch, and one half at the tie.
+  # The custom VJP must retain this information because ``dist`` alone cannot
+  # distinguish a clamped negative value from an exact zero.
+  clamp_grad = jnp.where(raw_dist > 0.0, 1.0, jnp.where(raw_dist < 0.0, 0.0, 0.5))
   dist = jnp.maximum(raw_dist, 0.0) + epsilon
 
   num = (dot + bias) if has_bias else dot
@@ -112,7 +118,7 @@ def _yat_scores(q_f32, k_f32, bias, epsilon, mask, has_bias, has_mask, scale):
     scores = jnp.where(mask, scores, 0.0)
 
   L = jnp.sum(scores, axis=-1, keepdims=True)
-  return scores, L, dist, dot, num
+  return scores, L, dist, dot, num, clamp_grad
 
 
 # ── custom_vjp implementation ──────────────────────────────────────────
@@ -123,7 +129,7 @@ def _fused_yat_l1_attn(query, key, value, bias, epsilon, mask,
   q_f32 = query.astype(jnp.float32)
   k_f32 = key.astype(jnp.float32)
 
-  scores, L, _, _, _ = _yat_scores(
+  scores, L, _, _, _, _ = _yat_scores(
       q_f32, k_f32, bias.astype(jnp.float32) if has_bias else bias,
       epsilon.astype(jnp.float32), mask, has_bias, has_mask, scale)
 
@@ -138,7 +144,7 @@ def _fused_yat_l1_attn_fwd(query, key, value, bias, epsilon, mask,
   q_f32 = query.astype(jnp.float32)
   k_f32 = key.astype(jnp.float32)
 
-  scores, L, _, _, _ = _yat_scores(
+  scores, L, _, _, _, _ = _yat_scores(
       q_f32, k_f32, bias.astype(jnp.float32) if has_bias else bias,
       epsilon.astype(jnp.float32), mask, has_bias, has_mask, scale)
 
@@ -159,7 +165,7 @@ def _fused_yat_l1_attn_bwd(has_bias, has_mask, has_eps_grad, scale, precision,
   e_f32 = epsilon.astype(jnp.float32)
   b_f32 = bias.astype(jnp.float32) if has_bias else bias
 
-  scores, _, dist, dot, num = _yat_scores(
+  scores, _, dist, dot, num, clamp_grad = _yat_scores(
       q_f32, k_f32, b_f32, e_f32, mask, has_bias, has_mask, scale)
 
   L_safe = L + 1e-12
@@ -197,10 +203,11 @@ def _fused_yat_l1_attn_bwd(has_bias, has_mask, has_eps_grad, scale, precision,
   d_scores_d_dist = -(num ** 2) * inv_dist_scale_sq
 
   g_num = dS * d_scores_d_num           # [..., H, Q, K]
-  g_dist = dS * d_scores_d_dist         # [..., H, Q, K]
+  g_dist = dS * d_scores_d_dist         # gradient wrt dist = clamp(raw) + eps
+  g_raw_dist = g_dist * clamp_grad       # gradient wrt reconstructed distance
 
   # Total dot gradient = numerator path (d_num/d_dot=1) + dist path (d_dist/d_dot=-2)
-  g_dot_total = g_num + g_dist * (-2.0)
+  g_dot_total = g_num + g_raw_dist * (-2.0)
 
   # ── g_dot_total -> dQ, dK through einsum ──────────────────────────
   # dot = einsum("...qhd,...khd->...hqk")
@@ -212,7 +219,7 @@ def _fused_yat_l1_attn_bwd(has_bias, has_mask, has_eps_grad, scale, precision,
   # g_dist shape: [..., H, Q, K], q shape: [..., Q, H, D]
   # q_sq_t shape: [..., H, Q, 1] -- was summed over K via broadcasting
   # So g_q_sq = sum(g_dist, axis=-1, keepdims=False)  -> [..., H, Q]
-  g_q_sq = jnp.sum(g_dist, axis=-1)              # [..., H, Q]
+  g_q_sq = jnp.sum(g_raw_dist, axis=-1)          # [..., H, Q]
   # Transpose back: [..., H, Q] -> [..., Q, H] -> [..., Q, H, 1]
   batch_dims = query.ndim - 3
   q_perm_back = tuple(range(batch_dims)) + (batch_dims + 1, batch_dims)
@@ -220,7 +227,7 @@ def _fused_yat_l1_attn_bwd(has_bias, has_mask, has_eps_grad, scale, precision,
   dQ += 2.0 * q_f32 * g_q_sq_t
 
   # Contribution from g_dist through k_sq path
-  g_k_sq = jnp.sum(g_dist, axis=-2)              # [..., H, K]
+  g_k_sq = jnp.sum(g_raw_dist, axis=-2)          # [..., H, K]
   k_perm_back = tuple(range(batch_dims)) + (batch_dims + 1, batch_dims)
   g_k_sq_t = g_k_sq.transpose(k_perm_back)[..., None]  # [..., K, H, 1]
   dK += 2.0 * k_f32 * g_k_sq_t
@@ -337,7 +344,7 @@ def _yat_self_scores(x_f32, bias, epsilon, has_bias, scale):
   """Compute raw YAT scores with zero diagonal, and the L1 normalizer that
   includes the diagonal.
 
-  Returns (scores_off_diag, L, dist, dot, num) where:
+  Returns (scores_off_diag, L, dist, dot, num, clamp_grad) where:
     - scores_off_diag has zero diagonal
     - L = sum(scores_full, axis=-1, keepdims=True)   # includes diagonal
   """
@@ -352,6 +359,7 @@ def _yat_self_scores(x_f32, bias, epsilon, has_bias, scale):
   x_sq_k = jnp.swapaxes(x_sq_t, -2, -1)                # [..., heads, 1, seq]
 
   raw_dist = x_sq_t + x_sq_k - 2.0 * dot
+  clamp_grad = jnp.where(raw_dist > 0.0, 1.0, jnp.where(raw_dist < 0.0, 0.0, 0.5))
   dist = jnp.maximum(raw_dist, 0.0) + epsilon
 
   num = (dot + bias) if has_bias else dot
@@ -365,7 +373,7 @@ def _yat_self_scores(x_f32, bias, epsilon, has_bias, scale):
   eye = jnp.eye(seq_len, dtype=jnp.bool_)
   scores_off_diag = jnp.where(eye, 0.0, scores)
 
-  return scores_off_diag, L, dist, dot, num
+  return scores_off_diag, L, dist, dot, num, clamp_grad
 
 
 @functools.partial(jax.custom_vjp, nondiff_argnums=(4, 5, 6, 7))
@@ -373,7 +381,7 @@ def _fused_yat_l1_self_attn(x, value, bias, epsilon,
                              has_bias, has_eps_grad, scale, precision):
   x_f32 = x.astype(jnp.float32)
 
-  scores_off, L, _, _, _ = _yat_self_scores(
+  scores_off, L, _, _, _, _ = _yat_self_scores(
       x_f32, bias.astype(jnp.float32) if has_bias else bias,
       epsilon.astype(jnp.float32), has_bias, scale)
 
@@ -386,7 +394,7 @@ def _fused_yat_l1_self_attn_fwd(x, value, bias, epsilon,
                                  has_bias, has_eps_grad, scale, precision):
   x_f32 = x.astype(jnp.float32)
 
-  scores_off, L, _, _, _ = _yat_self_scores(
+  scores_off, L, _, _, _, _ = _yat_self_scores(
       x_f32, bias.astype(jnp.float32) if has_bias else bias,
       epsilon.astype(jnp.float32), has_bias, scale)
 
@@ -403,7 +411,7 @@ def _fused_yat_l1_self_attn_bwd(has_bias, has_eps_grad, scale, precision, res, g
   e_f32 = epsilon.astype(jnp.float32)
   b_f32 = bias.astype(jnp.float32) if has_bias else bias
 
-  scores_off, _, dist, dot, num = _yat_self_scores(
+  scores_off, _, dist, dot, num, clamp_grad = _yat_self_scores(
       x_f32, b_f32, e_f32, has_bias, scale)
 
   seq_len = scores_off.shape[-1]
@@ -450,10 +458,11 @@ def _fused_yat_l1_self_attn_bwd(has_bias, has_eps_grad, scale, precision, res, g
 
   g_num = dS * d_scores_d_num
   g_dist = dS * d_scores_d_dist
+  g_raw_dist = g_dist * clamp_grad
 
   # dot = x @ x^T:  d(dot_ij)/d(x_i) = x_j,  d(dot_ij)/d(x_j) = x_i
   # Both contribute to dx. Use symmetric accumulation.
-  g_dot_total = g_num + g_dist * (-2.0)
+  g_dot_total = g_num + g_raw_dist * (-2.0)
 
   # dx through dot path (both roles of x — as q and as k)
   dx_from_dot_q = jnp.einsum("...hqk,...khd->...qhd", g_dot_total, x_f32, precision=precision)
@@ -464,11 +473,11 @@ def _fused_yat_l1_self_attn_bwd(has_bias, has_eps_grad, scale, precision, res, g
   batch_dims = x.ndim - 3
   q_perm_back = tuple(range(batch_dims)) + (batch_dims + 1, batch_dims)
 
-  g_q_sq = jnp.sum(g_dist, axis=-1)                     # [..., H, S]
+  g_q_sq = jnp.sum(g_raw_dist, axis=-1)                 # [..., H, S]
   g_q_sq_t = g_q_sq.transpose(q_perm_back)[..., None]   # [..., S, H, 1]
   dx = dx + 2.0 * x_f32 * g_q_sq_t
 
-  g_k_sq = jnp.sum(g_dist, axis=-2)                     # [..., H, S]
+  g_k_sq = jnp.sum(g_raw_dist, axis=-2)                 # [..., H, S]
   g_k_sq_t = g_k_sq.transpose(q_perm_back)[..., None]
   dx = dx + 2.0 * x_f32 * g_k_sq_t
 

--- a/src/nmn/nnx/layers/attention/maclaurin_yat.py
+++ b/src/nmn/nnx/layers/attention/maclaurin_yat.py
@@ -218,6 +218,7 @@ def _linear_readout(
     causal: bool,
     epsilon: float,
     precision: PrecisionLike,
+    mask: Array | None = None,
 ) -> Array:
     """Feature-map-agnostic linear-attention readout.
 
@@ -231,6 +232,29 @@ def _linear_readout(
     NOTE: the features are sign-indefinite, so a small epsilon is added only to
     the **denominator** (never to the features) for division stability.
     """
+    if mask is not None:
+        mask = jnp.asarray(mask, dtype=jnp.bool_)
+        if mask.ndim < 3 or mask.shape[-2] != 1:
+            raise ValueError(
+                "Linear YAT attention only supports key-padding masks with "
+                "shape [..., heads, 1, kv_length]; use causal=True for causal masks."
+            )
+        if mask.shape[-1] not in (1, k_feat.shape[-3]):
+            raise ValueError(
+                f"Mask key length {mask.shape[-1]} is incompatible with "
+                f"kv_length {k_feat.shape[-3]}."
+            )
+        # [..., H, 1, K] -> [..., K, H, 1], broadcast over feature dim.
+        key_mask = jnp.swapaxes(jnp.squeeze(mask, axis=-2), -1, -2)[..., None]
+        try:
+            key_mask = jnp.broadcast_to(key_mask, k_feat.shape[:-1] + (1,))
+        except ValueError as exc:
+            raise ValueError(
+                f"Mask shape {mask.shape} is not broadcastable to key shape "
+                f"{k_feat.shape}."
+            ) from exc
+        k_feat = jnp.where(key_mask, k_feat, 0.0)
+
     if causal:
         kv = jnp.einsum("...khm,...khd->...khmd", k_feat, value, precision=precision)
         kv_cum = jnp.cumsum(kv, axis=-4)
@@ -262,6 +286,7 @@ def maclaurin_yat_attention(
     epsilon: float = 1e-6,
     precision: PrecisionLike = None,
     gradient_scaling: bool = True,
+    mask: Array | None = None,
 ) -> Array:
     """Compute spherical Yat attention using MAY (Random Maclaurin) features.
 
@@ -279,6 +304,9 @@ def maclaurin_yat_attention(
         epsilon: Denominator stability constant (added to the denominator only).
         precision: JAX precision.
         gradient_scaling: Unused, kept for API compatibility with SLAY.
+        mask: Optional key-padding mask of shape
+            ``[..., heads, 1, kv_length]``. General query-dependent masks are
+            rejected because they cannot be represented by linear reordering.
 
     Returns:
         Output ``[..., q_length, num_heads, v_dim]``.
@@ -288,4 +316,4 @@ def maclaurin_yat_attention(
     q_feat = maclaurin_features(query, params, normalize=True)
     k_feat = maclaurin_features(key, params, normalize=True)
 
-    return _linear_readout(q_feat, k_feat, value, causal, epsilon, precision)
+    return _linear_readout(q_feat, k_feat, value, causal, epsilon, precision, mask)

--- a/src/nmn/nnx/layers/attention/maclaurin_yat.py
+++ b/src/nmn/nnx/layers/attention/maclaurin_yat.py
@@ -211,6 +211,32 @@ def maclaurin_features(
     return scale * feat
 
 
+def _validate_linear_attention_mask(
+    mask: Array | None,
+    expected_shape: tuple[int, ...],
+) -> None:
+    """Validate a factorable key-padding mask without evaluating its values."""
+    if mask is None:
+        return
+    if mask.ndim < 3 or mask.shape[-2] != 1:
+        raise ValueError(
+            "Linear YAT attention only supports key-padding masks with "
+            "shape [..., heads, 1, kv_length]; use causal=True for causal masks."
+        )
+    try:
+        broadcast_shape = jnp.broadcast_shapes(tuple(mask.shape), expected_shape)
+    except ValueError as exc:
+        raise ValueError(
+            f"Mask shape {mask.shape} is not broadcastable to "
+            f"{expected_shape}."
+        ) from exc
+    if broadcast_shape != expected_shape:
+        raise ValueError(
+            f"Mask shape {mask.shape} would expand linear attention shape "
+            f"{expected_shape} to {broadcast_shape}."
+        )
+
+
 def _linear_readout(
     q_feat: Array,
     k_feat: Array,
@@ -234,25 +260,15 @@ def _linear_readout(
     """
     if mask is not None:
         mask = jnp.asarray(mask, dtype=jnp.bool_)
-        if mask.ndim < 3 or mask.shape[-2] != 1:
-            raise ValueError(
-                "Linear YAT attention only supports key-padding masks with "
-                "shape [..., heads, 1, kv_length]; use causal=True for causal masks."
-            )
-        if mask.shape[-1] not in (1, k_feat.shape[-3]):
-            raise ValueError(
-                f"Mask key length {mask.shape[-1]} is incompatible with "
-                f"kv_length {k_feat.shape[-3]}."
-            )
+        expected_mask_shape = k_feat.shape[:-3] + (
+            k_feat.shape[-2],
+            1,
+            k_feat.shape[-3],
+        )
+        _validate_linear_attention_mask(mask, expected_mask_shape)
         # [..., H, 1, K] -> [..., K, H, 1], broadcast over feature dim.
         key_mask = jnp.swapaxes(jnp.squeeze(mask, axis=-2), -1, -2)[..., None]
-        try:
-            key_mask = jnp.broadcast_to(key_mask, k_feat.shape[:-1] + (1,))
-        except ValueError as exc:
-            raise ValueError(
-                f"Mask shape {mask.shape} is not broadcastable to key shape "
-                f"{k_feat.shape}."
-            ) from exc
+        key_mask = jnp.broadcast_to(key_mask, k_feat.shape[:-1] + (1,))
         k_feat = jnp.where(key_mask, k_feat, 0.0)
 
     if causal:

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -27,7 +27,6 @@ from flax.nnx import rnglib
 from flax.nnx.module import Module, first_from
 from flax.nnx.nn import initializers
 from flax.nnx.nn.linear import LinearGeneral, default_kernel_init
-from flax.nnx.nn.normalization import LayerNorm
 from flax.typing import (
     Dtype,
     Shape,
@@ -37,7 +36,7 @@ from flax.typing import (
 )
 from jax import Array
 
-from .yat_attention import yat_attention
+from .yat_attention import normalize_qk as l2_normalize_qk, yat_attention
 from .masks import combine_masks
 
 # Default constant alpha value (sqrt(2)), same as NMN
@@ -65,7 +64,7 @@ class MultiHeadAttention(Module):
         num_heads: Number of attention heads.
         in_features: Input feature dimension.
         qkv_features: Dimension of Q, K, V projections.
-        out_features: Output dimension (same as qkv_features by default).
+        out_features: Output dimension (same as in_features by default).
         head_dim: Dimension per head (qkv_features // num_heads).
         epsilon: Numerical stability constant for YAT attention.
         use_softermax: Whether to use softermax instead of softmax.
@@ -160,7 +159,7 @@ class MultiHeadAttention(Module):
             use_bias: Whether to use bias in projections.
             attention_fn: Attention function to use (default: yat_attention).
             decode: Whether to use autoregressive decoding mode.
-            normalize_qk: Whether to apply layer norm to Q and K.
+            normalize_qk: Whether to L2-normalize Q and K per head.
             use_alpha: Whether to use alpha scaling for YAT attention. Ignored if
                 constant_alpha is set.
             constant_alpha: If True, use sqrt(2) as constant alpha. If a float,
@@ -195,7 +194,10 @@ class MultiHeadAttention(Module):
         self.out_bias_init = out_bias_init
         self.use_bias = use_bias
         self.attention_fn = attention_fn
-        self.decode = decode
+        # Ordinary calls are non-decoding unless explicitly requested.  This
+        # keeps ``decode`` optional as documented while preserving the call-time
+        # override used by autoregressive clients.
+        self.decode = False if decode is None else decode
         self.normalize_qk = normalize_qk
         self.qkv_dot_general = qkv_dot_general
         self.out_dot_general = out_dot_general
@@ -273,32 +275,31 @@ class MultiHeadAttention(Module):
         self.key = linear(rngs=rngs)
         self.value = linear(rngs=rngs)
 
-        # Optional QK normalization (ViT-22B style)
-        self.query_ln: LayerNorm | None
-        self.key_ln: LayerNorm | None
-        if self.normalize_qk:
-            self.query_ln = LayerNorm(
-                self.head_dim,
-                use_bias=False,
-                dtype=self.dtype,
-                param_dtype=self.param_dtype,
-                rngs=rngs,
-            )
-            self.key_ln = LayerNorm(
-                self.head_dim,
-                use_bias=False,
-                dtype=self.dtype,
-                param_dtype=self.param_dtype,
-                rngs=rngs,
-            )
-        else:
-            self.query_ln = None
-            self.key_ln = None
+        # Project the headed attention result back to the requested output
+        # dimension.  Keeping the head axes intact matches Flax's
+        # MultiHeadAttention parameter layout and avoids an unnecessary reshape.
+        self.out = LinearGeneral(
+            in_features=(self.num_heads, self.head_dim),
+            out_features=self.out_features,
+            axis=(-2, -1),
+            dtype=self.dtype,
+            param_dtype=self.param_dtype,
+            kernel_init=self.out_kernel_init or self.kernel_init,
+            bias_init=self.out_bias_init or self.bias_init,
+            use_bias=self.use_bias,
+            precision=self.precision,
+            rngs=rngs,
+        )
+
+        # normalize_qk has the same per-head L2 semantics as the other NMN
+        # backends.  Retain data placeholders for stable NNX graph structure.
+        self.query_ln = nnx.data(None)
+        self.key_ln = nnx.data(None)
 
         # Autoregressive decoding cache
-        self.cached_key: nnx.Cache[Array] | None = None
-        self.cached_value: nnx.Cache[Array] | None = None
-        self.cache_index: nnx.Cache[Array] | None = None
+        self.cached_key: nnx.Cache[Array] | None = nnx.data(None)
+        self.cached_value: nnx.Cache[Array] | None = nnx.data(None)
+        self.cache_index: nnx.Cache[Array] | None = nnx.data(None)
 
     def __call__(
         self,
@@ -331,7 +332,7 @@ class MultiHeadAttention(Module):
             decode: If True, use autoregressive decoding mode.
 
         Returns:
-            Output of shape [batch..., length, qkv_features].
+            Output of shape [batch..., length, out_features].
         """
         # Handle self-attention and cross-attention
         if inputs_k is None:
@@ -378,9 +379,7 @@ class MultiHeadAttention(Module):
 
         # Optional QK normalization (stabilizes training with higher LR)
         if self.normalize_qk:
-            assert self.query_ln is not None and self.key_ln is not None
-            query = self.query_ln(query)
-            key = self.key_ln(key)
+            query, key = l2_normalize_qk(query, key, self.epsilon)
 
         # Handle autoregressive decoding
         decode = first_from(
@@ -408,23 +407,31 @@ class MultiHeadAttention(Module):
                 depth_per_head,
             ) = self.cached_key[...].shape
 
-            # Validate query shape
+            # Validate the key/value slice that is written to the cache.  Query
+            # feature dimensions need not govern a cross-attention cache.
             expected_shape = tuple(batch_dims) + (1, num_heads, depth_per_head)
-            if expected_shape != query.shape:
+            if expected_shape != key.shape:
                 raise ValueError(
                     f"Autoregressive cache shape error, "
-                    f"expected query shape {expected_shape} instead got {query.shape}."
+                    f"expected key shape {expected_shape} instead got {key.shape}."
                 )
 
             # Update cache
             cur_index = self.cache_index[...]
+            if (
+                not isinstance(cur_index, jax.core.Tracer)
+                and int(cur_index) >= max_length
+            ):
+                raise ValueError(
+                    f"Autoregressive cache is full at length {max_length}."
+                )
             zero = jnp.array(0, dtype=lax.dtype(cur_index.dtype))
             indices = (zero,) * len(batch_dims) + (cur_index, zero, zero)
             key = lax.dynamic_update_slice(self.cached_key[...], key, indices)
             value = lax.dynamic_update_slice(self.cached_value[...], value, indices)
-            self.cached_key.value = key
-            self.cached_value.value = value
-            self.cache_index.value += 1
+            self.cached_key[...] = key
+            self.cached_value[...] = value
+            self.cache_index[...] += 1
 
             # Causal mask for cached decoding
             mask = combine_masks(
@@ -482,9 +489,7 @@ class MultiHeadAttention(Module):
         if self._constant_alpha_value is not None:
             x = x * self._constant_alpha_value
 
-        # Reshape back: [batch..., length, num_heads, head_dim] -> [batch..., length, qkv_features]
-        x = x.reshape(x.shape[:-2] + (self.qkv_features,))
-        return x
+        return self.out(x)
 
     def init_cache(self, input_shape: Shape, dtype: Dtype = jnp.float32):
         """Initializes the cache for autoregressive decoding.
@@ -497,6 +502,3 @@ class MultiHeadAttention(Module):
         self.cached_key = nnx.Cache(jnp.zeros(cache_shape, dtype))
         self.cached_value = nnx.Cache(jnp.zeros(cache_shape, dtype))
         self.cache_index = nnx.Cache(jnp.array(0, dtype=jnp.int32))
-
-
-

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -36,11 +36,53 @@ from flax.typing import (
 )
 from jax import Array
 
-from .yat_attention import normalize_qk as l2_normalize_qk, yat_attention
+from .yat_attention import yat_attention
 from .masks import combine_masks
 
 # Default constant alpha value (sqrt(2)), same as NMN
 DEFAULT_CONSTANT_ALPHA = jnp.sqrt(2.0)
+_L2_NORMALIZE_EPSILON = 1e-12
+
+
+def _l2_normalize_per_head(x: Array) -> Array:
+    """Match ``torch.nn.functional.normalize(..., p=2, eps=1e-12)``."""
+    norm = jnp.linalg.norm(x, axis=-1, keepdims=True)
+    epsilon = jnp.asarray(_L2_NORMALIZE_EPSILON, dtype=norm.dtype)
+    return x / jnp.maximum(norm, epsilon)
+
+
+def _raise_cache_overflow(index: Array, max_length: int) -> None:
+    if int(index) >= max_length:
+        raise ValueError(f"Autoregressive cache is full at length {max_length}.")
+
+
+def _check_cache_capacity(index: Array, max_length: int) -> None:
+    """Fail before a cache write in eager mode and under ``nnx.jit``."""
+    if isinstance(index, jax.core.Tracer):
+        jax.debug.callback(
+            functools.partial(_raise_cache_overflow, max_length=max_length),
+            index,
+            ordered=True,
+        )
+    else:
+        _raise_cache_overflow(index, max_length)
+
+
+def _validate_decode_mask(mask: Array | None, expected_shape: tuple[int, ...]) -> None:
+    if mask is None:
+        return
+    try:
+        broadcast_shape = jnp.broadcast_shapes(tuple(mask.shape), expected_shape)
+    except ValueError as exc:
+        raise ValueError(
+            f"Decode mask shape {mask.shape} is not broadcastable to "
+            f"{expected_shape}."
+        ) from exc
+    if broadcast_shape != expected_shape:
+        raise ValueError(
+            f"Decode mask shape {mask.shape} would expand attention shape "
+            f"{expected_shape} to {broadcast_shape}."
+        )
 
 
 class MultiHeadAttention(Module):
@@ -379,7 +421,8 @@ class MultiHeadAttention(Module):
 
         # Optional QK normalization (stabilizes training with higher LR)
         if self.normalize_qk:
-            query, key = l2_normalize_qk(query, key, self.epsilon)
+            query = _l2_normalize_per_head(query)
+            key = _l2_normalize_per_head(key)
 
         # Handle autoregressive decoding
         decode = first_from(
@@ -407,40 +450,46 @@ class MultiHeadAttention(Module):
                 depth_per_head,
             ) = self.cached_key[...].shape
 
-            # Validate the key/value slice that is written to the cache.  Query
-            # feature dimensions need not govern a cross-attention cache.
             expected_shape = tuple(batch_dims) + (1, num_heads, depth_per_head)
-            if expected_shape != key.shape:
-                raise ValueError(
-                    f"Autoregressive cache shape error, "
-                    f"expected key shape {expected_shape} instead got {key.shape}."
-                )
-
-            # Update cache
-            cur_index = self.cache_index[...]
-            if (
-                not isinstance(cur_index, jax.core.Tracer)
-                and int(cur_index) >= max_length
+            for name, tensor in (
+                ("query", query),
+                ("key", key),
+                ("value", value),
             ):
-                raise ValueError(
-                    f"Autoregressive cache is full at length {max_length}."
-                )
+                if expected_shape != tensor.shape:
+                    raise ValueError(
+                        f"Autoregressive cache shape error, expected {name} shape "
+                        f"{expected_shape} instead got {tensor.shape}."
+                    )
+
+            decode_mask_shape = tuple(batch_dims) + (
+                self.num_heads,
+                1,
+                max_length,
+            )
+            _validate_decode_mask(mask, decode_mask_shape)
+
+            # Build the next cache state locally.  It is committed only after
+            # attention and output projection complete successfully.
+            cur_index = self.cache_index[...]
+            _check_cache_capacity(cur_index, max_length)
             zero = jnp.array(0, dtype=lax.dtype(cur_index.dtype))
             indices = (zero,) * len(batch_dims) + (cur_index, zero, zero)
-            key = lax.dynamic_update_slice(self.cached_key[...], key, indices)
-            value = lax.dynamic_update_slice(self.cached_value[...], value, indices)
-            self.cached_key[...] = key
-            self.cached_value[...] = value
-            self.cache_index[...] += 1
-
-            # Causal mask for cached decoding
-            mask = combine_masks(
-                mask,
-                jnp.broadcast_to(
-                    jnp.arange(max_length) <= cur_index,
-                    tuple(batch_dims) + (1, 1, max_length),
-                ),
+            next_key = lax.dynamic_update_slice(self.cached_key[...], key, indices)
+            next_value = lax.dynamic_update_slice(
+                self.cached_value[...], value, indices
             )
+            key = next_key
+            value = next_value
+
+            causal_mask = jnp.broadcast_to(
+                jnp.arange(max_length) <= cur_index,
+                tuple(batch_dims) + (1, 1, max_length),
+            )
+            mask = combine_masks(mask, causal_mask)
+            pending_cache = (next_key, next_value, cur_index + 1)
+        else:
+            pending_cache = None
 
         # Get dropout RNG if needed
         dropout_rng = None
@@ -489,7 +538,18 @@ class MultiHeadAttention(Module):
         if self._constant_alpha_value is not None:
             x = x * self._constant_alpha_value
 
-        return self.out(x)
+        output = self.out(x)
+
+        if pending_cache is not None:
+            assert self.cached_key is not None
+            assert self.cached_value is not None
+            assert self.cache_index is not None
+            next_key, next_value, next_index = pending_cache
+            self.cached_key[...] = next_key
+            self.cached_value[...] = next_value
+            self.cache_index[...] = next_index
+
+        return output
 
     def init_cache(self, input_shape: Shape, dtype: Dtype = jnp.float32):
         """Initializes the cache for autoregressive decoding.

--- a/src/nmn/nnx/layers/attention/radial_yat.py
+++ b/src/nmn/nnx/layers/attention/radial_yat.py
@@ -192,6 +192,7 @@ def radial_yat_attention(
     epsilon: float = 1e-6,
     precision: PrecisionLike = None,
     gradient_scaling: bool = True,
+    mask: Array | None = None,
 ) -> Array:
     """Compute spherical Yat attention using RAY (radial) features.
 
@@ -204,6 +205,9 @@ def radial_yat_attention(
         epsilon: Denominator stability constant (added to the denominator only).
         precision: JAX precision.
         gradient_scaling: Unused, kept for API compatibility with SLAY.
+        mask: Optional key-padding mask of shape
+            ``[..., heads, 1, kv_length]``. General query-dependent masks are
+            rejected because they cannot be represented by linear reordering.
 
     Returns:
         Output ``[..., q_length, num_heads, v_dim]``.
@@ -213,4 +217,4 @@ def radial_yat_attention(
     q_feat = radial_features(query, params, normalize=True)
     k_feat = radial_features(key, params, normalize=True)
 
-    return _linear_readout(q_feat, k_feat, value, causal, epsilon, precision)
+    return _linear_readout(q_feat, k_feat, value, causal, epsilon, precision, mask)

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -110,7 +110,7 @@ def apply_rotary_emb(
     x: Array,
     freqs_cos: Array,
     freqs_sin: Array,
-    position_offset: int = 0,
+    position_offset: int | Array = 0,
 ) -> Array:
     """Applies Rotary Position Embeddings to input tensor.
 
@@ -138,7 +138,10 @@ def apply_rotary_emb(
 
     # Bounds check: precomputed tables have a fixed length.
     max_seq_len = freqs_cos.shape[0]
-    if position_offset + seq_len > max_seq_len:
+    if (
+        not isinstance(position_offset, jax.core.Tracer)
+        and int(position_offset) + seq_len > max_seq_len
+    ):
         raise ValueError(
             f"Rotary frequencies were precomputed for max_seq_len={max_seq_len}, "
             f"but position_offset + seq_len = {position_offset + seq_len} exceeds it. "
@@ -148,8 +151,14 @@ def apply_rotary_emb(
 
     # Slice frequencies for the current sequence
     # freqs shape: [seq_len, head_dim//2]
-    freqs_cos = freqs_cos[position_offset : position_offset + seq_len]
-    freqs_sin = freqs_sin[position_offset : position_offset + seq_len]
+    # dynamic_slice_in_dim accepts a traced cache index, so incremental decode
+    # remains compatible with nnx.jit.
+    freqs_cos = jax.lax.dynamic_slice_in_dim(
+        freqs_cos, position_offset, seq_len, axis=0
+    )
+    freqs_sin = jax.lax.dynamic_slice_in_dim(
+        freqs_sin, position_offset, seq_len, axis=0
+    )
 
     # Split x into even and odd components
     # x shape: [..., seq_len, num_heads, head_dim]
@@ -192,6 +201,7 @@ def rotary_yat_attention_weights(
     position_offset: int = 0,
     alpha: Optional[Array] = None,
     normalization: str = "softmax",
+    key_position_offset: int | Array | None = None,
 ) -> Array:
     """Computes Rotary YAT attention weights.
 
@@ -206,6 +216,8 @@ def rotary_yat_attention_weights(
         mask: Optional attention mask.
         epsilon: Numerical stability constant.
         position_offset: Starting position for RoPE.
+        key_position_offset: Optional independent starting position for keys;
+            used when a one-token decoded query attends over a full key cache.
         alpha: Optional alpha scaling parameter.
         normalization: ``"softmax"`` (default), ``"l1"``, or ``"softermax"``.
 
@@ -213,8 +225,10 @@ def rotary_yat_attention_weights(
         Attention weights of shape [..., num_heads, q_length, kv_length].
     """
     # Apply RoPE to query and key
+    if key_position_offset is None:
+        key_position_offset = position_offset
     query_rotated = apply_rotary_emb(query, freqs_cos, freqs_sin, position_offset)
-    key_rotated = apply_rotary_emb(key, freqs_cos, freqs_sin, position_offset)
+    key_rotated = apply_rotary_emb(key, freqs_cos, freqs_sin, key_position_offset)
 
     # Compute YAT attention weights on rotated Q, K
     return yat_attention_weights(
@@ -258,6 +272,7 @@ def rotary_yat_attention(
     position_offset: int = 0,
     alpha: Optional[Array] = None,
     normalization: str = "softmax",
+    key_position_offset: int | Array | None = None,
 ) -> Array:
     """Computes Rotary YAT attention: RoPE + YAT formula + V weighted sum.
 
@@ -266,6 +281,7 @@ def rotary_yat_attention(
         freqs_cos, freqs_sin: RoPE frequencies.
         epsilon: Numerical stability constant.
         position_offset: Starting position for RoPE.
+        key_position_offset: Optional independent starting position for keys.
         alpha: Optional alpha scaling parameter.
         normalization: ``"softmax"`` (default), ``"l1"``, or ``"softermax"``.
 
@@ -296,6 +312,7 @@ def rotary_yat_attention(
         position_offset=position_offset,
         alpha=alpha,
         normalization=normalization,
+        key_position_offset=key_position_offset,
     )
 
     # Return weighted sum over values
@@ -326,6 +343,7 @@ def rotary_yat_performer_attention(
     normalize_inputs: bool = True,
     alpha: Optional[Array] = None,
     gradient_scaling: bool = True,
+    key_position_offset: int | Array | None = None,
 ) -> Array:
     """Computes Rotary YAT Performer attention using Multi-Scale TP-PRF.
 
@@ -338,8 +356,10 @@ def rotary_yat_performer_attention(
     dtype = query.dtype
 
     # Apply RoPE first
+    if key_position_offset is None:
+        key_position_offset = position_offset
     query_rotated = apply_rotary_emb(query, freqs_cos, freqs_sin, position_offset)
-    key_rotated = apply_rotary_emb(key, freqs_cos, freqs_sin, position_offset)
+    key_rotated = apply_rotary_emb(key, freqs_cos, freqs_sin, key_position_offset)
 
     # Normalize to unit vectors (required for YAT approximation)
     if normalize_inputs:
@@ -355,6 +375,7 @@ def rotary_yat_performer_attention(
         epsilon=epsilon,
         precision=precision,
         gradient_scaling=gradient_scaling,
+        mask=mask,
     )
 
     # Apply alpha scaling
@@ -684,9 +705,9 @@ class RotaryYatAttention(Module):
             self.key_ln = None
 
         # Cache for autoregressive decoding
-        self.cached_key: nnx.Cache[Array] | None = None
-        self.cached_value: nnx.Cache[Array] | None = None
-        self.cache_index: nnx.Cache[Array] | None = None
+        self.cached_key: nnx.Cache[Array] | None = nnx.data(None)
+        self.cached_value: nnx.Cache[Array] | None = nnx.data(None)
+        self.cache_index: nnx.Cache[Array] | None = nnx.data(None)
 
     def __call__(
         self,
@@ -715,6 +736,12 @@ class RotaryYatAttention(Module):
         """
         batch_size, seq_len, _ = x.shape
 
+        if decode and self.use_performer:
+            raise ValueError(
+                "Incremental decode is not supported in Performer mode; "
+                "use quadratic attention for cached decoding."
+            )
+
         # Project to Q, K, V
         q = self.q_proj(x)
         k = self.k_proj(x)
@@ -733,12 +760,36 @@ class RotaryYatAttention(Module):
 
         # Handle autoregressive decoding
         if decode:
-            if self.cached_key is None or self.cached_value is None:
+            if (
+                self.cached_key is None
+                or self.cached_value is None
+                or self.cache_index is None
+            ):
                 raise ValueError(
                     "Cache not initialized. Call init_cache first."
                 )
 
             cur_index = self.cache_index[...]
+            if seq_len != 1:
+                raise ValueError(
+                    f"Autoregressive decode expects one token, got seq_len={seq_len}."
+                )
+            expected_shape = (
+                self.cached_key.shape[0], 1, self.num_heads, self.head_dim
+            )
+            if k.shape != expected_shape:
+                raise ValueError(
+                    f"Autoregressive cache shape error, expected key shape "
+                    f"{expected_shape} instead got {k.shape}."
+                )
+            if (
+                not isinstance(cur_index, jax.core.Tracer)
+                and int(cur_index) >= self.cached_key.shape[1]
+            ):
+                raise ValueError(
+                    f"Autoregressive cache is full at length "
+                    f"{self.cached_key.shape[1]}."
+                )
             # Update cache
             indices = (0, cur_index, 0, 0)
             k_cached = jax.lax.dynamic_update_slice(
@@ -747,9 +798,9 @@ class RotaryYatAttention(Module):
             v_cached = jax.lax.dynamic_update_slice(
                 self.cached_value[...], v, indices
             )
-            self.cached_key.value = k_cached
-            self.cached_value.value = v_cached
-            self.cache_index.value += 1
+            self.cached_key[...] = k_cached
+            self.cached_value[...] = v_cached
+            self.cache_index[...] += 1
 
             k = k_cached
             v = v_cached
@@ -763,7 +814,12 @@ class RotaryYatAttention(Module):
                     (batch_size, 1, 1, max_length),
                 ),
             )
-            position_offset = 0  # Use full cache positions
+            # The one-token query is at the current decode position, while the
+            # complete cached key sequence occupies positions starting at zero.
+            position_offset = cur_index
+            key_position_offset = 0
+        else:
+            key_position_offset = position_offset
 
         # Get RoPE frequencies
         freqs_cos = jax.device_put(self.freqs_cos[...])
@@ -828,12 +884,13 @@ class RotaryYatAttention(Module):
                 causal=self.causal,
                 normalize_inputs=self.performer_normalize,
                 alpha=alpha_value,
+                key_position_offset=key_position_offset,
             )
         elif self.use_performer:
             # MAY / RAY performer: bias-aware Random Maclaurin / radial features.
             # Apply RoPE then dispatch to the matching linear-attention readout.
             q_rot = apply_rotary_emb(q, freqs_cos, freqs_sin, position_offset)
-            k_rot = apply_rotary_emb(k, freqs_cos, freqs_sin, position_offset)
+            k_rot = apply_rotary_emb(k, freqs_cos, freqs_sin, key_position_offset)
 
             # Rebuild the param dict from the generic cache + meta store.
             performer_params = {
@@ -846,12 +903,14 @@ class RotaryYatAttention(Module):
                     q_rot, k_rot, v, performer_params,
                     causal=self.causal,
                     precision=self.precision,
+                    mask=mask,
                 )
             else:  # radial
                 output = radial_yat_attention(
                     q_rot, k_rot, v, performer_params,
                     causal=self.causal,
                     precision=self.precision,
+                    mask=mask,
                 )
 
             # Apply learnable alpha scaling (matches the SLAY path behavior).
@@ -884,6 +943,7 @@ class RotaryYatAttention(Module):
                 position_offset=position_offset,
                 alpha=alpha_value,
                 normalization=self.normalization,
+                key_position_offset=key_position_offset,
             )
 
         # Apply constant alpha as direct scale (e.g. sqrt(2))
@@ -911,4 +971,3 @@ class RotaryYatAttention(Module):
         self.cached_key = nnx.Cache(jnp.zeros(cache_shape, dtype))
         self.cached_value = nnx.Cache(jnp.zeros(cache_shape, dtype))
         self.cache_index = nnx.Cache(jnp.array(0, dtype=jnp.int32))
-

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -57,6 +57,7 @@ from .spherical_yat_performer import (
     create_yat_tp_projection,
 )
 from .maclaurin_yat import (
+    _validate_linear_attention_mask,
     create_maclaurin_projection,
     maclaurin_yat_attention,
 )
@@ -64,7 +65,11 @@ from .radial_yat import (
     create_radial_projection,
     radial_yat_attention,
 )
-from .multi_head import DEFAULT_CONSTANT_ALPHA
+from .multi_head import (
+    DEFAULT_CONSTANT_ALPHA,
+    _check_cache_capacity,
+    _validate_decode_mask,
+)
 from .masks import combine_masks
 from nmn.nnx.layers.squashers import softermax
 
@@ -741,6 +746,11 @@ class RotaryYatAttention(Module):
                 "Incremental decode is not supported in Performer mode; "
                 "use quadratic attention for cached decoding."
             )
+        if self.use_performer:
+            _validate_linear_attention_mask(
+                mask,
+                (batch_size, self.num_heads, 1, seq_len),
+            )
 
         # Project to Q, K, V
         q = self.q_proj(x)
@@ -769,7 +779,6 @@ class RotaryYatAttention(Module):
                     "Cache not initialized. Call init_cache first."
                 )
 
-            cur_index = self.cache_index[...]
             if seq_len != 1:
                 raise ValueError(
                     f"Autoregressive decode expects one token, got seq_len={seq_len}."
@@ -777,20 +786,23 @@ class RotaryYatAttention(Module):
             expected_shape = (
                 self.cached_key.shape[0], 1, self.num_heads, self.head_dim
             )
-            if k.shape != expected_shape:
-                raise ValueError(
-                    f"Autoregressive cache shape error, expected key shape "
-                    f"{expected_shape} instead got {k.shape}."
-                )
-            if (
-                not isinstance(cur_index, jax.core.Tracer)
-                and int(cur_index) >= self.cached_key.shape[1]
-            ):
-                raise ValueError(
-                    f"Autoregressive cache is full at length "
-                    f"{self.cached_key.shape[1]}."
-                )
-            # Update cache
+            for name, tensor in (("query", q), ("key", k), ("value", v)):
+                if tensor.shape != expected_shape:
+                    raise ValueError(
+                        f"Autoregressive cache shape error, expected {name} "
+                        f"shape {expected_shape} instead got {tensor.shape}."
+                    )
+
+            max_length = self.cached_key.shape[1]
+            _validate_decode_mask(
+                mask,
+                (batch_size, self.num_heads, 1, max_length),
+            )
+
+            # Build the next cache state locally and commit it only after the
+            # complete attention/output computation succeeds.
+            cur_index = self.cache_index[...]
+            _check_cache_capacity(cur_index, max_length)
             indices = (0, cur_index, 0, 0)
             k_cached = jax.lax.dynamic_update_slice(
                 self.cached_key[...], k, indices
@@ -798,15 +810,10 @@ class RotaryYatAttention(Module):
             v_cached = jax.lax.dynamic_update_slice(
                 self.cached_value[...], v, indices
             )
-            self.cached_key[...] = k_cached
-            self.cached_value[...] = v_cached
-            self.cache_index[...] += 1
-
             k = k_cached
             v = v_cached
 
             # Causal mask for decoding
-            max_length = k.shape[1]
             mask = combine_masks(
                 mask,
                 jnp.broadcast_to(
@@ -818,8 +825,10 @@ class RotaryYatAttention(Module):
             # complete cached key sequence occupies positions starting at zero.
             position_offset = cur_index
             key_position_offset = 0
+            pending_cache = (k_cached, v_cached, cur_index + 1)
         else:
             key_position_offset = position_offset
+            pending_cache = None
 
         # Get RoPE frequencies
         freqs_cos = jax.device_put(self.freqs_cos[...])
@@ -956,6 +965,15 @@ class RotaryYatAttention(Module):
         # Optional output projection
         if self.o_proj is not None:
             output = self.o_proj(output)
+
+        if pending_cache is not None:
+            assert self.cached_key is not None
+            assert self.cached_value is not None
+            assert self.cache_index is not None
+            next_key, next_value, next_index = pending_cache
+            self.cached_key[...] = next_key
+            self.cached_value[...] = next_value
+            self.cache_index[...] = next_index
 
         return output
 

--- a/src/nmn/nnx/layers/attention/spherical_yat_performer.py
+++ b/src/nmn/nnx/layers/attention/spherical_yat_performer.py
@@ -283,6 +283,7 @@ def yat_tp_attention(
     epsilon: float = 1e-5,
     precision: PrecisionLike = None,
     gradient_scaling: bool = True,
+    mask: Array | None = None,
 ) -> Array:
     """Compute YAT attention using anchor-based tensor product features.
 
@@ -303,6 +304,9 @@ def yat_tp_attention(
         epsilon: Numerical stability constant.
         precision: JAX precision.
         gradient_scaling: Unused, kept for API compatibility.
+        mask: Optional key-padding mask of shape
+            ``[..., heads, 1, kv_length]``. Query-dependent masks are not
+            compatible with the linear-attention reordering.
 
     Returns:
         Output [..., q_length, num_heads, v_dim].
@@ -316,6 +320,28 @@ def yat_tp_attention(
     # add epsilon for numerical safety
     q_feat = q_feat + epsilon
     k_feat = k_feat + epsilon
+
+    if mask is not None:
+        mask = jnp.asarray(mask, dtype=jnp.bool_)
+        if mask.ndim < 3 or mask.shape[-2] != 1:
+            raise ValueError(
+                "Linear YAT attention only supports key-padding masks with "
+                "shape [..., heads, 1, kv_length]; use causal=True for causal masks."
+            )
+        if mask.shape[-1] not in (1, k_feat.shape[-3]):
+            raise ValueError(
+                f"Mask key length {mask.shape[-1]} is incompatible with "
+                f"kv_length {k_feat.shape[-3]}."
+            )
+        key_mask = jnp.swapaxes(jnp.squeeze(mask, axis=-2), -1, -2)[..., None]
+        try:
+            key_mask = jnp.broadcast_to(key_mask, k_feat.shape[:-1] + (1,))
+        except ValueError as exc:
+            raise ValueError(
+                f"Mask shape {mask.shape} is not broadcastable to key shape "
+                f"{k_feat.shape}."
+            ) from exc
+        k_feat = jnp.where(key_mask, k_feat, 0.0)
 
     if causal:
         kv = jnp.einsum("...khm,...khd->...khmd", k_feat, value, precision=precision)

--- a/tests/test_nnx/test_attention_regressions.py
+++ b/tests/test_nnx/test_attention_regressions.py
@@ -1,0 +1,306 @@
+"""Regression coverage for NNX attention API, gradients, masks, and decode."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from nmn.nnx.layers.attention import MultiHeadAttention, RotaryYatAttention
+from nmn.nnx.layers.attention.fused_yat_attention import (
+    fused_yat_l1_attention,
+    fused_yat_l1_self_attention,
+)
+from nmn.nnx.layers.attention.yat_attention import normalize_qk
+
+
+def _causal_mask(batch_size: int, length: int) -> jax.Array:
+    return jnp.broadcast_to(
+        jnp.tril(jnp.ones((length, length), dtype=jnp.bool_)),
+        (batch_size, 1, length, length),
+    )
+
+
+def _reference_l1(query, key, value, epsilon=1e-3):
+    dot = jnp.einsum("...qhd,...khd->...hqk", query, key)
+    q_sq = jnp.sum(query**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
+    k_sq = jnp.sum(key**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
+    raw_dist = q_sq + jnp.swapaxes(k_sq, -2, -1) - 2.0 * dot
+    dist = jnp.maximum(raw_dist, 0.0) + epsilon
+    scores = dot**2 / (dist * jnp.sqrt(jnp.float32(query.shape[-1])))
+    weights = scores / (jnp.sum(scores, axis=-1, keepdims=True) + 1e-12)
+    return jnp.einsum("...hqk,...khd->...qhd", weights, value)
+
+
+def _reference_l1_self(x, value, epsilon=1e-3):
+    dot = jnp.einsum("...qhd,...khd->...hqk", x, x)
+    x_sq = jnp.sum(x**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
+    raw_dist = x_sq + jnp.swapaxes(x_sq, -2, -1) - 2.0 * dot
+    dist = jnp.maximum(raw_dist, 0.0) + epsilon
+    scores = dot**2 / (dist * jnp.sqrt(jnp.float32(x.shape[-1])))
+    normalizer = jnp.sum(scores, axis=-1, keepdims=True)
+    scores = jnp.where(jnp.eye(x.shape[-3], dtype=jnp.bool_), 0.0, scores)
+    weights = scores / (normalizer + 1e-12)
+    return jnp.einsum("...hqk,...khd->...qhd", weights, value)
+
+
+@pytest.mark.parametrize("case", ["positive", "zero", "negative"])
+def test_fused_l1_clamp_subgradient_matches_autodiff(case):
+    if case == "positive":
+        query = jnp.array([[[[0.0, 1.0]], [[2.0, -1.0]]]])
+        key = jnp.array([[[[1.0, 0.0]], [[-1.0, 2.0]]]])
+    elif case == "zero":
+        query = jnp.array([[[[1.0, 2.0]], [[-2.0, 1.0]]]])
+        key = query
+    else:
+        # Deterministically contains negative reconstructed self-distances from
+        # fp32 cancellation (seed 1, width 16, scale 10).
+        query = jax.random.normal(jax.random.key(1), (1, 2, 1, 16)) * 10.0
+        key = query
+    value = jax.random.normal(jax.random.key(9), query.shape)
+    dot = jnp.einsum("...qhd,...khd->...hqk", query, key)
+    q_sq = jnp.sum(query**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
+    k_sq = jnp.sum(key**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
+    raw_dist = q_sq + jnp.swapaxes(k_sq, -2, -1) - 2.0 * dot
+    if case == "positive":
+        assert jnp.all(raw_dist > 0.0)
+    elif case == "zero":
+        assert jnp.any(raw_dist == 0.0)
+    else:
+        assert jnp.any(raw_dist < 0.0)
+
+    def fused_loss(q, k, v):
+        return jnp.sum(fused_yat_l1_attention(q, k, v, epsilon=1e-3) ** 2)
+
+    def reference_loss(q, k, v):
+        return jnp.sum(_reference_l1(q, k, v) ** 2)
+
+    actual = jax.grad(fused_loss, argnums=(0, 1, 2))(query, key, value)
+    expected = jax.grad(reference_loss, argnums=(0, 1, 2))(query, key, value)
+    for got, want in zip(actual, expected):
+        assert jnp.allclose(got, want, rtol=2e-5, atol=2e-5)
+
+
+def test_fused_l1_self_negative_clamp_subgradient_matches_autodiff():
+    x = jax.random.normal(jax.random.key(1), (1, 2, 1, 16)) * 10.0
+    value = jax.random.normal(jax.random.key(12), x.shape)
+
+    def fused_loss(x, value):
+        return jnp.sum(fused_yat_l1_self_attention(x, value, epsilon=1e-3) ** 2)
+
+    def reference_loss(x, value):
+        return jnp.sum(_reference_l1_self(x, value) ** 2)
+
+    actual = jax.grad(fused_loss, argnums=(0, 1))(x, value)
+    expected = jax.grad(reference_loss, argnums=(0, 1))(x, value)
+    for got, want in zip(actual, expected):
+        assert jnp.allclose(got, want, rtol=2e-5, atol=2e-5)
+
+
+def test_multi_head_honors_output_projection_initializers_and_default_decode():
+    module = MultiHeadAttention(
+        num_heads=2,
+        in_features=8,
+        qkv_features=4,
+        out_features=3,
+        out_kernel_init=nnx.initializers.zeros_init(),
+        out_bias_init=nnx.initializers.constant(2.5),
+        rngs=nnx.Rngs(0),
+    )
+    output = module(jnp.ones((2, 5, 8)), deterministic=True)
+    assert output.shape == (2, 5, 3)
+    assert jnp.all(output == 2.5)
+
+
+def test_multi_head_normalize_qk_is_parameter_free_per_head_l2():
+    captured = {}
+
+    def capture_attention(query, key, value, **_):
+        captured["query"] = query
+        captured["key"] = key
+        return value
+
+    module = MultiHeadAttention(
+        num_heads=2,
+        in_features=8,
+        normalize_qk=True,
+        attention_fn=capture_attention,
+        decode=False,
+        rngs=nnx.Rngs(0),
+    )
+    x = jax.random.normal(jax.random.key(3), (2, 4, 8))
+    projected_q = module.query(x).reshape(2, 4, 2, 4)
+    projected_k = module.key(x).reshape(2, 4, 2, 4)
+    expected_q, expected_k = normalize_qk(projected_q, projected_k, module.epsilon)
+    module(x, deterministic=True)
+
+    assert module.query_ln is None and module.key_ln is None
+    assert jnp.allclose(captured["query"], expected_q, atol=1e-6)
+    assert jnp.allclose(captured["key"], expected_k, atol=1e-6)
+
+
+def test_multi_head_normalize_qk_matches_torch_with_synchronized_weights():
+    torch = pytest.importorskip("torch")
+    from nmn.torch import MultiHeadYatAttention
+
+    nnx_module = MultiHeadAttention(
+        num_heads=2,
+        in_features=8,
+        normalize_qk=True,
+        use_alpha=False,
+        decode=False,
+        rngs=nnx.Rngs(0),
+    )
+    torch_module = MultiHeadYatAttention(
+        embed_dim=8,
+        num_heads=2,
+        normalize_qk=True,
+        use_alpha=False,
+    )
+    generator = np.random.default_rng(0)
+
+    with torch.no_grad():
+        for nnx_layer, torch_layer in (
+            (nnx_module.query, torch_module.q_proj),
+            (nnx_module.key, torch_module.k_proj),
+            (nnx_module.value, torch_module.v_proj),
+        ):
+            kernel = generator.normal(size=(8, 8)).astype(np.float32) * 0.1
+            bias = generator.normal(size=(8,)).astype(np.float32) * 0.1
+            nnx_layer.kernel[...] = jnp.asarray(kernel)
+            nnx_layer.bias[...] = jnp.asarray(bias)
+            torch_layer.weight.copy_(torch.from_numpy(kernel.T))
+            torch_layer.bias.copy_(torch.from_numpy(bias))
+
+        out_kernel = generator.normal(size=(8, 8)).astype(np.float32) * 0.1
+        out_bias = generator.normal(size=(8,)).astype(np.float32) * 0.1
+        nnx_module.out.kernel[...] = jnp.asarray(out_kernel.reshape(2, 4, 8))
+        nnx_module.out.bias[...] = jnp.asarray(out_bias)
+        torch_module.out_proj.weight.copy_(torch.from_numpy(out_kernel.T))
+        torch_module.out_proj.bias.copy_(torch.from_numpy(out_bias))
+
+    inputs = generator.normal(size=(2, 5, 8)).astype(np.float32)
+    nnx_output = np.asarray(nnx_module(jnp.asarray(inputs), deterministic=True))
+    torch_output = (
+        torch_module(torch.from_numpy(inputs), deterministic=True).detach().numpy()
+    )
+    assert np.allclose(nnx_output, torch_output, rtol=2e-5, atol=3e-6)
+
+
+@pytest.mark.parametrize("batch_size", [1, 3])
+def test_multi_head_full_causal_matches_incremental_decode(batch_size):
+    length, features = 5, 8
+    module = MultiHeadAttention(
+        num_heads=2,
+        in_features=features,
+        decode=False,
+        use_alpha=False,
+        rngs=nnx.Rngs(10),
+    )
+    x = jax.random.normal(jax.random.key(11), (batch_size, length, features))
+    full = module(x, mask=_causal_mask(batch_size, length), deterministic=True)
+
+    module.init_cache(x.shape)
+    incremental = jnp.concatenate(
+        [
+            module(x[:, i : i + 1], decode=True, deterministic=True)
+            for i in range(length)
+        ],
+        axis=1,
+    )
+    assert jnp.allclose(incremental, full, rtol=2e-5, atol=2e-5)
+    with pytest.raises(ValueError, match="cache is full"):
+        module(x[:, :1], decode=True, deterministic=True)
+
+
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_rotary_full_causal_matches_incremental_decode(batch_size):
+    length, features = 5, 8
+    module = RotaryYatAttention(
+        embed_dim=features,
+        num_heads=2,
+        max_seq_len=length,
+        use_alpha=False,
+        rngs=nnx.Rngs(20),
+    )
+    x = jax.random.normal(jax.random.key(21), (batch_size, length, features))
+    full = module(x, mask=_causal_mask(batch_size, length), deterministic=True)
+
+    module.init_cache(batch_size, length)
+    incremental = jnp.concatenate(
+        [
+            module(x[:, i : i + 1], decode=True, deterministic=True)
+            for i in range(length)
+        ],
+        axis=1,
+    )
+    assert jnp.allclose(incremental, full, rtol=3e-5, atol=3e-5)
+    with pytest.raises(ValueError, match="cache is full"):
+        module(x[:, :1], decode=True, deterministic=True)
+
+
+def test_multi_head_decode_cache_mutates_under_nnx_jit():
+    module = MultiHeadAttention(
+        num_heads=2, in_features=8, decode=True, use_alpha=False, rngs=nnx.Rngs(30)
+    )
+    x = jax.random.normal(jax.random.key(32), (2, 4, 8))
+    full = module(x, mask=_causal_mask(2, 4), decode=False, deterministic=True)
+    module.init_cache(x.shape)
+
+    @nnx.jit
+    def step(attention, token):
+        return attention(token, deterministic=True)
+
+    incremental = jnp.concatenate(
+        [step(module, x[:, i : i + 1]) for i in range(x.shape[1])], axis=1
+    )
+    assert jnp.allclose(incremental, full, rtol=2e-5, atol=2e-5)
+    assert int(module.cache_index[...]) == 4
+
+
+def test_rotary_decode_cache_mutates_under_nnx_jit():
+    module = RotaryYatAttention(
+        embed_dim=8, num_heads=2, max_seq_len=4, use_alpha=False, rngs=nnx.Rngs(31)
+    )
+    x = jax.random.normal(jax.random.key(33), (2, 4, 8))
+    full = module(x, mask=_causal_mask(2, 4), deterministic=True)
+    module.init_cache(2, 4)
+
+    @nnx.jit
+    def step(attention, token):
+        return attention(token, decode=True, deterministic=True)
+
+    incremental = jnp.concatenate(
+        [step(module, x[:, i : i + 1]) for i in range(x.shape[1])], axis=1
+    )
+    assert jnp.allclose(incremental, full, rtol=3e-5, atol=3e-5)
+    assert int(module.cache_index[...]) == 4
+
+
+@pytest.mark.parametrize("kind", ["slay", "maclaurin", "radial"])
+def test_rotary_performer_respects_key_padding_mask(kind):
+    module = RotaryYatAttention(
+        embed_dim=8,
+        num_heads=2,
+        max_seq_len=8,
+        use_performer=True,
+        performer_kind=kind,
+        performer_num_features=32,
+        performer_sketch_m=2,
+        performer_num_radial=2,
+        performer_radial_dim=2,
+        use_alpha=False,
+        rngs=nnx.Rngs(40),
+    )
+    x = jax.random.normal(jax.random.key(41), (2, 5, 8))
+    all_keys = jnp.ones((2, 1, 1, 5), dtype=jnp.bool_)
+    padded = all_keys.at[..., -1].set(False)
+    out_all = module(x, mask=all_keys, deterministic=True)
+    out_padded = module(x, mask=padded, deterministic=True)
+    assert not jnp.allclose(out_all, out_padded)
+
+    with pytest.raises(ValueError, match="key-padding masks"):
+        module(x, mask=_causal_mask(2, 5), deterministic=True)
+    module.init_cache(2, 5)
+    with pytest.raises(ValueError, match="Incremental decode"):
+        module(x[:, :1], decode=True, deterministic=True)

--- a/tests/test_nnx/test_attention_regressions.py
+++ b/tests/test_nnx/test_attention_regressions.py
@@ -11,7 +11,6 @@ from nmn.nnx.layers.attention.fused_yat_attention import (
     fused_yat_l1_attention,
     fused_yat_l1_self_attention,
 )
-from nmn.nnx.layers.attention.yat_attention import normalize_qk
 
 
 def _causal_mask(batch_size: int, length: int) -> jax.Array:
@@ -21,23 +20,25 @@ def _causal_mask(batch_size: int, length: int) -> jax.Array:
     )
 
 
-def _reference_l1(query, key, value, epsilon=1e-3):
+def _reference_l1(query, key, value, bias=None, epsilon=1e-3):
     dot = jnp.einsum("...qhd,...khd->...hqk", query, key)
     q_sq = jnp.sum(query**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
     k_sq = jnp.sum(key**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
     raw_dist = q_sq + jnp.swapaxes(k_sq, -2, -1) - 2.0 * dot
     dist = jnp.maximum(raw_dist, 0.0) + epsilon
-    scores = dot**2 / (dist * jnp.sqrt(jnp.float32(query.shape[-1])))
+    numerator = dot if bias is None else dot + bias
+    scores = numerator**2 / (dist * jnp.sqrt(jnp.float32(query.shape[-1])))
     weights = scores / (jnp.sum(scores, axis=-1, keepdims=True) + 1e-12)
     return jnp.einsum("...hqk,...khd->...qhd", weights, value)
 
 
-def _reference_l1_self(x, value, epsilon=1e-3):
+def _reference_l1_self(x, value, bias=None, epsilon=1e-3):
     dot = jnp.einsum("...qhd,...khd->...hqk", x, x)
     x_sq = jnp.sum(x**2, axis=-1, keepdims=True).transpose(0, 2, 1, 3)
     raw_dist = x_sq + jnp.swapaxes(x_sq, -2, -1) - 2.0 * dot
     dist = jnp.maximum(raw_dist, 0.0) + epsilon
-    scores = dot**2 / (dist * jnp.sqrt(jnp.float32(x.shape[-1])))
+    numerator = dot if bias is None else dot + bias
+    scores = numerator**2 / (dist * jnp.sqrt(jnp.float32(x.shape[-1])))
     normalizer = jnp.sum(scores, axis=-1, keepdims=True)
     scores = jnp.where(jnp.eye(x.shape[-3], dtype=jnp.bool_), 0.0, scores)
     weights = scores / (normalizer + 1e-12)
@@ -97,6 +98,67 @@ def test_fused_l1_self_negative_clamp_subgradient_matches_autodiff():
         assert jnp.allclose(got, want, rtol=2e-5, atol=2e-5)
 
 
+def _bias_for_case(case, batch, heads, q_length, kv_length):
+    shapes = {
+        "scalar": (),
+        "per_head": (heads, 1, 1),
+        "batched": (batch, heads, 1, kv_length),
+        "full": (batch, heads, q_length, kv_length),
+    }
+    return jax.random.normal(jax.random.key(50), shapes[case]) * 0.05
+
+
+@pytest.mark.parametrize("bias_case", ["scalar", "per_head", "batched", "full"])
+def test_fused_l1_all_operand_gradients_for_broadcast_bias(bias_case):
+    query = jax.random.normal(jax.random.key(51), (2, 3, 2, 4))
+    key = jax.random.normal(jax.random.key(52), (2, 4, 2, 4))
+    value = jax.random.normal(jax.random.key(53), (2, 4, 2, 5))
+    bias = _bias_for_case(bias_case, 2, 2, 3, 4)
+    epsilon = jnp.array(0.1)
+
+    def fused_loss(q, k, v, b, e):
+        return jnp.sum(
+            fused_yat_l1_attention(q, k, v, bias=b, epsilon=e) ** 2
+        )
+
+    def reference_loss(q, k, v, b, e):
+        return jnp.sum(_reference_l1(q, k, v, bias=b, epsilon=e) ** 2)
+
+    actual = jax.grad(fused_loss, argnums=(0, 1, 2, 3, 4))(
+        query, key, value, bias, epsilon
+    )
+    expected = jax.grad(reference_loss, argnums=(0, 1, 2, 3, 4))(
+        query, key, value, bias, epsilon
+    )
+    for got, want in zip(actual, expected):
+        assert jnp.allclose(got, want, rtol=3e-5, atol=3e-5)
+
+
+@pytest.mark.parametrize("bias_case", ["scalar", "per_head", "batched", "full"])
+def test_fused_l1_self_all_operand_gradients_for_broadcast_bias(bias_case):
+    x = jax.random.normal(jax.random.key(54), (2, 3, 2, 4))
+    value = jax.random.normal(jax.random.key(55), (2, 3, 2, 5))
+    bias = _bias_for_case(bias_case, 2, 2, 3, 3)
+    epsilon = jnp.array(0.1)
+
+    def fused_loss(x, v, b, e):
+        return jnp.sum(
+            fused_yat_l1_self_attention(x, v, bias=b, epsilon=e) ** 2
+        )
+
+    def reference_loss(x, v, b, e):
+        return jnp.sum(_reference_l1_self(x, v, bias=b, epsilon=e) ** 2)
+
+    actual = jax.grad(fused_loss, argnums=(0, 1, 2, 3))(
+        x, value, bias, epsilon
+    )
+    expected = jax.grad(reference_loss, argnums=(0, 1, 2, 3))(
+        x, value, bias, epsilon
+    )
+    for got, want in zip(actual, expected):
+        assert jnp.allclose(got, want, rtol=3e-5, atol=3e-5)
+
+
 def test_multi_head_honors_output_projection_initializers_and_default_decode():
     module = MultiHeadAttention(
         num_heads=2,
@@ -131,12 +193,57 @@ def test_multi_head_normalize_qk_is_parameter_free_per_head_l2():
     x = jax.random.normal(jax.random.key(3), (2, 4, 8))
     projected_q = module.query(x).reshape(2, 4, 2, 4)
     projected_k = module.key(x).reshape(2, 4, 2, 4)
-    expected_q, expected_k = normalize_qk(projected_q, projected_k, module.epsilon)
+    expected_q = projected_q / jnp.maximum(
+        jnp.linalg.norm(projected_q, axis=-1, keepdims=True), 1e-12
+    )
+    expected_k = projected_k / jnp.maximum(
+        jnp.linalg.norm(projected_k, axis=-1, keepdims=True), 1e-12
+    )
     module(x, deterministic=True)
 
     assert module.query_ln is None and module.key_ln is None
     assert jnp.allclose(captured["query"], expected_q, atol=1e-6)
     assert jnp.allclose(captured["key"], expected_k, atol=1e-6)
+
+
+def test_multi_head_normalize_qk_matches_torch_for_zero_and_tiny_vectors():
+    torch = pytest.importorskip("torch")
+    captured = {}
+
+    def capture_attention(query, key, value, **_):
+        captured["query"] = query
+        captured["key"] = key
+        return value
+
+    module = MultiHeadAttention(
+        num_heads=2,
+        in_features=8,
+        normalize_qk=True,
+        attention_fn=capture_attention,
+        use_alpha=False,
+        decode=False,
+        rngs=nnx.Rngs(0),
+    )
+    identity = jnp.eye(8, dtype=jnp.float32)
+    module.query.kernel[...] = identity
+    module.key.kernel[...] = identity
+    module.query.bias[...] = 0.0
+    module.key.bias[...] = 0.0
+    inputs = jnp.array(
+        [[
+            [0.0] * 8,
+            [1e-14, -1e-14, 2e-14, -2e-14, 0.0, 0.0, 1e-15, -1e-15],
+            [1.0, -2.0, 3.0, -4.0, 0.5, -0.5, 2.0, -2.0],
+        ]],
+        dtype=jnp.float32,
+    )
+    module(inputs, deterministic=True)
+    projected = inputs.reshape(1, 3, 2, 4)
+    expected = torch.nn.functional.normalize(
+        torch.from_numpy(np.array(projected, copy=True)), p=2, dim=-1
+    ).numpy()
+    assert np.allclose(np.asarray(captured["query"]), expected, atol=1e-7)
+    assert np.allclose(np.asarray(captured["key"]), expected, atol=1e-7)
 
 
 def test_multi_head_normalize_qk_matches_torch_with_synchronized_weights():
@@ -277,6 +384,116 @@ def test_rotary_decode_cache_mutates_under_nnx_jit():
     assert int(module.cache_index[...]) == 4
 
 
+def _cache_snapshot(module):
+    return (
+        np.array(module.cached_key[...], copy=True),
+        np.array(module.cached_value[...], copy=True),
+        int(module.cache_index[...]),
+    )
+
+
+def _assert_cache_unchanged(module, snapshot):
+    key, value, index = snapshot
+    assert np.array_equal(np.asarray(module.cached_key[...]), key)
+    assert np.array_equal(np.asarray(module.cached_value[...]), value)
+    assert int(module.cache_index[...]) == index
+
+
+@pytest.mark.parametrize("kind", ["multi_head", "rotary"])
+def test_decode_jit_overflow_fails_without_overwriting_cache(kind):
+    if kind == "multi_head":
+        module = MultiHeadAttention(
+            num_heads=2,
+            in_features=8,
+            decode=True,
+            use_alpha=False,
+            rngs=nnx.Rngs(60),
+        )
+        module.init_cache((1, 2, 8))
+
+        @nnx.jit
+        def step(attention, token):
+            return attention(token, deterministic=True)
+
+    else:
+        module = RotaryYatAttention(
+            embed_dim=8,
+            num_heads=2,
+            max_seq_len=2,
+            use_alpha=False,
+            rngs=nnx.Rngs(60),
+        )
+        module.init_cache(1, 2)
+
+        @nnx.jit
+        def step(attention, token):
+            return attention(token, decode=True, deterministic=True)
+
+    step(module, jnp.ones((1, 1, 8)))
+    step(module, jnp.full((1, 1, 8), 2.0))
+    snapshot = _cache_snapshot(module)
+    with pytest.raises(Exception, match="cache is full"):
+        step(module, jnp.full((1, 1, 8), 3.0))
+    _assert_cache_unchanged(module, snapshot)
+
+
+@pytest.mark.parametrize("kind", ["multi_head", "rotary"])
+def test_decode_validation_failures_are_transactional(kind):
+    if kind == "multi_head":
+        module = MultiHeadAttention(
+            num_heads=2,
+            in_features=8,
+            decode=True,
+            use_alpha=False,
+            rngs=nnx.Rngs(61),
+        )
+        module.init_cache((1, 2, 8))
+        call = lambda token, mask=None: module(
+            token, mask=mask, deterministic=True
+        )
+    else:
+        module = RotaryYatAttention(
+            embed_dim=8,
+            num_heads=2,
+            max_seq_len=2,
+            use_alpha=False,
+            rngs=nnx.Rngs(61),
+        )
+        module.init_cache(1, 2)
+        call = lambda token, mask=None: module(
+            token, mask=mask, decode=True, deterministic=True
+        )
+
+    snapshot = _cache_snapshot(module)
+    with pytest.raises(ValueError, match="shape|one token"):
+        call(jnp.ones((1, 2, 8)))
+    _assert_cache_unchanged(module, snapshot)
+
+    invalid_mask = jnp.ones((1, 1, 2, 2), dtype=jnp.bool_)
+    with pytest.raises(ValueError, match="[Mm]ask shape"):
+        call(jnp.ones((1, 1, 8)), mask=invalid_mask)
+    _assert_cache_unchanged(module, snapshot)
+
+
+def test_multi_head_attention_failure_does_not_commit_cache():
+    def failing_attention(*_, **__):
+        raise RuntimeError("attention failed")
+
+    module = MultiHeadAttention(
+        num_heads=2,
+        in_features=8,
+        decode=True,
+        use_alpha=False,
+        attention_fn=failing_attention,
+        rngs=nnx.Rngs(62),
+    )
+    module.init_cache((1, 2, 8))
+    snapshot = _cache_snapshot(module)
+    with pytest.raises(RuntimeError, match="attention failed"):
+        module(jnp.ones((1, 1, 8)), deterministic=True)
+    _assert_cache_unchanged(module, snapshot)
+
+
 @pytest.mark.parametrize("kind", ["slay", "maclaurin", "radial"])
 def test_rotary_performer_respects_key_padding_mask(kind):
     module = RotaryYatAttention(
@@ -304,3 +521,43 @@ def test_rotary_performer_respects_key_padding_mask(kind):
     module.init_cache(2, 5)
     with pytest.raises(ValueError, match="Incremental decode"):
         module(x[:, :1], decode=True, deterministic=True)
+
+
+@pytest.mark.parametrize("failure", ["mask", "decode"])
+def test_rotary_performer_rejection_does_not_advance_rng_or_cache(failure):
+    module = RotaryYatAttention(
+        embed_dim=8,
+        num_heads=2,
+        max_seq_len=5,
+        dropout_rate=0.5,
+        use_performer=True,
+        performer_kind="maclaurin",
+        performer_num_features=16,
+        use_alpha=False,
+        rngs=nnx.Rngs(63),
+    )
+    module.init_cache(1, 5)
+    call_rngs = nnx.Rngs(dropout=64)
+    rng_count = int(call_rngs.dropout.count[...])
+    cache = _cache_snapshot(module)
+    x = jnp.ones((1, 5, 8))
+
+    if failure == "mask":
+        with pytest.raises(ValueError, match="key-padding masks"):
+            module(
+                x,
+                mask=_causal_mask(1, 5),
+                deterministic=False,
+                rngs=call_rngs,
+            )
+    else:
+        with pytest.raises(ValueError, match="Incremental decode"):
+            module(
+                x[:, :1],
+                decode=True,
+                deterministic=False,
+                rngs=call_rngs,
+            )
+
+    assert int(call_rngs.dropout.count[...]) == rng_count
+    _assert_cache_unchanged(module, cache)


### PR DESCRIPTION
Fixes #66
Fixes #67
Fixes #68
Fixes #69
Fixes #79

Repairs fused/self-attention VJPs, makes autoregressive cache updates transactional and JIT overflow-safe, restores the headed output projection, validates performer masks before state/RNG use, and aligns parameter-free query/key normalization with PyTorch.

Verification:
- focused attention suite: 200 passed
- full local NNX suite: 319 passed, 1 skipped
- independent adversarial review: 72 passed
- full/batched/scalar bias and epsilon gradient parity
- eager/JIT full-vs-incremental cache parity and no-mutation failure probes

Operational note: compiled cache overflow uses an ordered JAX host callback, so it surfaces as JaxRuntimeError and should be performance-watched on accelerators.