### PR TITLE
fix(keras): stabilize precision and convolution semantics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,47 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
       continue-on-error: true
 
+  test-keras-multibackend:
+    name: Test Keras (${{ matrix.backend }} backend)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [jax, torch]
+
+    env:
+      KERAS_BACKEND: ${{ matrix.backend }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install Keras test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov
+        pip install -e ".[keras]"
+
+    - name: Install JAX backend
+      if: matrix.backend == 'jax'
+      run: pip install "jax==0.9.1" "jaxlib==0.9.1"
+
+    - name: Install Torch backend
+      if: matrix.backend == 'torch'
+      run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+    - name: Verify isolated backend import
+      run: |
+        python -c "import keras; import nmn.keras; assert keras.backend.backend() == '${{ matrix.backend }}'"
+
+    - name: Run Keras backend suite
+      run: pytest tests/test_keras/ -v --cov=nmn --cov-report=xml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pip install nmn                   # the Yat layers, no framework deps
 pip install "nmn[torch]"          # + PyTorch
 pip install "nmn[nnx]"            # + Flax NNX (JAX)
 pip install "nmn[linen]"          # + Flax Linen (JAX)
-pip install "nmn[keras]"          # + Keras 3 / TensorFlow
+pip install "nmn[keras]"          # + Keras 3 (choose JAX, TF, or Torch separately)
 pip install "nmn[tf]"             # + TensorFlow
 pip install "nmn[mlx]"            # + MLX (Apple Silicon only)
 pip install "nmn[all]"            # everything except MLX (Linux/Windows safe)

--- a/docs/guides/keras.md
+++ b/docs/guides/keras.md
@@ -14,6 +14,7 @@ End-to-end walkthrough for using NMN with **Keras 3** (backend-agnostic: works o
 pip install "nmn[keras]"
 # Then install one backend, for example:
 pip install jax                 # or tensorflow / torch
+export KERAS_BACKEND=jax        # set before importing keras
 ```
 
 Verify:
@@ -27,7 +28,7 @@ layer = YatNMN(units=64)
 print(layer(keras.ops.ones((32, 128))).shape)  # (32, 64)
 ```
 
-To switch Keras backend, set the env var **before** importing keras:
+To switch Keras backend, change the env var **before** importing keras:
 
 ```bash
 export KERAS_BACKEND=jax      # or tensorflow, torch

--- a/docs/guides/keras.md
+++ b/docs/guides/keras.md
@@ -3,7 +3,8 @@
 End-to-end walkthrough for using NMN with **Keras 3** (backend-agnostic: works on JAX, TensorFlow, or PyTorch backends).
 
 - **Module path**: `nmn.keras`
-- **Minimum versions**: Python 3.10+, Keras 3.x, TensorFlow ≥ 2.10
+- **Minimum versions**: Python 3.10+, Keras 3.x, plus a supported JAX,
+  TensorFlow, or PyTorch backend
 
 ---
 
@@ -11,6 +12,8 @@ End-to-end walkthrough for using NMN with **Keras 3** (backend-agnostic: works o
 
 ```bash
 pip install "nmn[keras]"
+# Then install one backend, for example:
+pip install jax                 # or tensorflow / torch
 ```
 
 Verify:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "isort>=5.12.0",
     "mypy>=1.0.0",
     "hatch-vcs>=0.3.0",
+    "tomli>=1.1.0; python_version < '3.11'",
 ]
 nnx = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
 torch = ["torch>=1.11.0", "torchvision>=0.12.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
 ]
 nnx = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
 torch = ["torch>=1.11.0", "torchvision>=0.12.0"]
-keras = ["tensorflow>=2.10.0"]
+keras = ["keras>=3.0.0"]
 tf = ["tensorflow>=2.10.0"]
 linen = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
 mlx = ["mlx>=0.18.0"]

--- a/src/nmn/keras/_yat_core.py
+++ b/src/nmn/keras/_yat_core.py
@@ -56,12 +56,14 @@ def stable_yat_ratio(dot_product, distance_sq, epsilon):
             if source_dtype == "float16":
                 dot_grad = ops.clip(dot_grad, -65504.0, 65504.0)
                 distance_grad = ops.clip(distance_grad, -65504.0, 65504.0)
-                denominator_grad = ops.clip(
-                    denominator_grad, -65504.0, 65504.0
-                )
-            epsilon_grad = ops.reshape(
-                ops.sum(denominator_grad), ops.shape(eps)
-            )
+            # ``eps`` is scalar for every current caller, so its cotangent must
+            # sum all broadcast denominator contributions.  Reduce before
+            # clipping: clipping each element first can still overflow when
+            # two or more fp16 contributions are added together.
+            epsilon_grad = ops.sum(denominator_grad)
+            epsilon_max = 65504.0 if source_dtype == "float16" else 3.38953139e38
+            epsilon_grad = ops.clip(epsilon_grad, -epsilon_max, epsilon_max)
+            epsilon_grad = ops.reshape(epsilon_grad, ops.shape(eps))
             return (
                 ops.cast(dot_grad, source_dtype),
                 ops.cast(distance_grad, source_dtype),

--- a/src/nmn/keras/_yat_core.py
+++ b/src/nmn/keras/_yat_core.py
@@ -40,27 +40,41 @@ def reduction_safe_upcast(value):
     finite.  This boundary keeps the reduction in fp32 and performs exactly one
     saturating cast when its aggregate cotangent returns to the lowp leaf.
     """
-    # Materialize Keras Variables before passing them to custom_gradient.
-    # The Torch backend's autograd.Function only tracks Tensor arguments;
-    # handing it a Variable wrapper disconnects the underlying Parameter.
-    value = ops.convert_to_tensor(value)
     dtype = standardize_dtype(value.dtype)
     if dtype not in _LOW_PRECISION_DTYPES:
-        return value
+        return ops.convert_to_tensor(value)
+    # Materialize Keras Variables *outside* custom_gradient.  Torch's
+    # autograd.Function only tracks Tensor arguments, while TensorFlow treats
+    # a resource read performed inside a custom forward as a captured variable
+    # and then requires a separate ``variables=`` gradient result.  A
+    # dtype-changing cast creates a tracked tensor boundary without detaching
+    # the underlying parameter on any backend.  The custom identity below
+    # clips its fp32 cotangent before the ordinary cast backward converts that
+    # finite value to the low-precision leaf dtype.
+    value = ops.cast(value, "float32")
     max_value = _dtype_max(dtype)
 
     @ops.custom_gradient
     def upcast(x):
-        result = ops.cast(x, "float32")
+        result = x
 
-        def grad(*args, upstream=None):
+        def grad(*args, upstream=None, variables=None):
             if upstream is None:
                 (upstream,) = args
             # clip preserves NaNs on the supported Keras backends while
             # saturating both finite overflow and +/-inf.
             upstream32 = ops.cast(upstream, "float32")
             saturated = ops.clip(upstream32, -max_value, max_value)
-            return ops.cast(saturated, dtype)
+            input_grad = saturated
+            if variables is not None:
+                # This is a defensive TensorFlow-contract fallback.  The
+                # materializing cast above ensures current callers have no
+                # variables captured inside this custom forward.
+                variable_grads = [
+                    ops.cast(input_grad, variable.dtype) for variable in variables
+                ]
+                return input_grad, variable_grads
+            return input_grad
 
         return result, grad
 
@@ -79,14 +93,20 @@ def saturating_downcast(value, dtype):
         active = ops.logical_and(x > -max_value, x < max_value)
         result = ops.cast(ops.clip(x, -max_value, max_value), dtype)
 
-        def grad(*args, upstream=None):
+        def grad(*args, upstream=None, variables=None):
             if upstream is None:
                 (upstream,) = args
             upstream32 = ops.cast(upstream, "float32")
             # Comparisons are false for NaN.  Pass its cotangent through so the
             # upstream arithmetic remains NaN instead of silently zeroing it.
             active_or_nan = ops.logical_or(active, ops.isnan(x))
-            return upstream32 * ops.cast(active_or_nan, "float32")
+            input_grad = upstream32 * ops.cast(active_or_nan, "float32")
+            if variables is not None:
+                variable_grads = [
+                    ops.cast(input_grad, variable.dtype) for variable in variables
+                ]
+                return input_grad, variable_grads
+            return input_grad
 
         return result, grad
 

--- a/src/nmn/keras/_yat_core.py
+++ b/src/nmn/keras/_yat_core.py
@@ -13,9 +13,31 @@ tail block) and avoids long parameter lists.
 from __future__ import annotations
 
 from keras import ops
+from keras.src.backend import standardize_dtype
 
 
-__all__ = ["yat_score"]
+__all__ = ["stable_yat_ratio", "yat_score"]
+
+
+def stable_yat_ratio(dot_product, distance_sq, epsilon):
+    """Evaluate the YAT ratio without low-precision overflow/cancellation."""
+    distance_sq = ops.maximum(distance_sq, ops.cast(0.0, distance_sq.dtype))
+    source_dtype = standardize_dtype(dot_product.dtype)
+    if source_dtype in {"float16", "bfloat16"}:
+        # The exact-match score 1 / epsilon can exceed float16's finite range.
+        # Returning the fp32 compute result follows mixed-precision practice and
+        # also keeps gradients finite instead of overflowing before a cast.
+        dot_product = ops.cast(dot_product, "float32")
+        distance_sq = ops.cast(distance_sq, "float32")
+        epsilon = ops.cast(epsilon, "float32")
+    ratio = ops.square(dot_product) / (distance_sq + epsilon)
+    if source_dtype == "float16":
+        # Saturate scores that cannot be represented by the source policy.
+        # Besides preventing an eventual inf cast, the flat saturated branch
+        # prevents its otherwise unrepresentable input gradient from becoming
+        # inf/nan at exact query/kernel collisions.
+        ratio = ops.minimum(ratio, ops.cast(65504.0, ratio.dtype))
+    return ratio
 
 
 def yat_score(layer, dot_prod_map, distance_sq_map):
@@ -51,8 +73,13 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
     else:
         eps = layer.epsilon
 
+    # Squared distances assembled from norms and dot products are susceptible
+    # to cancellation in float16/bfloat16.  A squared distance is
+    # mathematically non-negative, so clamp before adding epsilon.  Keeping the
+    # clamp here guarantees identical behaviour for all forward and transpose
+    # convolution variants.
     # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps).
-    outputs = dot_prod_map ** 2 / (distance_sq_map + eps)
+    outputs = stable_yat_ratio(dot_prod_map, distance_sq_map, eps)
 
     # Optional alpha (constant via _constant_alpha_value is folded into
     # `layer.alpha` at __init__ time; here we only need `use_alpha` + alpha).

--- a/src/nmn/keras/_yat_core.py
+++ b/src/nmn/keras/_yat_core.py
@@ -16,63 +16,96 @@ from keras import ops
 from keras.src.backend import standardize_dtype
 
 
-__all__ = ["stable_yat_ratio", "yat_score"]
+__all__ = [
+    "reduction_safe_upcast",
+    "saturating_downcast",
+    "stable_yat_ratio",
+    "yat_score",
+]
 
 
-def stable_yat_ratio(dot_product, distance_sq, epsilon):
-    """Evaluate the YAT ratio without low-precision overflow/cancellation."""
-    distance_sq = ops.maximum(distance_sq, ops.cast(0.0, distance_sq.dtype))
-    source_dtype = standardize_dtype(dot_product.dtype)
-    if source_dtype not in {"float16", "bfloat16"}:
-        return ops.square(dot_product) / (distance_sq + epsilon)
+_LOW_PRECISION_DTYPES = {"float16", "bfloat16"}
 
-    epsilon = ops.cast(epsilon, source_dtype)
+
+def _dtype_max(dtype):
+    return 65504.0 if dtype == "float16" else 3.38953139e38
+
+
+def reduction_safe_upcast(value):
+    """Upcast low-precision reduction inputs and saturate their final cotangent.
+
+    A regular lowp-to-fp32 cast downcasts its backward result without guarding
+    the already-reduced cotangent.  Multi-output conv/matmul gradients can then
+    become ``inf`` at the leaf even though every individual contribution is
+    finite.  This boundary keeps the reduction in fp32 and performs exactly one
+    saturating cast when its aggregate cotangent returns to the lowp leaf.
+    """
+    # Materialize Keras Variables before passing them to custom_gradient.
+    # The Torch backend's autograd.Function only tracks Tensor arguments;
+    # handing it a Variable wrapper disconnects the underlying Parameter.
+    value = ops.convert_to_tensor(value)
+    dtype = standardize_dtype(value.dtype)
+    if dtype not in _LOW_PRECISION_DTYPES:
+        return value
+    max_value = _dtype_max(dtype)
 
     @ops.custom_gradient
-    def low_precision_ratio(dot, distance, eps):
-        dot32 = ops.cast(dot, "float32")
-        distance32 = ops.cast(distance, "float32")
-        eps32 = ops.cast(eps, "float32")
-        denominator = distance32 + eps32
-        raw_ratio = ops.square(dot32) / denominator
-        max_value = 65504.0 if source_dtype == "float16" else 3.38953139e38
-        active = raw_ratio < max_value
-        result = ops.cast(ops.minimum(raw_ratio, max_value), source_dtype)
+    def upcast(x):
+        result = ops.cast(x, "float32")
+
+        def grad(*args, upstream=None):
+            if upstream is None:
+                (upstream,) = args
+            # clip preserves NaNs on the supported Keras backends while
+            # saturating both finite overflow and +/-inf.
+            upstream32 = ops.cast(upstream, "float32")
+            saturated = ops.clip(upstream32, -max_value, max_value)
+            return ops.cast(saturated, dtype)
+
+        return result, grad
+
+    return upcast(value)
+
+
+def saturating_downcast(value, dtype):
+    """Cast an fp32 result to a lowp policy without overflow or NaN masking."""
+    dtype = standardize_dtype(dtype)
+    if dtype not in _LOW_PRECISION_DTYPES:
+        return ops.cast(value, dtype)
+    max_value = _dtype_max(dtype)
+
+    @ops.custom_gradient
+    def downcast(x):
+        active = ops.logical_and(x > -max_value, x < max_value)
+        result = ops.cast(ops.clip(x, -max_value, max_value), dtype)
 
         def grad(*args, upstream=None):
             if upstream is None:
                 (upstream,) = args
             upstream32 = ops.cast(upstream, "float32")
-            active32 = ops.cast(active, "float32")
-            dot_grad = upstream32 * (2.0 * dot32 / denominator) * active32
-            denominator_grad = (
-                upstream32
-                * (-ops.square(dot32) / ops.square(denominator))
-                * active32
-            )
-            distance_grad = ops.where(
-                distance32 > 0.0, denominator_grad, ops.zeros_like(denominator_grad)
-            )
-            if source_dtype == "float16":
-                dot_grad = ops.clip(dot_grad, -65504.0, 65504.0)
-                distance_grad = ops.clip(distance_grad, -65504.0, 65504.0)
-            # ``eps`` is scalar for every current caller, so its cotangent must
-            # sum all broadcast denominator contributions.  Reduce before
-            # clipping: clipping each element first can still overflow when
-            # two or more fp16 contributions are added together.
-            epsilon_grad = ops.sum(denominator_grad)
-            epsilon_max = 65504.0 if source_dtype == "float16" else 3.38953139e38
-            epsilon_grad = ops.clip(epsilon_grad, -epsilon_max, epsilon_max)
-            epsilon_grad = ops.reshape(epsilon_grad, ops.shape(eps))
-            return (
-                ops.cast(dot_grad, source_dtype),
-                ops.cast(distance_grad, source_dtype),
-                ops.cast(epsilon_grad, source_dtype),
-            )
+            # Comparisons are false for NaN.  Pass its cotangent through so the
+            # upstream arithmetic remains NaN instead of silently zeroing it.
+            active_or_nan = ops.logical_or(active, ops.isnan(x))
+            return upstream32 * ops.cast(active_or_nan, "float32")
 
         return result, grad
 
-    return low_precision_ratio(dot_product, distance_sq, epsilon)
+    return downcast(ops.cast(value, "float32"))
+
+
+def stable_yat_ratio(dot_product, distance_sq, epsilon, output_dtype=None):
+    """Evaluate the YAT ratio without low-precision overflow/cancellation."""
+    source_dtype = standardize_dtype(dot_product.dtype)
+    output_dtype = source_dtype if output_dtype is None else output_dtype
+    dot_product = reduction_safe_upcast(dot_product)
+    distance_sq = reduction_safe_upcast(distance_sq)
+    if hasattr(epsilon, "dtype"):
+        epsilon = reduction_safe_upcast(epsilon)
+    else:
+        epsilon = ops.cast(epsilon, "float32")
+    distance_sq = ops.maximum(distance_sq, ops.cast(0.0, distance_sq.dtype))
+    ratio = ops.square(dot_product) / (distance_sq + epsilon)
+    return saturating_downcast(ratio, output_dtype)
 
 
 def yat_score(layer, dot_prod_map, distance_sq_map):
@@ -96,7 +129,7 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
         if layer._constant_bias_value is not None:
             dot_prod_map = dot_prod_map + layer._constant_bias_value
         else:
-            bias = layer.bias
+            bias = reduction_safe_upcast(layer.bias)
             if layer.data_format == "channels_first":
                 bias_shape = (1, -1) + (1,) * len(layer.kernel_size)
                 bias = ops.reshape(bias, bias_shape)
@@ -104,9 +137,9 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
 
     # Resolve effective epsilon (learnable via softplus, or constant).
     if layer.learnable_epsilon and layer.epsilon_param is not None:
-        eps = ops.softplus(layer.epsilon_param)
+        eps = ops.softplus(reduction_safe_upcast(layer.epsilon_param))
     else:
-        eps = layer.epsilon
+        eps = ops.cast(layer.epsilon, "float32")
 
     # Squared distances assembled from norms and dot products are susceptible
     # to cancellation in float16/bfloat16.  A squared distance is
@@ -114,11 +147,13 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
     # clamp here guarantees identical behaviour for all forward and transpose
     # convolution variants.
     # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps).
-    outputs = stable_yat_ratio(dot_prod_map, distance_sq_map, eps)
+    outputs = stable_yat_ratio(
+        dot_prod_map, distance_sq_map, eps, output_dtype="float32"
+    )
 
     # Optional alpha (constant via _constant_alpha_value is folded into
     # `layer.alpha` at __init__ time; here we only need `use_alpha` + alpha).
     if layer.use_alpha and layer.alpha is not None:
-        outputs = outputs * layer.alpha
+        outputs = outputs * reduction_safe_upcast(layer.alpha)
 
-    return outputs
+    return saturating_downcast(outputs, layer.compute_dtype)

--- a/src/nmn/keras/_yat_core.py
+++ b/src/nmn/keras/_yat_core.py
@@ -23,21 +23,54 @@ def stable_yat_ratio(dot_product, distance_sq, epsilon):
     """Evaluate the YAT ratio without low-precision overflow/cancellation."""
     distance_sq = ops.maximum(distance_sq, ops.cast(0.0, distance_sq.dtype))
     source_dtype = standardize_dtype(dot_product.dtype)
-    if source_dtype in {"float16", "bfloat16"}:
-        # The exact-match score 1 / epsilon can exceed float16's finite range.
-        # Returning the fp32 compute result follows mixed-precision practice and
-        # also keeps gradients finite instead of overflowing before a cast.
-        dot_product = ops.cast(dot_product, "float32")
-        distance_sq = ops.cast(distance_sq, "float32")
-        epsilon = ops.cast(epsilon, "float32")
-    ratio = ops.square(dot_product) / (distance_sq + epsilon)
-    if source_dtype == "float16":
-        # Saturate scores that cannot be represented by the source policy.
-        # Besides preventing an eventual inf cast, the flat saturated branch
-        # prevents its otherwise unrepresentable input gradient from becoming
-        # inf/nan at exact query/kernel collisions.
-        ratio = ops.minimum(ratio, ops.cast(65504.0, ratio.dtype))
-    return ratio
+    if source_dtype not in {"float16", "bfloat16"}:
+        return ops.square(dot_product) / (distance_sq + epsilon)
+
+    epsilon = ops.cast(epsilon, source_dtype)
+
+    @ops.custom_gradient
+    def low_precision_ratio(dot, distance, eps):
+        dot32 = ops.cast(dot, "float32")
+        distance32 = ops.cast(distance, "float32")
+        eps32 = ops.cast(eps, "float32")
+        denominator = distance32 + eps32
+        raw_ratio = ops.square(dot32) / denominator
+        max_value = 65504.0 if source_dtype == "float16" else 3.38953139e38
+        active = raw_ratio < max_value
+        result = ops.cast(ops.minimum(raw_ratio, max_value), source_dtype)
+
+        def grad(*args, upstream=None):
+            if upstream is None:
+                (upstream,) = args
+            upstream32 = ops.cast(upstream, "float32")
+            active32 = ops.cast(active, "float32")
+            dot_grad = upstream32 * (2.0 * dot32 / denominator) * active32
+            denominator_grad = (
+                upstream32
+                * (-ops.square(dot32) / ops.square(denominator))
+                * active32
+            )
+            distance_grad = ops.where(
+                distance32 > 0.0, denominator_grad, ops.zeros_like(denominator_grad)
+            )
+            if source_dtype == "float16":
+                dot_grad = ops.clip(dot_grad, -65504.0, 65504.0)
+                distance_grad = ops.clip(distance_grad, -65504.0, 65504.0)
+                denominator_grad = ops.clip(
+                    denominator_grad, -65504.0, 65504.0
+                )
+            epsilon_grad = ops.reshape(
+                ops.sum(denominator_grad), ops.shape(eps)
+            )
+            return (
+                ops.cast(dot_grad, source_dtype),
+                ops.cast(distance_grad, source_dtype),
+                ops.cast(epsilon_grad, source_dtype),
+            )
+
+        return result, grad
+
+    return low_precision_ratio(dot_product, distance_sq, epsilon)
 
 
 def yat_score(layer, dot_prod_map, distance_sq_map):

--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -13,6 +13,7 @@ from typing import Optional, Tuple, Union
 
 from keras.src import initializers, ops
 from keras.src.layers.layer import Layer
+from keras.src.saving.object_registration import register_keras_serializable
 
 __all__ = [
     "normalize_qk",
@@ -172,6 +173,7 @@ def yat_attention_normalized(
     )
 
 
+@register_keras_serializable(package="nmn", name="MultiHeadYatAttention")
 class MultiHeadYatAttention(Layer):
     """Multi-head attention using the YAT formula (Keras Layer).
 

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -2,14 +2,18 @@
 
 import math
 import threading
+import weakref
 
 from keras.src import activations, constraints, initializers, regularizers
 from keras.src import ops
 from keras.src.api_export import keras_export
+from keras.src.backend import standardize_dtype
 from keras.src.backend.common.backend_utils import compute_conv_transpose_output_shape
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
 from keras.src.ops.operation_utils import compute_conv_output_shape
+from keras.src.saving.object_registration import register_keras_serializable
+from keras.src.saving.serialization_lib import deserialize_keras_object
 
 from ._yat_core import yat_score
 
@@ -22,6 +26,99 @@ def _reject_kernel_bank_expansion(bank_id, existing_filters, requested_filters):
         "shapes; create the first consumer with a sufficiently large "
         "kernel_bank_size. The existing bank was not modified."
     )
+
+
+@register_keras_serializable(package="nmn", name="YatKernelBank")
+class _KernelBankRef:
+    """Serializable identity for a shared kernel without owning its Variable.
+
+    Keras' object-sharing scope preserves one ref object when a Functional model
+    containing multiple consumers is cloned or loaded.  Each consumer tracks the
+    shared Variable exactly once; the process-local weak registry is only used
+    to connect layers constructed directly by users.
+    """
+
+    def __init__(self, bank_id, signature, capacity):
+        self.bank_id = bank_id
+        self.signature = _freeze_signature(signature)
+        self.capacity = int(capacity)
+        self.variable = None
+
+    def get_config(self):
+        return {
+            "bank_id": self.bank_id,
+            "signature": self.signature,
+            "capacity": self.capacity,
+        }
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
+
+
+class _KernelBankSerializationMixin:
+    @classmethod
+    def from_config(cls, config):
+        config = dict(config)
+        bank = config.get("kernel_bank")
+        if isinstance(bank, dict):
+            config["kernel_bank"] = deserialize_keras_object(bank)
+        return cls(**config)
+
+
+def _freeze_signature(value):
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_signature(item) for item in value)
+    return value
+
+
+def _safe_kernel_initializer(initializer):
+    """Initialize low-precision kernels through fp32 for JAX LAPACK safety."""
+
+    def initialize(shape, dtype=None):
+        dtype_name = standardize_dtype(dtype)
+        if dtype_name in {"float16", "bfloat16"}:
+            return ops.cast(initializer(shape, dtype="float32"), dtype_name)
+        return initializer(shape, dtype=dtype)
+
+    return initialize
+
+
+def _validate_kernel_bank_config(layer):
+    if (
+        layer.tie_kernel_bank
+        and layer.kernel_bank_size is not None
+        and layer.kernel_bank_size < layer.filters
+    ):
+        raise ValueError(
+            f"kernel_bank_size ({layer.kernel_bank_size}) must be greater than "
+            f"or equal to filters ({layer.filters})."
+        )
+
+
+def _get_bank_ref(layer, signature, capacity):
+    supplied = layer._kernel_bank_ref
+    if supplied is not None:
+        if supplied.signature != _freeze_signature(signature):
+            raise ValueError("Serialized kernel bank signature is incompatible.")
+        if supplied.capacity < layer.filters:
+            _reject_kernel_bank_expansion(
+                supplied.bank_id, supplied.capacity, layer.filters
+            )
+        return supplied
+
+    key = (layer.kernel_bank_id, tuple(signature))
+    with type(layer)._KERNEL_BANKS_LOCK:
+        bank = type(layer)._KERNEL_BANKS.get(key)
+        if bank is None:
+            bank = _KernelBankRef(layer.kernel_bank_id, signature, capacity)
+            type(layer)._KERNEL_BANKS[key] = bank
+        elif capacity > bank.capacity:
+            _reject_kernel_bank_expansion(
+                layer.kernel_bank_id, bank.capacity, capacity
+            )
+    layer._kernel_bank_ref = bank
+    return bank
 
 
 def _conv_output_shape(layer, input_shape):
@@ -50,55 +147,80 @@ def _conv_transpose_output_shape(layer, input_shape):
     )
 
 
-def _build_transpose_kernel(layer, input_dim):
-    """Create or attach a fixed-capacity transpose-convolution kernel bank."""
+def _build_forward_kernel(layer, input_dim):
     if not layer.tie_kernel_bank:
         layer.kernel = layer.add_weight(
             name="kernel",
-            shape=tuple(layer.kernel_size) + (layer.filters, input_dim),
-            initializer=layer.kernel_initializer,
+            shape=tuple(layer.kernel_size)
+            + (input_dim // layer.groups, layer.filters),
+            initializer=_safe_kernel_initializer(layer.kernel_initializer),
             regularizer=layer.kernel_regularizer,
             constraint=layer.kernel_constraint,
             trainable=True,
         )
         return
 
-    bank_filters = layer.kernel_bank_size or layer.filters
-    bank_kernel_shape = tuple(layer.kernel_size) + (bank_filters, input_dim)
-    bank_key = (
-        layer.kernel_bank_id,
+    capacity = layer.kernel_bank_size or layer.filters
+    signature = (
+        "forward",
         tuple(layer.kernel_size),
-        input_dim,
-        "transpose",
+        input_dim // layer.groups,
+        layer.groups,
     )
-    with type(layer)._KERNEL_BANKS_LOCK:
-        shared_kernel = type(layer)._KERNEL_BANKS.get(bank_key)
-        if shared_kernel is None:
-            layer.kernel = layer.add_weight(
-                name="kernel",
-                shape=bank_kernel_shape,
-                initializer=layer.kernel_initializer,
-                regularizer=layer.kernel_regularizer,
-                constraint=layer.kernel_constraint,
-                trainable=True,
-            )
-            type(layer)._KERNEL_BANKS[bank_key] = layer.kernel
-        else:
-            filter_axis = len(layer.kernel_size)
-            existing_filters = shared_kernel.shape[filter_axis]
-            if bank_filters > existing_filters:
-                _reject_kernel_bank_expansion(
-                    layer.kernel_bank_id, existing_filters, bank_filters
-                )
-            layer.kernel = shared_kernel
-            layer._track_variable(shared_kernel)
+    bank = _get_bank_ref(layer, signature, capacity)
+    if bank.variable is None:
+        bank.variable = layer.add_weight(
+            name="kernel",
+            shape=tuple(layer.kernel_size)
+            + (input_dim // layer.groups, bank.capacity),
+            initializer=_safe_kernel_initializer(layer.kernel_initializer),
+            regularizer=layer.kernel_regularizer,
+            constraint=layer.kernel_constraint,
+            trainable=True,
+        )
+    else:
+        layer.kernel = bank.variable
+    if not hasattr(layer, "kernel"):
+        layer.kernel = bank.variable
+    layer._kernel_slice = slice(0, layer.filters)
+
+
+def _build_transpose_kernel(layer, input_dim):
+    """Create or attach a fixed-capacity transpose-convolution kernel bank."""
+    if not layer.tie_kernel_bank:
+        layer.kernel = layer.add_weight(
+            name="kernel",
+            shape=tuple(layer.kernel_size) + (layer.filters, input_dim),
+            initializer=_safe_kernel_initializer(layer.kernel_initializer),
+            regularizer=layer.kernel_regularizer,
+            constraint=layer.kernel_constraint,
+            trainable=True,
+        )
+        return
+
+    capacity = layer.kernel_bank_size or layer.filters
+    signature = ("transpose", tuple(layer.kernel_size), input_dim)
+    bank = _get_bank_ref(layer, signature, capacity)
+    if bank.variable is None:
+        bank.variable = layer.add_weight(
+            name="kernel",
+            shape=tuple(layer.kernel_size) + (bank.capacity, input_dim),
+            initializer=_safe_kernel_initializer(layer.kernel_initializer),
+            regularizer=layer.kernel_regularizer,
+            constraint=layer.kernel_constraint,
+            trainable=True,
+        )
+    else:
+        layer.kernel = bank.variable
+    if not hasattr(layer, "kernel"):
+        layer.kernel = bank.variable
     layer._kernel_slice = slice(0, layer.filters)
 
 
 @keras_export("keras.layers.YatConv1D")
-class YatConv1D(Layer):
+class YatConv1D(_KernelBankSerializationMixin, Layer):
     # Class-level shared kernel banks (guarded by a lock for thread safety)
-    _KERNEL_BANKS = {}
+    _KERNEL_BANKS = weakref.WeakValueDictionary()
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     """1D YAT convolution layer (e.g. temporal convolution).
@@ -181,6 +303,7 @@ class YatConv1D(Layer):
         tie_kernel_bank=False,
         kernel_bank_size=None,
         kernel_bank_id="default",
+        kernel_bank=None,
         kernel_initializer="orthogonal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -216,6 +339,8 @@ class YatConv1D(Layer):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        self._kernel_bank_ref = kernel_bank
+        _validate_kernel_bank_config(self)
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -261,47 +386,7 @@ class YatConv1D(Layer):
                 f"divisible by the number of groups ({self.groups})."
             )
 
-        # Kernel: standalone or from a shared bank
-        if self.tie_kernel_bank:
-            bank_filters = self.kernel_bank_size or self.filters
-            bank_kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, bank_filters)
-            bank_key = (
-                self.kernel_bank_id,
-                tuple(self.kernel_size),
-                input_dim // self.groups,
-                self.groups,
-            )
-            with type(self)._KERNEL_BANKS_LOCK:
-                shared_kernel = type(self)._KERNEL_BANKS.get(bank_key)
-                if shared_kernel is None:
-                    self.kernel = self.add_weight(
-                        name="kernel",
-                        shape=bank_kernel_shape,
-                        initializer=self.kernel_initializer,
-                        regularizer=self.kernel_regularizer,
-                        constraint=self.kernel_constraint,
-                        trainable=True,
-                    )
-                    type(self)._KERNEL_BANKS[bank_key] = self.kernel
-                else:
-                    existing_filters = shared_kernel.shape[-1]
-                    if bank_filters > existing_filters:
-                        _reject_kernel_bank_expansion(
-                            self.kernel_bank_id, existing_filters, bank_filters
-                        )
-                    self.kernel = shared_kernel
-                    self._track_variable(shared_kernel)
-            self._kernel_slice = slice(0, self.filters)
-        else:
-            kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, self.filters)
-            self.kernel = self.add_weight(
-                name="kernel",
-                shape=kernel_shape,
-                initializer=self.kernel_initializer,
-                regularizer=self.kernel_regularizer,
-                constraint=self.kernel_constraint,
-                trainable=True,
-            )
+        _build_forward_kernel(self, input_dim)
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
         if self.use_bias and self._constant_bias_value is None:
@@ -466,6 +551,7 @@ class YatConv1D(Layer):
             "tie_kernel_bank": self.tie_kernel_bank,
             "kernel_bank_size": self.kernel_bank_size,
             "kernel_bank_id": self.kernel_bank_id,
+            "kernel_bank": self._kernel_bank_ref if self.tie_kernel_bank else None,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -478,9 +564,9 @@ class YatConv1D(Layer):
 
 
 @keras_export("keras.layers.YatConv2D")
-class YatConv2D(Layer):
+class YatConv2D(_KernelBankSerializationMixin, Layer):
     # Class-level shared kernel banks (guarded by a lock for thread safety)
-    _KERNEL_BANKS = {}
+    _KERNEL_BANKS = weakref.WeakValueDictionary()
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     """2D YAT convolution layer (e.g. spatial convolution over images).
@@ -571,6 +657,7 @@ class YatConv2D(Layer):
         tie_kernel_bank=False,
         kernel_bank_size=None,
         kernel_bank_id="default",
+        kernel_bank=None,
         kernel_initializer="orthogonal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -600,6 +687,8 @@ class YatConv2D(Layer):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        self._kernel_bank_ref = kernel_bank
+        _validate_kernel_bank_config(self)
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -645,47 +734,7 @@ class YatConv2D(Layer):
                 f"divisible by the number of groups ({self.groups})."
             )
 
-        # Kernel: standalone or from a shared bank
-        if self.tie_kernel_bank:
-            bank_filters = self.kernel_bank_size or self.filters
-            bank_kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, bank_filters)
-            bank_key = (
-                self.kernel_bank_id,
-                tuple(self.kernel_size),
-                input_dim // self.groups,
-                self.groups,
-            )
-            with type(self)._KERNEL_BANKS_LOCK:
-                shared_kernel = type(self)._KERNEL_BANKS.get(bank_key)
-                if shared_kernel is None:
-                    self.kernel = self.add_weight(
-                        name="kernel",
-                        shape=bank_kernel_shape,
-                        initializer=self.kernel_initializer,
-                        regularizer=self.kernel_regularizer,
-                        constraint=self.kernel_constraint,
-                        trainable=True,
-                    )
-                    type(self)._KERNEL_BANKS[bank_key] = self.kernel
-                else:
-                    existing_filters = shared_kernel.shape[-1]
-                    if bank_filters > existing_filters:
-                        _reject_kernel_bank_expansion(
-                            self.kernel_bank_id, existing_filters, bank_filters
-                        )
-                    self.kernel = shared_kernel
-                    self._track_variable(shared_kernel)
-            self._kernel_slice = slice(0, self.filters)
-        else:
-            kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, self.filters)
-            self.kernel = self.add_weight(
-                name="kernel",
-                shape=kernel_shape,
-                initializer=self.kernel_initializer,
-                regularizer=self.kernel_regularizer,
-                constraint=self.kernel_constraint,
-                trainable=True,
-            )
+        _build_forward_kernel(self, input_dim)
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
         if self.use_bias and self._constant_bias_value is None:
@@ -836,6 +885,7 @@ class YatConv2D(Layer):
             "tie_kernel_bank": self.tie_kernel_bank,
             "kernel_bank_size": self.kernel_bank_size,
             "kernel_bank_id": self.kernel_bank_id,
+            "kernel_bank": self._kernel_bank_ref if self.tie_kernel_bank else None,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -848,9 +898,9 @@ class YatConv2D(Layer):
 
 
 @keras_export("keras.layers.YatConv3D")
-class YatConv3D(Layer):
+class YatConv3D(_KernelBankSerializationMixin, Layer):
     # Class-level shared kernel banks (guarded by a lock for thread safety)
-    _KERNEL_BANKS = {}
+    _KERNEL_BANKS = weakref.WeakValueDictionary()
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     """3D YAT convolution layer (e.g. spatial convolution over volumes).
@@ -908,6 +958,7 @@ class YatConv3D(Layer):
         tie_kernel_bank=False,
         kernel_bank_size=None,
         kernel_bank_id="default",
+        kernel_bank=None,
         kernel_initializer="orthogonal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -937,6 +988,8 @@ class YatConv3D(Layer):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        self._kernel_bank_ref = kernel_bank
+        _validate_kernel_bank_config(self)
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -982,47 +1035,7 @@ class YatConv3D(Layer):
                 f"divisible by the number of groups ({self.groups})."
             )
 
-        # Kernel: standalone or from a shared bank
-        if self.tie_kernel_bank:
-            bank_filters = self.kernel_bank_size or self.filters
-            bank_kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, bank_filters)
-            bank_key = (
-                self.kernel_bank_id,
-                tuple(self.kernel_size),
-                input_dim // self.groups,
-                self.groups,
-            )
-            with type(self)._KERNEL_BANKS_LOCK:
-                shared_kernel = type(self)._KERNEL_BANKS.get(bank_key)
-                if shared_kernel is None:
-                    self.kernel = self.add_weight(
-                        name="kernel",
-                        shape=bank_kernel_shape,
-                        initializer=self.kernel_initializer,
-                        regularizer=self.kernel_regularizer,
-                        constraint=self.kernel_constraint,
-                        trainable=True,
-                    )
-                    type(self)._KERNEL_BANKS[bank_key] = self.kernel
-                else:
-                    existing_filters = shared_kernel.shape[-1]
-                    if bank_filters > existing_filters:
-                        _reject_kernel_bank_expansion(
-                            self.kernel_bank_id, existing_filters, bank_filters
-                        )
-                    self.kernel = shared_kernel
-                    self._track_variable(shared_kernel)
-            self._kernel_slice = slice(0, self.filters)
-        else:
-            kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, self.filters)
-            self.kernel = self.add_weight(
-                name="kernel",
-                shape=kernel_shape,
-                initializer=self.kernel_initializer,
-                regularizer=self.kernel_regularizer,
-                constraint=self.kernel_constraint,
-                trainable=True,
-            )
+        _build_forward_kernel(self, input_dim)
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
         if self.use_bias and self._constant_bias_value is None:
@@ -1173,6 +1186,7 @@ class YatConv3D(Layer):
             "tie_kernel_bank": self.tie_kernel_bank,
             "kernel_bank_size": self.kernel_bank_size,
             "kernel_bank_id": self.kernel_bank_id,
+            "kernel_bank": self._kernel_bank_ref if self.tie_kernel_bank else None,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -1185,9 +1199,9 @@ class YatConv3D(Layer):
 
 
 @keras_export("keras.layers.YatConvTranspose1D")
-class YatConvTranspose1D(Layer):
+class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
     # Class-level shared kernel banks (guarded by a lock for thread safety)
-    _KERNEL_BANKS = {}
+    _KERNEL_BANKS = weakref.WeakValueDictionary()
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     """1D YAT transposed convolution layer (deconvolution).
@@ -1233,6 +1247,7 @@ class YatConvTranspose1D(Layer):
         tie_kernel_bank=False,
         kernel_bank_size=None,
         kernel_bank_id="default",
+        kernel_bank=None,
         kernel_initializer="orthogonal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -1261,6 +1276,8 @@ class YatConvTranspose1D(Layer):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        self._kernel_bank_ref = kernel_bank
+        _validate_kernel_bank_config(self)
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -1442,6 +1459,7 @@ class YatConvTranspose1D(Layer):
             "tie_kernel_bank": self.tie_kernel_bank,
             "kernel_bank_size": self.kernel_bank_size,
             "kernel_bank_id": self.kernel_bank_id,
+            "kernel_bank": self._kernel_bank_ref if self.tie_kernel_bank else None,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -1454,9 +1472,9 @@ class YatConvTranspose1D(Layer):
 
 
 @keras_export("keras.layers.YatConvTranspose2D")
-class YatConvTranspose2D(Layer):
+class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
     # Class-level shared kernel banks (guarded by a lock for thread safety)
-    _KERNEL_BANKS = {}
+    _KERNEL_BANKS = weakref.WeakValueDictionary()
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     """2D YAT transposed convolution layer (deconvolution).
@@ -1502,6 +1520,7 @@ class YatConvTranspose2D(Layer):
         tie_kernel_bank=False,
         kernel_bank_size=None,
         kernel_bank_id="default",
+        kernel_bank=None,
         kernel_initializer="orthogonal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -1530,6 +1549,8 @@ class YatConvTranspose2D(Layer):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        self._kernel_bank_ref = kernel_bank
+        _validate_kernel_bank_config(self)
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -1711,6 +1732,7 @@ class YatConvTranspose2D(Layer):
             "tie_kernel_bank": self.tie_kernel_bank,
             "kernel_bank_size": self.kernel_bank_size,
             "kernel_bank_id": self.kernel_bank_id,
+            "kernel_bank": self._kernel_bank_ref if self.tie_kernel_bank else None,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),
@@ -1723,9 +1745,9 @@ class YatConvTranspose2D(Layer):
 
 
 @keras_export("keras.layers.YatConvTranspose3D")
-class YatConvTranspose3D(Layer):
+class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
     # Class-level shared kernel banks (guarded by a lock for thread safety)
-    _KERNEL_BANKS = {}
+    _KERNEL_BANKS = weakref.WeakValueDictionary()
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     """3D YAT transposed convolution layer (deconvolution).
@@ -1771,6 +1793,7 @@ class YatConvTranspose3D(Layer):
         tie_kernel_bank=False,
         kernel_bank_size=None,
         kernel_bank_id="default",
+        kernel_bank=None,
         kernel_initializer="orthogonal",
         bias_initializer="zeros",
         kernel_regularizer=None,
@@ -1799,6 +1822,8 @@ class YatConvTranspose3D(Layer):
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
         self._kernel_slice = slice(None)
+        self._kernel_bank_ref = kernel_bank
+        _validate_kernel_bank_config(self)
 
         # Bias configuration: learnable, constant, or none
         self._constant_bias_value = None
@@ -1979,6 +2004,7 @@ class YatConvTranspose3D(Layer):
             "tie_kernel_bank": self.tie_kernel_bank,
             "kernel_bank_size": self.kernel_bank_size,
             "kernel_bank_id": self.kernel_bank_id,
+            "kernel_bank": self._kernel_bank_ref if self.tie_kernel_bank else None,
             "kernel_initializer": initializers.serialize(self.kernel_initializer),
             "bias_initializer": initializers.serialize(self.bias_initializer),
             "kernel_regularizer": regularizers.serialize(self.kernel_regularizer),

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -7,7 +7,7 @@ import weakref
 from keras.src import activations, constraints, initializers, regularizers
 from keras.src import ops
 from keras.src.api_export import keras_export
-from keras.src.backend import standardize_dtype
+from keras.src.backend import backend, standardize_dtype
 from keras.src.backend.common.backend_utils import compute_conv_transpose_output_shape
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
@@ -43,6 +43,10 @@ class _KernelBankRef:
         self.signature = _freeze_signature(signature)
         self.capacity = int(capacity)
         self.variable = None
+        # Registry lookup and Variable creation are separate operations.  This
+        # per-reference lock keeps the first creation and every attachment
+        # atomic without serializing unrelated kernel banks.
+        self.lock = threading.Lock()
 
     def get_config(self):
         return {
@@ -97,6 +101,14 @@ def _validate_kernel_bank_config(layer):
 
 
 def _get_bank_ref(layer, signature, capacity):
+    policy_signature = (
+        "dtype_policy",
+        backend(),
+        layer.dtype_policy.name,
+        standardize_dtype(layer.variable_dtype),
+        standardize_dtype(layer.compute_dtype),
+    )
+    signature = tuple(signature) + (policy_signature,)
     supplied = layer._kernel_bank_ref
     if supplied is not None:
         if supplied.signature != _freeze_signature(signature):
@@ -168,19 +180,17 @@ def _build_forward_kernel(layer, input_dim):
         layer.groups,
     )
     bank = _get_bank_ref(layer, signature, capacity)
-    if bank.variable is None:
-        bank.variable = layer.add_weight(
-            name="kernel",
-            shape=tuple(layer.kernel_size)
-            + (input_dim // layer.groups, bank.capacity),
-            initializer=_safe_kernel_initializer(layer.kernel_initializer),
-            regularizer=layer.kernel_regularizer,
-            constraint=layer.kernel_constraint,
-            trainable=True,
-        )
-    else:
-        layer.kernel = bank.variable
-    if not hasattr(layer, "kernel"):
+    with bank.lock:
+        if bank.variable is None:
+            bank.variable = layer.add_weight(
+                name="kernel",
+                shape=tuple(layer.kernel_size)
+                + (input_dim // layer.groups, bank.capacity),
+                initializer=_safe_kernel_initializer(layer.kernel_initializer),
+                regularizer=layer.kernel_regularizer,
+                constraint=layer.kernel_constraint,
+                trainable=True,
+            )
         layer.kernel = bank.variable
     layer._kernel_slice = slice(0, layer.filters)
 
@@ -201,18 +211,16 @@ def _build_transpose_kernel(layer, input_dim):
     capacity = layer.kernel_bank_size or layer.filters
     signature = ("transpose", tuple(layer.kernel_size), input_dim)
     bank = _get_bank_ref(layer, signature, capacity)
-    if bank.variable is None:
-        bank.variable = layer.add_weight(
-            name="kernel",
-            shape=tuple(layer.kernel_size) + (bank.capacity, input_dim),
-            initializer=_safe_kernel_initializer(layer.kernel_initializer),
-            regularizer=layer.kernel_regularizer,
-            constraint=layer.kernel_constraint,
-            trainable=True,
-        )
-    else:
-        layer.kernel = bank.variable
-    if not hasattr(layer, "kernel"):
+    with bank.lock:
+        if bank.variable is None:
+            bank.variable = layer.add_weight(
+                name="kernel",
+                shape=tuple(layer.kernel_size) + (bank.capacity, input_dim),
+                initializer=_safe_kernel_initializer(layer.kernel_initializer),
+                regularizer=layer.kernel_regularizer,
+                constraint=layer.kernel_constraint,
+                trainable=True,
+            )
         layer.kernel = bank.variable
     layer._kernel_slice = slice(0, layer.filters)
 

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -15,7 +15,7 @@ from keras.src.ops.operation_utils import compute_conv_output_shape
 from keras.src.saving.object_registration import register_keras_serializable
 from keras.src.saving.serialization_lib import deserialize_keras_object
 
-from ._yat_core import yat_score
+from ._yat_core import reduction_safe_upcast, yat_score
 
 
 def _reject_kernel_bank_expansion(bank_id, existing_filters, requested_filters):
@@ -449,6 +449,9 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
         if self.tie_kernel_bank:
             kernel = kernel[..., self._kernel_slice]
 
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
+
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
@@ -797,6 +800,9 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
         if self.tie_kernel_bank:
             kernel = kernel[..., self._kernel_slice]
 
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
+
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
@@ -1098,6 +1104,9 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
         if self.tie_kernel_bank:
             kernel = kernel[..., self._kernel_slice]
 
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
+
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
@@ -1379,6 +1388,9 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             slicer[filter_axis] = self._kernel_slice
             kernel = kernel[tuple(slicer)]
 
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
+
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
@@ -1652,6 +1664,9 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             slicer[filter_axis] = self._kernel_slice
             kernel = kernel[tuple(slicer)]
 
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
+
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
@@ -1924,6 +1939,9 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             slicer = [slice(None)] * kernel.ndim
             slicer[filter_axis] = self._kernel_slice
             kernel = kernel[tuple(slicer)]
+
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -1,18 +1,98 @@
 """YAT convolution layers for Keras/TensorFlow."""
 
-import logging
+import math
 import threading
 
 from keras.src import activations, constraints, initializers, regularizers
+from keras.src import ops
 from keras.src.api_export import keras_export
+from keras.src.backend.common.backend_utils import compute_conv_transpose_output_shape
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
-from keras.src import ops
-import math
+from keras.src.ops.operation_utils import compute_conv_output_shape
 
 from ._yat_core import yat_score
 
-logger = logging.getLogger(__name__)
+
+def _reject_kernel_bank_expansion(bank_id, existing_filters, requested_filters):
+    """Reject fixed-shape Keras variable expansion before mutating a bank."""
+    raise ValueError(
+        f"Kernel bank '{bank_id}' has {existing_filters} filters and cannot be "
+        f"expanded in place to {requested_filters}. Keras variables have fixed "
+        "shapes; create the first consumer with a sufficiently large "
+        "kernel_bank_size. The existing bank was not modified."
+    )
+
+
+def _conv_output_shape(layer, input_shape):
+    return compute_conv_output_shape(
+        input_shape,
+        layer.filters,
+        tuple(layer.kernel_size),
+        strides=tuple(layer.strides),
+        padding=layer.padding,
+        data_format=layer.data_format or "channels_last",
+        dilation_rate=tuple(layer.dilation_rate),
+    )
+
+
+def _conv_transpose_output_shape(layer, input_shape):
+    return tuple(
+        compute_conv_transpose_output_shape(
+            input_shape,
+            tuple(layer.kernel_size),
+            layer.filters,
+            strides=tuple(layer.strides),
+            padding=layer.padding,
+            data_format=layer.data_format or "channels_last",
+            dilation_rate=tuple(layer.dilation_rate),
+        )
+    )
+
+
+def _build_transpose_kernel(layer, input_dim):
+    """Create or attach a fixed-capacity transpose-convolution kernel bank."""
+    if not layer.tie_kernel_bank:
+        layer.kernel = layer.add_weight(
+            name="kernel",
+            shape=tuple(layer.kernel_size) + (layer.filters, input_dim),
+            initializer=layer.kernel_initializer,
+            regularizer=layer.kernel_regularizer,
+            constraint=layer.kernel_constraint,
+            trainable=True,
+        )
+        return
+
+    bank_filters = layer.kernel_bank_size or layer.filters
+    bank_kernel_shape = tuple(layer.kernel_size) + (bank_filters, input_dim)
+    bank_key = (
+        layer.kernel_bank_id,
+        tuple(layer.kernel_size),
+        input_dim,
+        "transpose",
+    )
+    with type(layer)._KERNEL_BANKS_LOCK:
+        shared_kernel = type(layer)._KERNEL_BANKS.get(bank_key)
+        if shared_kernel is None:
+            layer.kernel = layer.add_weight(
+                name="kernel",
+                shape=bank_kernel_shape,
+                initializer=layer.kernel_initializer,
+                regularizer=layer.kernel_regularizer,
+                constraint=layer.kernel_constraint,
+                trainable=True,
+            )
+            type(layer)._KERNEL_BANKS[bank_key] = layer.kernel
+        else:
+            filter_axis = len(layer.kernel_size)
+            existing_filters = shared_kernel.shape[filter_axis]
+            if bank_filters > existing_filters:
+                _reject_kernel_bank_expansion(
+                    layer.kernel_bank_id, existing_filters, bank_filters
+                )
+            layer.kernel = shared_kernel
+            layer._track_variable(shared_kernel)
+    layer._kernel_slice = slice(0, layer.filters)
 
 
 @keras_export("keras.layers.YatConv1D")
@@ -117,6 +197,12 @@ class YatConv1D(Layer):
         self.padding = padding.lower()
         self.data_format = data_format
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate,)
+        if any(stride != 1 for stride in self.strides) and any(
+            dilation != 1 for dilation in self.dilation_rate
+        ):
+            raise ValueError(
+                "`strides > 1` is incompatible with `dilation_rate > 1`."
+            )
         self.groups = groups
         self.use_alpha = use_alpha
         if epsilon <= 0:
@@ -200,20 +286,11 @@ class YatConv1D(Layer):
                 else:
                     existing_filters = shared_kernel.shape[-1]
                     if bank_filters > existing_filters:
-                        logger.info(
-                            "Auto-expanding Keras kernel bank '%s': %d -> %d filters",
-                            self.kernel_bank_id, existing_filters, bank_filters,
+                        _reject_kernel_bank_expansion(
+                            self.kernel_bank_id, existing_filters, bank_filters
                         )
-                        # Expand the shared kernel by sampling new tail filters
-                        new_kernel_val = self.kernel_initializer(bank_kernel_shape, dtype=shared_kernel.dtype)
-                        old_val = shared_kernel.numpy() if hasattr(shared_kernel, "numpy") else ops.convert_to_numpy(shared_kernel)
-                        new_kernel_val = ops.convert_to_tensor(new_kernel_val)
-                        # Splice old values into the front
-                        import numpy as _np
-                        new_arr = _np.array(new_kernel_val)
-                        new_arr[..., :existing_filters] = _np.array(old_val)
-                        shared_kernel.assign(ops.convert_to_tensor(new_arr))
                     self.kernel = shared_kernel
+                    self._track_variable(shared_kernel)
             self._kernel_slice = slice(0, self.filters)
         else:
             kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, self.filters)
@@ -295,39 +372,57 @@ class YatConv1D(Layer):
                 ops.sqrt(ops.sum(ops.square(kernel), axis=reduce_axes, keepdims=True)) + 1e-8
             )
 
+        # Keras' low-level conv op only accepts valid/same.  Causal Conv1D is
+        # left padded by the effective dilated kernel size, then evaluated as
+        # valid for both the dot product and patch norm.
+        conv_inputs = inputs
+        conv_padding = self.padding
+        if self.padding == "causal":
+            left_pad = self.dilation_rate[0] * (self.kernel_size[0] - 1)
+            if self.data_format == "channels_first":
+                pad_width = ((0, 0), (0, 0), (left_pad, 0))
+            else:
+                pad_width = ((0, 0), (left_pad, 0), (0, 0))
+            conv_inputs = ops.pad(inputs, pad_width)
+            conv_padding = "valid"
+
         # Compute standard convolution (dot product)
         dot_prod_map = ops.conv(
-            inputs,
+            conv_inputs,
             kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=conv_padding,
             data_format=self.data_format,
             dilation_rate=self.dilation_rate,
         )
 
         # Compute squared input patches using convolution with ones
-        inputs_squared = inputs * inputs
+        inputs_squared = conv_inputs * conv_inputs
 
         # Create ones kernel for computing patch squared sums
         input_channels_per_group = kernel.shape[-2]
-        ones_kernel_shape = tuple(self.kernel_size) + (input_channels_per_group, 1)
+        ones_kernel_shape = tuple(self.kernel_size) + (
+            input_channels_per_group,
+            self.groups,
+        )
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
         patch_sq_sum_map_raw = ops.conv(
             inputs_squared,
             ones_kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=conv_padding,
             data_format=self.data_format,
             dilation_rate=self.dilation_rate,
         )
 
         # Handle grouped convolution
         channel_axis = 1 if self.data_format == "channels_first" else -1
-        if self.groups > 1:
-            patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters // self.groups, axis=channel_axis)
-        else:
-            patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=channel_axis)
+        patch_sq_sum_map = ops.repeat(
+            patch_sq_sum_map_raw,
+            self.filters // self.groups,
+            axis=channel_axis,
+        )
 
         # Compute kernel squared sum per filter (1.0 if normalized)
         if self.weight_normalized:
@@ -348,24 +443,7 @@ class YatConv1D(Layer):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
-        if self.data_format == "channels_first":
-            length = input_shape[2]
-            if length is not None:
-                if self.padding == "valid":
-                    length = length - self.kernel_size[0] + 1
-                elif self.padding == "causal":
-                    length = length
-                length = (length + self.strides[0] - 1) // self.strides[0]
-            return (input_shape[0], self.filters, length)
-        else:
-            length = input_shape[1]
-            if length is not None:
-                if self.padding == "valid":
-                    length = length - self.kernel_size[0] + 1
-                elif self.padding == "causal":
-                    length = length
-                length = (length + self.strides[0] - 1) // self.strides[0]
-            return (input_shape[0], length, self.filters)
+        return _conv_output_shape(self, input_shape)
 
     def get_config(self):
         config = super().get_config()
@@ -592,17 +670,11 @@ class YatConv2D(Layer):
                 else:
                     existing_filters = shared_kernel.shape[-1]
                     if bank_filters > existing_filters:
-                        logger.info(
-                            "Auto-expanding Keras kernel bank '%s': %d -> %d filters",
-                            self.kernel_bank_id, existing_filters, bank_filters,
+                        _reject_kernel_bank_expansion(
+                            self.kernel_bank_id, existing_filters, bank_filters
                         )
-                        new_kernel_val = self.kernel_initializer(bank_kernel_shape, dtype=shared_kernel.dtype)
-                        import numpy as _np
-                        old_arr = _np.array(shared_kernel)
-                        new_arr = _np.array(new_kernel_val)
-                        new_arr[..., :existing_filters] = old_arr
-                        shared_kernel.assign(ops.convert_to_tensor(new_arr))
                     self.kernel = shared_kernel
+                    self._track_variable(shared_kernel)
             self._kernel_slice = slice(0, self.filters)
         else:
             kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, self.filters)
@@ -699,7 +771,10 @@ class YatConv2D(Layer):
 
         # Create ones kernel for computing patch squared sums
         input_channels_per_group = kernel.shape[-2]
-        ones_kernel_shape = tuple(self.kernel_size) + (input_channels_per_group, 1)
+        ones_kernel_shape = tuple(self.kernel_size) + (
+            input_channels_per_group,
+            self.groups,
+        )
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
         patch_sq_sum_map_raw = ops.conv(
@@ -713,10 +788,11 @@ class YatConv2D(Layer):
 
         # Handle grouped convolution
         channel_axis = 1 if self.data_format == "channels_first" else -1
-        if self.groups > 1:
-            patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters // self.groups, axis=channel_axis)
-        else:
-            patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=channel_axis)
+        patch_sq_sum_map = ops.repeat(
+            patch_sq_sum_map_raw,
+            self.filters // self.groups,
+            axis=channel_axis,
+        )
 
         # Compute kernel squared sum per filter (1.0 if normalized)
         if self.weight_normalized:
@@ -737,27 +813,7 @@ class YatConv2D(Layer):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
-        if self.data_format == "channels_first":
-            rows = input_shape[2]
-            cols = input_shape[3]
-        else:
-            rows = input_shape[1]
-            cols = input_shape[2]
-
-        if rows is not None:
-            if self.padding == "valid":
-                rows = rows - self.kernel_size[0] + 1
-            rows = (rows + self.strides[0] - 1) // self.strides[0]
-        
-        if cols is not None:
-            if self.padding == "valid":
-                cols = cols - self.kernel_size[1] + 1
-            cols = (cols + self.strides[1] - 1) // self.strides[1]
-
-        if self.data_format == "channels_first":
-            return (input_shape[0], self.filters, rows, cols)
-        else:
-            return (input_shape[0], rows, cols, self.filters)
+        return _conv_output_shape(self, input_shape)
 
     def get_config(self):
         config = super().get_config()
@@ -951,17 +1007,11 @@ class YatConv3D(Layer):
                 else:
                     existing_filters = shared_kernel.shape[-1]
                     if bank_filters > existing_filters:
-                        logger.info(
-                            "Auto-expanding Keras kernel bank '%s': %d -> %d filters",
-                            self.kernel_bank_id, existing_filters, bank_filters,
+                        _reject_kernel_bank_expansion(
+                            self.kernel_bank_id, existing_filters, bank_filters
                         )
-                        new_kernel_val = self.kernel_initializer(bank_kernel_shape, dtype=shared_kernel.dtype)
-                        import numpy as _np
-                        old_arr = _np.array(shared_kernel)
-                        new_arr = _np.array(new_kernel_val)
-                        new_arr[..., :existing_filters] = old_arr
-                        shared_kernel.assign(ops.convert_to_tensor(new_arr))
                     self.kernel = shared_kernel
+                    self._track_variable(shared_kernel)
             self._kernel_slice = slice(0, self.filters)
         else:
             kernel_shape = tuple(self.kernel_size) + (input_dim // self.groups, self.filters)
@@ -1058,7 +1108,10 @@ class YatConv3D(Layer):
 
         # Create ones kernel for computing patch squared sums
         input_channels_per_group = kernel.shape[-2]
-        ones_kernel_shape = tuple(self.kernel_size) + (input_channels_per_group, 1)
+        ones_kernel_shape = tuple(self.kernel_size) + (
+            input_channels_per_group,
+            self.groups,
+        )
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
         patch_sq_sum_map_raw = ops.conv(
@@ -1072,10 +1125,11 @@ class YatConv3D(Layer):
 
         # Handle grouped convolution
         channel_axis = 1 if self.data_format == "channels_first" else -1
-        if self.groups > 1:
-            patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters // self.groups, axis=channel_axis)
-        else:
-            patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=channel_axis)
+        patch_sq_sum_map = ops.repeat(
+            patch_sq_sum_map_raw,
+            self.filters // self.groups,
+            axis=channel_axis,
+        )
 
         # Compute kernel squared sum per filter (1.0 if normalized)
         if self.weight_normalized:
@@ -1096,23 +1150,7 @@ class YatConv3D(Layer):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
-        if self.data_format == "channels_first":
-            dims = [input_shape[2], input_shape[3], input_shape[4]]
-        else:
-            dims = [input_shape[1], input_shape[2], input_shape[3]]
-
-        new_dims = []
-        for i, dim in enumerate(dims):
-            if dim is not None:
-                if self.padding == "valid":
-                    dim = dim - self.kernel_size[i] + 1
-                dim = (dim + self.strides[i] - 1) // self.strides[i]
-            new_dims.append(dim)
-
-        if self.data_format == "channels_first":
-            return (input_shape[0], self.filters) + tuple(new_dims)
-        else:
-            return (input_shape[0],) + tuple(new_dims) + (self.filters,)
+        return _conv_output_shape(self, input_shape)
 
     def get_config(self):
         config = super().get_config()
@@ -1256,58 +1294,7 @@ class YatConvTranspose1D(Layer):
 
         input_dim = int(input_shape[channel_axis])
 
-        # Kernel: standalone or from a shared bank
-        # Transpose conv shape: (*kernel_size, filters, input_dim) — filter axis = len(kernel_size)
-        if self.tie_kernel_bank:
-            bank_filters = self.kernel_bank_size or self.filters
-            bank_kernel_shape = tuple(self.kernel_size) + (bank_filters, input_dim)
-            bank_key = (
-                self.kernel_bank_id,
-                tuple(self.kernel_size),
-                input_dim,
-                "transpose",
-            )
-            with type(self)._KERNEL_BANKS_LOCK:
-                shared_kernel = type(self)._KERNEL_BANKS.get(bank_key)
-                if shared_kernel is None:
-                    self.kernel = self.add_weight(
-                        name="kernel",
-                        shape=bank_kernel_shape,
-                        initializer=self.kernel_initializer,
-                        regularizer=self.kernel_regularizer,
-                        constraint=self.kernel_constraint,
-                        trainable=True,
-                    )
-                    type(self)._KERNEL_BANKS[bank_key] = self.kernel
-                else:
-                    filter_axis = len(self.kernel_size)
-                    existing_filters = shared_kernel.shape[filter_axis]
-                    if bank_filters > existing_filters:
-                        logger.info(
-                            "Auto-expanding Keras kernel bank '%s': %d -> %d filters",
-                            self.kernel_bank_id, existing_filters, bank_filters,
-                        )
-                        new_kernel_val = self.kernel_initializer(bank_kernel_shape, dtype=shared_kernel.dtype)
-                        import numpy as _np
-                        old_arr = _np.array(shared_kernel)
-                        new_arr = _np.array(new_kernel_val)
-                        # Splice along the filter axis
-                        slicer = [slice(None)] * new_arr.ndim
-                        slicer[filter_axis] = slice(0, existing_filters)
-                        new_arr[tuple(slicer)] = old_arr
-                        shared_kernel.assign(ops.convert_to_tensor(new_arr))
-                    self.kernel = shared_kernel
-            self._kernel_slice = slice(0, self.filters)
-        else:
-            kernel_shape = tuple(self.kernel_size) + (self.filters, input_dim)
-            self.kernel = self.add_weight(
-                name="kernel",
-                shape=kernel_shape,
-                initializer=self.kernel_initializer,
-                regularizer=self.kernel_regularizer,
-                constraint=self.kernel_constraint,
-                trainable=True,
-            )
+        _build_transpose_kernel(self, input_dim)
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
         if self.use_bias and self._constant_bias_value is None:
@@ -1433,21 +1420,7 @@ class YatConvTranspose1D(Layer):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
-        if self.data_format == "channels_first":
-            length = input_shape[2]
-        else:
-            length = input_shape[1]
-        
-        if length is not None:
-            if self.padding == "same":
-                length = length * self.strides[0]
-            else:
-                length = length * self.strides[0] + max(self.kernel_size[0] - self.strides[0], 0)
-        
-        if self.data_format == "channels_first":
-            return (input_shape[0], self.filters, length)
-        else:
-            return (input_shape[0], length, self.filters)
+        return _conv_transpose_output_shape(self, input_shape)
 
     def get_config(self):
         config = super().get_config()
@@ -1590,17 +1563,7 @@ class YatConvTranspose2D(Layer):
 
         input_dim = int(input_shape[channel_axis])
 
-        # Kernel shape for transpose conv: (*kernel_size, filters, input_dim)
-        kernel_shape = tuple(self.kernel_size) + (self.filters, input_dim)
-
-        self.kernel = self.add_weight(
-            name="kernel",
-            shape=kernel_shape,
-            initializer=self.kernel_initializer,
-            regularizer=self.kernel_regularizer,
-            constraint=self.kernel_constraint,
-            trainable=True,
-        )
+        _build_transpose_kernel(self, input_dim)
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
         if self.use_bias and self._constant_bias_value is None:
@@ -1726,29 +1689,7 @@ class YatConvTranspose2D(Layer):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
-        if self.data_format == "channels_first":
-            rows = input_shape[2]
-            cols = input_shape[3]
-        else:
-            rows = input_shape[1]
-            cols = input_shape[2]
-
-        if rows is not None:
-            if self.padding == "same":
-                rows = rows * self.strides[0]
-            else:
-                rows = rows * self.strides[0] + max(self.kernel_size[0] - self.strides[0], 0)
-        
-        if cols is not None:
-            if self.padding == "same":
-                cols = cols * self.strides[1]
-            else:
-                cols = cols * self.strides[1] + max(self.kernel_size[1] - self.strides[1], 0)
-
-        if self.data_format == "channels_first":
-            return (input_shape[0], self.filters, rows, cols)
-        else:
-            return (input_shape[0], rows, cols, self.filters)
+        return _conv_transpose_output_shape(self, input_shape)
 
     def get_config(self):
         config = super().get_config()
@@ -1891,17 +1832,7 @@ class YatConvTranspose3D(Layer):
 
         input_dim = int(input_shape[channel_axis])
 
-        # Kernel shape for transpose conv: (*kernel_size, filters, input_dim)
-        kernel_shape = tuple(self.kernel_size) + (self.filters, input_dim)
-
-        self.kernel = self.add_weight(
-            name="kernel",
-            shape=kernel_shape,
-            initializer=self.kernel_initializer,
-            regularizer=self.kernel_regularizer,
-            constraint=self.kernel_constraint,
-            trainable=True,
-        )
+        _build_transpose_kernel(self, input_dim)
 
         # Bias: learnable parameter, or None if constant_bias is set / use_bias=False
         if self.use_bias and self._constant_bias_value is None:
@@ -2026,24 +1957,7 @@ class YatConvTranspose3D(Layer):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
-        if self.data_format == "channels_first":
-            dims = [input_shape[2], input_shape[3], input_shape[4]]
-        else:
-            dims = [input_shape[1], input_shape[2], input_shape[3]]
-
-        new_dims = []
-        for i, dim in enumerate(dims):
-            if dim is not None:
-                if self.padding == "same":
-                    dim = dim * self.strides[i]
-                else:
-                    dim = dim * self.strides[i] + max(self.kernel_size[i] - self.strides[i], 0)
-            new_dims.append(dim)
-
-        if self.data_format == "channels_first":
-            return (input_shape[0], self.filters) + tuple(new_dims)
-        else:
-            return (input_shape[0],) + tuple(new_dims) + (self.filters,)
+        return _conv_transpose_output_shape(self, input_shape)
 
     def get_config(self):
         config = super().get_config()

--- a/src/nmn/keras/embed.py
+++ b/src/nmn/keras/embed.py
@@ -11,12 +11,16 @@ from typing import Optional, Union
 
 from keras.src import initializers, ops
 from keras.src.layers.layer import Layer
+from keras.src.saving.object_registration import register_keras_serializable
+
+from ._yat_core import stable_yat_ratio
 
 __all__ = ["YatEmbed"]
 
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
 
+@register_keras_serializable(package="nmn", name="YatEmbed")
 class YatEmbed(Layer):
     """Embedding with YAT attend method (Keras Layer).
 
@@ -132,7 +136,7 @@ class YatEmbed(Layer):
             )
             distances = query_sq + embed_sq - 2.0 * y
 
-        y = ops.square(y) / (distances + self.epsilon)
+        y = stable_yat_ratio(y, distances, self.epsilon)
 
         if self._constant_alpha_value is not None:
             y = y * self._constant_alpha_value

--- a/src/nmn/keras/embed.py
+++ b/src/nmn/keras/embed.py
@@ -13,7 +13,11 @@ from keras.src import initializers, ops
 from keras.src.layers.layer import Layer
 from keras.src.saving.object_registration import register_keras_serializable
 
-from ._yat_core import stable_yat_ratio
+from ._yat_core import (
+    reduction_safe_upcast,
+    saturating_downcast,
+    stable_yat_ratio,
+)
 
 __all__ = ["YatEmbed"]
 
@@ -115,7 +119,9 @@ class YatEmbed(Layer):
         if not self.built:
             self.build()
 
-        embedding = self.embedding
+        output_dtype = query.dtype
+        query = reduction_safe_upcast(query)
+        embedding = reduction_safe_upcast(self.embedding)
 
         if self.spherical:
             query = query / (
@@ -136,14 +142,14 @@ class YatEmbed(Layer):
             )
             distances = query_sq + embed_sq - 2.0 * y
 
-        y = stable_yat_ratio(y, distances, self.epsilon)
+        y = stable_yat_ratio(y, distances, self.epsilon, output_dtype="float32")
 
         if self._constant_alpha_value is not None:
             y = y * self._constant_alpha_value
         elif self.alpha is not None:
-            y = y * self.alpha
+            y = y * reduction_safe_upcast(self.alpha)
 
-        return y
+        return saturating_downcast(y, output_dtype)
 
     def compute_output_shape(self, input_shape):
         return input_shape + (self.features,)

--- a/src/nmn/keras/examples/mnist.py
+++ b/src/nmn/keras/examples/mnist.py
@@ -8,7 +8,7 @@ or:
 Set KERAS_BACKEND={jax,tensorflow,torch} before importing keras to choose backend.
 
 Requires:
-    pip install "nmn[keras]" keras tensorflow      # or jax / torch
+    pip install "nmn[keras]" jax      # or tensorflow / torch
 """
 from __future__ import annotations
 

--- a/tests/test_keras/test_attention.py
+++ b/tests/test_keras/test_attention.py
@@ -13,13 +13,15 @@ from nmn.keras.attention import (
     MultiHeadYatAttention,
 )
 
+to_numpy = keras.ops.convert_to_numpy
+
 
 class TestAttentionFunctions:
     def test_normalize_qk(self):
         q = np.random.randn(2, 5, 4, 8).astype(np.float32)
         k = np.random.randn(2, 5, 4, 8).astype(np.float32)
         q_n, k_n = normalize_qk(q, k)
-        q_norms = np.sqrt(np.sum(np.array(q_n) ** 2, axis=-1))
+        q_norms = np.sqrt(np.sum(to_numpy(q_n) ** 2, axis=-1))
         np.testing.assert_allclose(q_norms, np.ones_like(q_norms), atol=1e-5)
 
     def test_attention_weights_shape(self):
@@ -31,7 +33,7 @@ class TestAttentionFunctions:
     def test_attention_weights_sum_to_one(self):
         q = np.random.randn(2, 5, 4, 8).astype(np.float32)
         k = np.random.randn(2, 7, 4, 8).astype(np.float32)
-        weights = np.array(yat_attention_weights(q, k))
+        weights = to_numpy(yat_attention_weights(q, k))
         sums = weights.sum(axis=-1)
         np.testing.assert_allclose(sums, np.ones_like(sums), atol=1e-5)
 
@@ -46,7 +48,7 @@ class TestAttentionFunctions:
         q = np.random.randn(2, 5, 4, 8).astype(np.float32)
         k = np.random.randn(2, 7, 4, 8).astype(np.float32)
         v = np.random.randn(2, 7, 4, 8).astype(np.float32)
-        out = np.array(yat_attention(q, k, v))
+        out = to_numpy(yat_attention(q, k, v))
         assert not np.any(np.isnan(out))
 
     def test_attention_normalized_shape(self):
@@ -60,7 +62,7 @@ class TestAttentionFunctions:
         q = np.random.randn(2, 5, 4, 8).astype(np.float32)
         k = np.random.randn(2, 7, 4, 8).astype(np.float32)
         v = np.random.randn(2, 7, 4, 8).astype(np.float32)
-        out = np.array(yat_attention(q, k, v, spherical=True))
+        out = to_numpy(yat_attention(q, k, v, spherical=True))
         assert not np.any(np.isnan(out))
 
 
@@ -81,25 +83,25 @@ class TestMultiHeadYatAttention:
     def test_no_nan(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4)
         x = np.random.randn(2, 10, 32).astype(np.float32)
-        out = np.array(attn(x))
+        out = to_numpy(attn(x))
         assert not np.any(np.isnan(out))
 
     def test_constant_alpha(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4, constant_alpha=True)
         x = np.random.randn(2, 10, 32).astype(np.float32)
-        out = np.array(attn(x))
+        out = to_numpy(attn(x))
         assert not np.any(np.isnan(out))
 
     def test_no_alpha(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4, use_alpha=False)
         x = np.random.randn(2, 10, 32).astype(np.float32)
-        out = np.array(attn(x))
+        out = to_numpy(attn(x))
         assert not np.any(np.isnan(out))
 
     def test_no_bias(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4, use_bias=False)
         x = np.random.randn(2, 10, 32).astype(np.float32)
-        out = np.array(attn(x))
+        out = to_numpy(attn(x))
         assert not np.any(np.isnan(out))
 
     def test_invalid_embed_dim(self):

--- a/tests/test_keras/test_embed.py
+++ b/tests/test_keras/test_embed.py
@@ -7,6 +7,8 @@ keras = pytest.importorskip("keras")
 
 from nmn.keras.embed import YatEmbed
 
+to_numpy = keras.ops.convert_to_numpy
+
 
 class TestYatEmbed:
     def test_forward_shape(self):
@@ -41,7 +43,7 @@ class TestYatEmbed:
         embed = YatEmbed(num_embeddings=100, features=32)
         embed.build()
         query = np.random.randn(4, 32).astype(np.float32)
-        out = np.array(embed.attend(query))
+        out = to_numpy(embed.attend(query))
         assert not np.any(np.isnan(out))
         assert not np.any(np.isinf(out))
 
@@ -49,7 +51,7 @@ class TestYatEmbed:
         embed = YatEmbed(num_embeddings=100, features=32)
         embed.build()
         query = np.random.randn(4, 32).astype(np.float32)
-        out = np.array(embed.attend(query))
+        out = to_numpy(embed.attend(query))
         assert np.all(out >= 0)
 
     def test_constant_alpha(self):
@@ -57,7 +59,7 @@ class TestYatEmbed:
         embed.build()
         assert embed._constant_alpha_value == pytest.approx(1.4142135, abs=1e-5)
         query = np.random.randn(4, 16).astype(np.float32)
-        out = np.array(embed.attend(query))
+        out = to_numpy(embed.attend(query))
         assert not np.any(np.isnan(out))
 
     def test_no_alpha(self):
@@ -65,7 +67,7 @@ class TestYatEmbed:
         embed.build()
         assert embed.alpha is None
         query = np.random.randn(4, 16).astype(np.float32)
-        out = np.array(embed.attend(query))
+        out = to_numpy(embed.attend(query))
         assert not np.any(np.isnan(out))
 
     def test_spherical_mode(self):

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import threading
 import tomllib
 from pathlib import Path
 
@@ -19,6 +21,7 @@ from nmn.keras import (
     YatConvTranspose3D,
     YatEmbed,
 )
+from nmn.keras._yat_core import stable_yat_ratio
 
 BACKEND = keras.backend.backend()
 
@@ -249,6 +252,65 @@ def test_tied_kernel_bank_functional_save_load_preserves_sharing_and_optimizer(t
     )
 
 
+def test_tied_kernel_bank_creation_is_atomic_across_threads():
+    YatConv1D._KERNEL_BANKS.clear()
+    start = threading.Barrier(2)
+    common = dict(
+        filters=2,
+        kernel_size=1,
+        tie_kernel_bank=True,
+        kernel_bank_size=2,
+        kernel_bank_id="threaded-first-creation",
+        use_bias=False,
+        use_alpha=False,
+        kernel_initializer="ones",
+    )
+    layers = [YatConv1D(**common), YatConv1D(**common)]
+
+    def build(layer):
+        start.wait(timeout=5)
+        layer.build((None, 4, 1))
+        return layer.kernel
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        kernels = list(executor.map(build, layers))
+
+    assert kernels[0] is kernels[1]
+    assert layers[0]._kernel_bank_ref is layers[1]._kernel_bank_ref
+    assert all(len(layer.trainable_weights) == 1 for layer in layers)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "mixed_float16"])
+def test_tied_kernel_banks_are_separated_by_effective_dtype_policy(dtype):
+    YatConv1D._KERNEL_BANKS.clear()
+    common = dict(
+        filters=1,
+        kernel_size=1,
+        tie_kernel_bank=True,
+        kernel_bank_size=1,
+        kernel_bank_id=f"dtype-policy-{dtype}",
+        use_bias=False,
+        use_alpha=False,
+        kernel_initializer="ones",
+    )
+    float32_layer = YatConv1D(dtype="float32", **common)
+    low_precision_layer = YatConv1D(dtype=dtype, **common)
+
+    float32_output = float32_layer(tensor([[[0.25]]], "float32"))
+    low_precision_output = low_precision_layer(tensor([[[0.25]]], "float16"))
+
+    assert float32_layer.kernel is not low_precision_layer.kernel
+    assert float32_layer._kernel_bank_ref is not low_precision_layer._kernel_bank_ref
+    assert keras.backend.standardize_dtype(float32_output.dtype) == "float32"
+    assert keras.backend.standardize_dtype(low_precision_output.dtype) == "float16"
+    assert keras.backend.standardize_dtype(float32_layer.kernel.dtype) == "float32"
+    expected_variable_dtype = "float32" if dtype == "mixed_float16" else "float16"
+    assert (
+        keras.backend.standardize_dtype(low_precision_layer.kernel.dtype)
+        == expected_variable_dtype
+    )
+
+
 @pytest.mark.parametrize(
     "layer_cls",
     [
@@ -320,6 +382,72 @@ def test_low_precision_embedding_exact_match_preserves_policy_and_gradients(dtyp
     assert np.all(np.isfinite(np.asarray(output)))
     assert np.all(np.asarray(output) >= 0)
     assert np.all(np.isfinite(np.asarray(gradient)))
+
+
+@pytest.mark.skipif(BACKEND != "jax", reason="JAX cotangent regression")
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_embed_shaped_exact_collision_reduces_epsilon_gradient_before_clipping(dtype):
+    import jax
+    import jax.numpy as jnp
+
+    dot = jnp.full((2, 3), 0.5, dtype=getattr(jnp, dtype))
+    distance = jnp.zeros_like(dot)
+    # YatEmbed passes its configured epsilon as a scalar into this helper.
+    epsilon = jnp.asarray(1e-5, dtype=getattr(jnp, dtype))
+
+    gradient = jax.grad(lambda eps: jnp.sum(stable_yat_ratio(dot, distance, eps)))(
+        epsilon
+    )
+    gradient32 = np.asarray(gradient, dtype=np.float32)
+
+    assert gradient.shape == epsilon.shape
+    assert np.all(np.isfinite(gradient32))
+    assert np.all(gradient32 < 0)
+    if dtype == "float16":
+        np.testing.assert_array_equal(gradient32, np.asarray(-65504.0))
+    else:
+        epsilon32 = np.asarray(epsilon, dtype=np.float32)
+        expected = -dot.size * 0.25 / np.square(epsilon32)
+        np.testing.assert_allclose(gradient32, expected, rtol=2e-2)
+
+
+@pytest.mark.skipif(BACKEND != "jax", reason="JAX cotangent regression")
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_conv_exact_collision_has_finite_learnable_epsilon_gradient(dtype):
+    import jax
+    import jax.numpy as jnp
+
+    value = jnp.full((1, 4, 1), 0.5, dtype=getattr(jnp, dtype))
+    layer = YatConv1D(
+        1,
+        1,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=1e-5,
+        learnable_epsilon=True,
+        kernel_initializer="zeros",
+        dtype=dtype,
+    )
+    layer(value)
+    layer.kernel.assign(jnp.full(layer.kernel.shape, 0.5, dtype=getattr(jnp, dtype)))
+    trainable_values = [variable.value for variable in layer.trainable_variables]
+    epsilon_index = next(
+        index
+        for index, variable in enumerate(layer.trainable_variables)
+        if variable is layer.epsilon_param
+    )
+
+    def loss(epsilon_param):
+        values = list(trainable_values)
+        values[epsilon_index] = epsilon_param
+        output, _ = layer.stateless_call(values, layer.non_trainable_variables, value)
+        return jnp.sum(output)
+
+    gradient = jax.grad(loss)(trainable_values[epsilon_index])
+
+    assert gradient.shape == layer.epsilon_param.shape
+    assert np.all(np.isfinite(np.asarray(gradient, dtype=np.float32)))
+    assert np.all(np.asarray(gradient, dtype=np.float32) < 0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -1,0 +1,299 @@
+"""Regression coverage for Keras issues #55, #56, #73-#76 and #78."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import keras
+import numpy as np
+import pytest
+
+from nmn.keras import (
+    MultiHeadYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatEmbed,
+)
+
+
+@pytest.mark.parametrize(
+    ("layer_cls", "input_shape"),
+    [
+        (YatConv1D, (2, 7, 4)),
+        (YatConv2D, (2, 7, 6, 4)),
+        (YatConv3D, (2, 6, 5, 4, 4)),
+    ],
+)
+def test_grouped_convolutions_have_per_group_patch_norms_and_gradients(
+    layer_cls, input_shape
+):
+    x = jax.random.normal(jax.random.key(len(input_shape)), input_shape)
+    layer = layer_cls(4, 3, groups=2, padding="same", use_bias=False)
+
+    y = layer(x)
+    dx = jax.grad(lambda value: jnp.sum(layer(value)))(x)
+
+    assert y.shape[:-1] == x.shape[:-1]
+    assert y.shape[-1] == 4
+    assert np.all(np.isfinite(np.asarray(y)))
+    assert np.all(np.isfinite(np.asarray(dx)))
+
+
+def test_causal_conv1d_is_causal_and_uses_effective_dilated_padding():
+    layer = YatConv1D(
+        1,
+        3,
+        padding="causal",
+        dilation_rate=2,
+        use_bias=False,
+        use_alpha=False,
+        kernel_initializer="ones",
+    )
+    x = jnp.arange(1, 9, dtype=jnp.float32).reshape(1, 8, 1)
+    changed_future = x.at[:, 5:, :].set(10_000.0)
+
+    y = layer(x)
+    changed_y = layer(changed_future)
+
+    assert y.shape == (1, 8, 1)
+    np.testing.assert_allclose(np.asarray(y[:, :5]), np.asarray(changed_y[:, :5]))
+    assert layer.compute_output_shape((None, None, 1)) == (None, None, 1)
+
+
+def test_conv1d_rejects_stride_and_dilation_combination():
+    with pytest.raises(ValueError, match="strides > 1"):
+        YatConv1D(2, 3, strides=2, dilation_rate=2, padding="causal")
+
+
+@pytest.mark.parametrize(
+    ("layer_cls", "input_shape"),
+    [
+        (YatConv1D, (2, 9, 2)),
+        (YatConv2D, (2, 9, 8, 2)),
+        (YatConv3D, (2, 8, 7, 6, 2)),
+        (YatConvTranspose1D, (2, 5, 2)),
+        (YatConvTranspose2D, (2, 5, 4, 2)),
+        (YatConvTranspose3D, (2, 4, 4, 3, 2)),
+    ],
+)
+@pytest.mark.parametrize(
+    ("padding", "stride_value", "dilation_value"),
+    [("valid", 1, 2), ("same", 2, 1)],
+)
+def test_dilation_aware_output_shape_matches_runtime(
+    layer_cls, input_shape, padding, stride_value, dilation_value
+):
+    rank = len(input_shape) - 2
+    layer = layer_cls(
+        3,
+        (3,) * rank,
+        padding=padding,
+        strides=(stride_value,) * rank,
+        dilation_rate=(dilation_value,) * rank,
+        use_bias=False,
+    )
+    x = jnp.ones(input_shape, dtype=jnp.float32)
+
+    assert tuple(layer(x).shape) == tuple(layer.compute_output_shape(input_shape))
+
+    unknown = (None,) + (None,) * rank + (input_shape[-1],)
+    expected = (None,) + (None,) * rank + (3,)
+    assert tuple(layer.compute_output_shape(unknown)) == expected
+
+
+@pytest.mark.parametrize(
+    ("layer_cls", "input_shape"),
+    [
+        (YatConv1D, (1, 5, 2)),
+        (YatConv2D, (1, 5, 5, 2)),
+        (YatConv3D, (1, 5, 5, 5, 2)),
+        (YatConvTranspose1D, (1, 5, 2)),
+        (YatConvTranspose2D, (1, 5, 5, 2)),
+        (YatConvTranspose3D, (1, 5, 5, 5, 2)),
+    ],
+)
+def test_kernel_bank_expansion_is_rejected_without_mutation(layer_cls, input_shape):
+    layer_cls._KERNEL_BANKS.clear()
+    rank = len(input_shape) - 2
+    kwargs = dict(
+        filters=2,
+        kernel_size=(1,) * rank,
+        tie_kernel_bank=True,
+        kernel_bank_size=3,
+        kernel_bank_id=f"regression-{layer_cls.__name__}",
+        kernel_initializer="ones",
+    )
+    first = layer_cls(**kwargs)
+    first(jnp.ones(input_shape))
+    before = np.asarray(first.kernel)
+
+    compatible = layer_cls(**{**kwargs, "filters": 1})
+    compatible(jnp.ones(input_shape))
+    assert compatible.kernel is first.kernel
+    assert any(variable is first.kernel for variable in compatible.trainable_weights)
+
+    too_large = layer_cls(**{**kwargs, "filters": 4, "kernel_bank_size": 4})
+    with pytest.raises(ValueError, match="cannot be expanded in place"):
+        too_large(jnp.ones(input_shape))
+
+    np.testing.assert_array_equal(np.asarray(first.kernel), before)
+    assert first.kernel.shape == before.shape
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_low_precision_exact_matches_are_finite_with_finite_gradients(dtype):
+    numeric_dtype = getattr(jnp, dtype)
+    query = jnp.asarray([[[0.5], [-0.25], [0.75]]], dtype=numeric_dtype)
+    kernel = jnp.reshape(query, (3, 1, 1))
+    conv = YatConv1D(
+        1,
+        3,
+        use_bias=False,
+        use_alpha=False,
+        dtype=dtype,
+        kernel_initializer="zeros",
+    )
+    conv(query)
+    conv.kernel.assign(kernel)
+
+    conv_output = conv(query)
+    conv_grad = jax.grad(lambda value: jnp.sum(conv(value)))(query)
+
+    embed = YatEmbed(
+        1,
+        3,
+        use_alpha=False,
+        dtype=dtype,
+        embedding_initializer="zeros",
+    )
+    embed(jnp.array([0]))
+    embed.embedding.assign(jnp.reshape(query, (1, 3)))
+    embed_query = jnp.reshape(query, (1, 3))
+    embed_output = embed.attend(embed_query)
+    embed_grad = jax.grad(lambda value: jnp.sum(embed.attend(value)))(embed_query)
+
+    for value in (conv_output, conv_grad, embed_output, embed_grad):
+        array = np.asarray(value)
+        assert np.all(np.isfinite(array))
+    assert np.all(np.asarray(conv_output) >= 0)
+    assert np.all(np.asarray(embed_output) >= 0)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "rtol", "atol"),
+    [("float16", 3e-2, 3e-2), ("bfloat16", 8e-2, 8e-2)],
+)
+def test_low_precision_conv_and_embedding_track_fp32_off_collision(dtype, rtol, atol):
+    x32 = jnp.asarray([[[0.2], [-0.3], [0.4], [0.1]]], dtype=jnp.float32)
+    kernel32 = jnp.asarray([[[0.35]], [[-0.1]]], dtype=jnp.float32)
+
+    def make_conv(policy):
+        layer = YatConv1D(
+            1,
+            2,
+            use_bias=False,
+            use_alpha=False,
+            dtype=policy,
+            kernel_initializer="zeros",
+        )
+        layer(ops_cast(x32, policy))
+        layer.kernel.assign(ops_cast(kernel32, policy))
+        return layer
+
+    conv32 = make_conv("float32")
+    conv_low = make_conv(dtype)
+    np.testing.assert_allclose(
+        np.asarray(conv_low(ops_cast(x32, dtype))),
+        np.asarray(conv32(x32)),
+        rtol=rtol,
+        atol=atol,
+    )
+
+    embedding32 = jnp.asarray([[0.2, -0.1, 0.3], [-0.4, 0.25, 0.1]])
+    query32 = jnp.asarray([[0.15, 0.35, -0.2]])
+
+    def make_embed(policy):
+        layer = YatEmbed(
+            2,
+            3,
+            use_alpha=False,
+            dtype=policy,
+            embedding_initializer="zeros",
+        )
+        layer(jnp.array([0]))
+        layer.embedding.assign(ops_cast(embedding32, policy))
+        return layer
+
+    embed32 = make_embed("float32")
+    embed_low = make_embed(dtype)
+    np.testing.assert_allclose(
+        np.asarray(embed_low.attend(ops_cast(query32, dtype))),
+        np.asarray(embed32.attend(query32)),
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def ops_cast(value, dtype):
+    """Cast through JAX without importing backend-specific Keras internals."""
+    return jnp.asarray(value, dtype=getattr(jnp, dtype))
+
+
+@pytest.mark.parametrize("layer", [YatEmbed(8, 4), MultiHeadYatAttention(4, 2)])
+def test_registered_layers_round_trip_without_custom_objects(layer):
+    serialized = keras.saving.serialize_keras_object(layer)
+    restored = keras.saving.deserialize_keras_object(serialized)
+
+    assert type(restored) is type(layer)
+    assert restored.get_config() == layer.get_config()
+    assert serialized["registered_name"].startswith("nmn>")
+
+
+def test_registered_layers_clone_and_full_model_round_trip(tmp_path):
+    inputs = keras.Input((3,), dtype="int32")
+    embedded = YatEmbed(
+        8,
+        4,
+        constant_alpha=True,
+        dtype="float32",
+        name="yat_embed",
+    )(inputs)
+    outputs = MultiHeadYatAttention(
+        4,
+        2,
+        constant_alpha=1.25,
+        normalize_qk=True,
+        name="yat_attention",
+    )(embedded)
+    model = keras.Model(inputs, outputs)
+    sample = jnp.asarray([[0, 1, 2]], dtype=jnp.int32)
+    reference = np.asarray(model(sample))
+
+    clone = keras.models.clone_model(model)
+    clone.set_weights(model.get_weights())
+    np.testing.assert_allclose(np.asarray(clone(sample)), reference, rtol=1e-6)
+
+    path = tmp_path / "registered.keras"
+    model.save(path)
+    restored = keras.models.load_model(path)
+    np.testing.assert_allclose(np.asarray(restored(sample)), reference, rtol=1e-6)
+    assert restored.get_layer("yat_embed").constant_alpha is True
+    assert restored.get_layer("yat_embed").dtype_policy.name == "float32"
+    assert restored.get_layer("yat_attention").constant_alpha == 1.25
+
+
+def test_keras_extra_declares_keras3_without_tensorflow():
+    metadata = tomllib.loads(
+        (Path(__file__).parents[2] / "pyproject.toml").read_text()
+    )["project"]["optional-dependencies"]
+
+    assert metadata["keras"] == ["keras>=3.0.0"]
+    assert all("tensorflow" not in requirement.lower() for requirement in metadata["keras"])
+    assert any("tensorflow" in requirement.lower() for requirement in metadata["tf"])

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 import threading
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10 compatibility
+    import tomli as tomllib
 
 import keras
 import numpy as np

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-import jax
-import jax.numpy as jnp
 import keras
 import numpy as np
 import pytest
@@ -22,6 +20,27 @@ from nmn.keras import (
     YatEmbed,
 )
 
+BACKEND = keras.backend.backend()
+
+
+def tensor(value, dtype="float32"):
+    return keras.ops.convert_to_tensor(np.asarray(value), dtype=dtype)
+
+
+def input_gradient(layer, value):
+    if BACKEND == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        return jax.grad(lambda x: jnp.sum(layer(x)))(value)
+    if BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        with tf.GradientTape() as tape:
+            tape.watch(value)
+            loss = tf.reduce_sum(layer(value))
+        return tape.gradient(loss, value)
+    pytest.skip("gradient assertion is implemented for JAX and TensorFlow backends")
+
 
 @pytest.mark.parametrize(
     ("layer_cls", "input_shape"),
@@ -34,11 +53,11 @@ from nmn.keras import (
 def test_grouped_convolutions_have_per_group_patch_norms_and_gradients(
     layer_cls, input_shape
 ):
-    x = jax.random.normal(jax.random.key(len(input_shape)), input_shape)
+    x = keras.random.normal(input_shape, seed=len(input_shape))
     layer = layer_cls(4, 3, groups=2, padding="same", use_bias=False)
 
     y = layer(x)
-    dx = jax.grad(lambda value: jnp.sum(layer(value)))(x)
+    dx = input_gradient(layer, x)
 
     assert y.shape[:-1] == x.shape[:-1]
     assert y.shape[-1] == 4
@@ -56,8 +75,11 @@ def test_causal_conv1d_is_causal_and_uses_effective_dilated_padding():
         use_alpha=False,
         kernel_initializer="ones",
     )
-    x = jnp.arange(1, 9, dtype=jnp.float32).reshape(1, 8, 1)
-    changed_future = x.at[:, 5:, :].set(10_000.0)
+    x_array = np.arange(1, 9, dtype=np.float32).reshape(1, 8, 1)
+    changed_array = x_array.copy()
+    changed_array[:, 5:, :] = 10_000.0
+    x = tensor(x_array)
+    changed_future = tensor(changed_array)
 
     y = layer(x)
     changed_y = layer(changed_future)
@@ -99,7 +121,7 @@ def test_dilation_aware_output_shape_matches_runtime(
         dilation_rate=(dilation_value,) * rank,
         use_bias=False,
     )
-    x = jnp.ones(input_shape, dtype=jnp.float32)
+    x = keras.ops.ones(input_shape, dtype="float32")
 
     assert tuple(layer(x).shape) == tuple(layer.compute_output_shape(input_shape))
 
@@ -131,41 +153,144 @@ def test_kernel_bank_expansion_is_rejected_without_mutation(layer_cls, input_sha
         kernel_initializer="ones",
     )
     first = layer_cls(**kwargs)
-    first(jnp.ones(input_shape))
+    first(keras.ops.ones(input_shape))
     before = np.asarray(first.kernel)
 
     compatible = layer_cls(**{**kwargs, "filters": 1})
-    compatible(jnp.ones(input_shape))
+    compatible(keras.ops.ones(input_shape))
     assert compatible.kernel is first.kernel
     assert any(variable is first.kernel for variable in compatible.trainable_weights)
 
     too_large = layer_cls(**{**kwargs, "filters": 4, "kernel_bank_size": 4})
     with pytest.raises(ValueError, match="cannot be expanded in place"):
-        too_large(jnp.ones(input_shape))
+        too_large(keras.ops.ones(input_shape))
 
     np.testing.assert_array_equal(np.asarray(first.kernel), before)
     assert first.kernel.shape == before.shape
 
 
+@pytest.mark.parametrize(
+    "layer_cls",
+    [
+        YatConv1D,
+        YatConv2D,
+        YatConv3D,
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    ],
+)
+def test_kernel_bank_capacity_smaller_than_filters_is_rejected_before_state(layer_cls):
+    layer_cls._KERNEL_BANKS.clear()
+    rank = 1 if "1D" in layer_cls.__name__ else 2 if "2D" in layer_cls.__name__ else 3
+
+    with pytest.raises(ValueError, match="must be greater than or equal to filters"):
+        layer_cls(
+            3,
+            (1,) * rank,
+            tie_kernel_bank=True,
+            kernel_bank_size=2,
+            kernel_bank_id="invalid-capacity",
+        )
+
+    assert not layer_cls._KERNEL_BANKS
+
+
+def test_tied_kernel_bank_functional_save_load_preserves_sharing_and_optimizer(tmp_path):
+    YatConv1D._KERNEL_BANKS.clear()
+    inputs = keras.Input((5, 1))
+    common = dict(
+        kernel_size=1,
+        tie_kernel_bank=True,
+        kernel_bank_size=3,
+        kernel_bank_id="functional-round-trip",
+        use_bias=False,
+        use_alpha=False,
+        kernel_initializer="ones",
+    )
+    first_layer = YatConv1D(2, name="bank_first", **common)
+    second_layer = YatConv1D(1, name="bank_second", **common)
+    outputs = keras.layers.Concatenate()([first_layer(inputs), second_layer(inputs)])
+    model = keras.Model(inputs, outputs)
+    model.compile(optimizer=keras.optimizers.SGD(0.01), loss="mse")
+    sample = tensor(np.arange(5, dtype=np.float32).reshape(1, 5, 1))
+    target = keras.ops.zeros((1, 5, 3))
+    model.train_on_batch(sample, target)
+    reference = np.asarray(model(sample))
+
+    assert first_layer.kernel is second_layer.kernel
+    assert len(first_layer.trainable_weights) == 1
+    assert len(second_layer.trainable_weights) == 1
+    assert len(model.trainable_variables) == 1
+    iterations = int(np.asarray(model.optimizer.iterations))
+
+    clone = keras.models.clone_model(model)
+    clone.set_weights(model.get_weights())
+    assert (
+        clone.get_layer("bank_first").kernel
+        is clone.get_layer("bank_second").kernel
+    )
+    np.testing.assert_allclose(np.asarray(clone(sample)), reference, rtol=1e-6)
+
+    path = tmp_path / "tied-bank.keras"
+    model.save(path)
+    restored = keras.models.load_model(path)
+    restored_first = restored.get_layer("bank_first")
+    restored_second = restored.get_layer("bank_second")
+
+    assert restored_first.kernel is restored_second.kernel
+    assert len(restored_first.trainable_weights) == 1
+    assert len(restored_second.trainable_weights) == 1
+    assert len(restored.trainable_variables) == 1
+    assert int(np.asarray(restored.optimizer.iterations)) == iterations
+    np.testing.assert_allclose(np.asarray(restored(sample)), reference, rtol=1e-6)
+    np.testing.assert_allclose(
+        np.asarray(restored_first.kernel), np.asarray(first_layer.kernel), rtol=1e-6
+    )
+
+
+@pytest.mark.parametrize(
+    "layer_cls",
+    [
+        YatConv1D,
+        YatConv2D,
+        YatConv3D,
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    ],
+)
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
-def test_low_precision_exact_matches_are_finite_with_finite_gradients(dtype):
-    numeric_dtype = getattr(jnp, dtype)
-    query = jnp.asarray([[[0.5], [-0.25], [0.75]]], dtype=numeric_dtype)
-    kernel = jnp.reshape(query, (3, 1, 1))
-    conv = YatConv1D(
+def test_low_precision_exact_matches_are_finite_for_every_conv_family(
+    layer_cls, dtype
+):
+    rank = 1 if "1D" in layer_cls.__name__ else 2 if "2D" in layer_cls.__name__ else 3
+    input_shape = (1,) + (1,) * rank + (1,)
+    value = tensor(np.full(input_shape, 0.5), dtype)
+    layer = layer_cls(
         1,
-        3,
+        (1,) * rank,
         use_bias=False,
         use_alpha=False,
         dtype=dtype,
-        kernel_initializer="zeros",
     )
-    conv(query)
-    conv.kernel.assign(kernel)
 
-    conv_output = conv(query)
-    conv_grad = jax.grad(lambda value: jnp.sum(conv(value)))(query)
+    # The default orthogonal initializer must build on JAX low-precision
+    # policies without dispatching unsupported float16/bfloat16 LAPACK.
+    layer(value)
+    layer.kernel.assign(tensor(np.full(layer.kernel.shape, 0.5), dtype))
+    output = layer(value)
+    gradient = input_gradient(layer, value)
 
+    assert keras.backend.standardize_dtype(output.dtype) == dtype
+    assert np.all(np.isfinite(np.asarray(output)))
+    assert np.all(np.asarray(output) >= 0)
+    assert np.all(np.isfinite(np.asarray(gradient)))
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_low_precision_embedding_exact_match_preserves_policy_and_gradients(dtype):
+    query = tensor([[0.5, -0.25, 0.75]], dtype)
     embed = YatEmbed(
         1,
         3,
@@ -173,31 +298,58 @@ def test_low_precision_exact_matches_are_finite_with_finite_gradients(dtype):
         dtype=dtype,
         embedding_initializer="zeros",
     )
-    embed(jnp.array([0]))
-    embed.embedding.assign(jnp.reshape(query, (1, 3)))
-    embed_query = jnp.reshape(query, (1, 3))
-    embed_output = embed.attend(embed_query)
-    embed_grad = jax.grad(lambda value: jnp.sum(embed.attend(value)))(embed_query)
+    embed(keras.ops.convert_to_tensor([0], dtype="int32"))
+    embed.embedding.assign(query)
+    output = embed.attend(query)
 
-    for value in (conv_output, conv_grad, embed_output, embed_grad):
-        array = np.asarray(value)
-        assert np.all(np.isfinite(array))
-    assert np.all(np.asarray(conv_output) >= 0)
-    assert np.all(np.asarray(embed_output) >= 0)
+    if BACKEND == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        gradient = jax.grad(lambda x: jnp.sum(embed.attend(x)))(query)
+    elif BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        with tf.GradientTape() as tape:
+            tape.watch(query)
+            loss = tf.reduce_sum(embed.attend(query))
+        gradient = tape.gradient(loss, query)
+    else:
+        pytest.skip("gradient assertion is implemented for JAX and TensorFlow")
+
+    assert keras.backend.standardize_dtype(output.dtype) == dtype
+    assert np.all(np.isfinite(np.asarray(output)))
+    assert np.all(np.asarray(output) >= 0)
+    assert np.all(np.isfinite(np.asarray(gradient)))
 
 
 @pytest.mark.parametrize(
     ("dtype", "rtol", "atol"),
     [("float16", 3e-2, 3e-2), ("bfloat16", 8e-2, 8e-2)],
 )
-def test_low_precision_conv_and_embedding_track_fp32_off_collision(dtype, rtol, atol):
-    x32 = jnp.asarray([[[0.2], [-0.3], [0.4], [0.1]]], dtype=jnp.float32)
-    kernel32 = jnp.asarray([[[0.35]], [[-0.1]]], dtype=jnp.float32)
+@pytest.mark.parametrize(
+    "layer_cls",
+    [
+        YatConv1D,
+        YatConv2D,
+        YatConv3D,
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    ],
+)
+def test_low_precision_conv_families_track_fp32_off_collision(
+    layer_cls, dtype, rtol, atol
+):
+    rank = 1 if "1D" in layer_cls.__name__ else 2 if "2D" in layer_cls.__name__ else 3
+    input_shape = (1,) + (2,) * rank + (1,)
+    x32 = tensor(np.full(input_shape, 0.2))
+    kernel_shape = (1,) * rank + (1, 1)
+    kernel32 = tensor(np.full(kernel_shape, 0.35))
 
     def make_conv(policy):
-        layer = YatConv1D(
+        layer = layer_cls(
             1,
-            2,
+            (1,) * rank,
             use_bias=False,
             use_alpha=False,
             dtype=policy,
@@ -216,8 +368,14 @@ def test_low_precision_conv_and_embedding_track_fp32_off_collision(dtype, rtol, 
         atol=atol,
     )
 
-    embedding32 = jnp.asarray([[0.2, -0.1, 0.3], [-0.4, 0.25, 0.1]])
-    query32 = jnp.asarray([[0.15, 0.35, -0.2]])
+
+@pytest.mark.parametrize(
+    ("dtype", "rtol", "atol"),
+    [("float16", 3e-2, 3e-2), ("bfloat16", 8e-2, 8e-2)],
+)
+def test_low_precision_embedding_tracks_fp32_off_collision(dtype, rtol, atol):
+    embedding32 = tensor([[0.2, -0.1, 0.3], [-0.4, 0.25, 0.1]])
+    query32 = tensor([[0.15, 0.35, -0.2]])
 
     def make_embed(policy):
         layer = YatEmbed(
@@ -227,7 +385,7 @@ def test_low_precision_conv_and_embedding_track_fp32_off_collision(dtype, rtol, 
             dtype=policy,
             embedding_initializer="zeros",
         )
-        layer(jnp.array([0]))
+        layer(keras.ops.convert_to_tensor([0], dtype="int32"))
         layer.embedding.assign(ops_cast(embedding32, policy))
         return layer
 
@@ -242,8 +400,7 @@ def test_low_precision_conv_and_embedding_track_fp32_off_collision(dtype, rtol, 
 
 
 def ops_cast(value, dtype):
-    """Cast through JAX without importing backend-specific Keras internals."""
-    return jnp.asarray(value, dtype=getattr(jnp, dtype))
+    return keras.ops.cast(value, dtype)
 
 
 @pytest.mark.parametrize("layer", [YatEmbed(8, 4), MultiHeadYatAttention(4, 2)])
@@ -273,7 +430,7 @@ def test_registered_layers_clone_and_full_model_round_trip(tmp_path):
         name="yat_attention",
     )(embedded)
     model = keras.Model(inputs, outputs)
-    sample = jnp.asarray([[0, 1, 2]], dtype=jnp.int32)
+    sample = keras.ops.convert_to_tensor([[0, 1, 2]], dtype="int32")
     reference = np.asarray(model(sample))
 
     clone = keras.models.clone_model(model)

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -131,7 +131,37 @@ def test_dilation_aware_output_shape_matches_runtime(
     )
     x = keras.ops.ones(input_shape, dtype="float32")
 
-    assert tuple(layer(x).shape) == tuple(layer.compute_output_shape(input_shape))
+    is_transpose = layer_cls in (
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    )
+    effective_kernel = dilation_value * 2 + 1
+    if is_transpose:
+        expected_spatial = tuple(
+            size * stride_value
+            if padding == "same"
+            else (size - 1) * stride_value + effective_kernel
+            for size in input_shape[1:-1]
+        )
+    else:
+        expected_spatial = tuple(
+            (size + stride_value - 1) // stride_value
+            if padding == "same"
+            else (size - effective_kernel) // stride_value + 1
+            for size in input_shape[1:-1]
+        )
+    computed = tuple(layer.compute_output_shape(input_shape))
+    assert computed == (input_shape[0], *expected_spatial, 3)
+
+    # TensorFlow CPU does not implement dilated transposed convolution.  The
+    # canonical shape formula above remains backend-neutral; runtime parity is
+    # exercised for this case by the JAX and Torch clean-environment jobs.
+    tensorflow_cpu_limitation = (
+        BACKEND == "tensorflow" and is_transpose and dilation_value > 1
+    )
+    if not tensorflow_cpu_limitation:
+        assert tuple(layer(x).shape) == computed
 
     unknown = (None,) + (None,) * rank + (input_shape[-1],)
     expected = (None,) + (None,) * rank + (3,)

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -30,6 +30,11 @@ def tensor(value, dtype="float32"):
     return keras.ops.convert_to_tensor(np.asarray(value), dtype=dtype)
 
 
+def to_numpy(value, dtype=None):
+    array = keras.ops.convert_to_numpy(value)
+    return np.asarray(array, dtype=dtype) if dtype is not None else array
+
+
 def input_gradient(layer, value):
     if BACKEND == "jax":
         import jax
@@ -64,8 +69,8 @@ def test_grouped_convolutions_have_per_group_patch_norms_and_gradients(
 
     assert y.shape[:-1] == x.shape[:-1]
     assert y.shape[-1] == 4
-    assert np.all(np.isfinite(np.asarray(y)))
-    assert np.all(np.isfinite(np.asarray(dx)))
+    assert np.all(np.isfinite(to_numpy(y)))
+    assert np.all(np.isfinite(to_numpy(dx)))
 
 
 def test_causal_conv1d_is_causal_and_uses_effective_dilated_padding():
@@ -88,7 +93,7 @@ def test_causal_conv1d_is_causal_and_uses_effective_dilated_padding():
     changed_y = layer(changed_future)
 
     assert y.shape == (1, 8, 1)
-    np.testing.assert_allclose(np.asarray(y[:, :5]), np.asarray(changed_y[:, :5]))
+    np.testing.assert_allclose(to_numpy(y[:, :5]), to_numpy(changed_y[:, :5]))
     assert layer.compute_output_shape((None, None, 1)) == (None, None, 1)
 
 
@@ -157,7 +162,7 @@ def test_kernel_bank_expansion_is_rejected_without_mutation(layer_cls, input_sha
     )
     first = layer_cls(**kwargs)
     first(keras.ops.ones(input_shape))
-    before = np.asarray(first.kernel)
+    before = to_numpy(first.kernel)
 
     compatible = layer_cls(**{**kwargs, "filters": 1})
     compatible(keras.ops.ones(input_shape))
@@ -168,7 +173,7 @@ def test_kernel_bank_expansion_is_rejected_without_mutation(layer_cls, input_sha
     with pytest.raises(ValueError, match="cannot be expanded in place"):
         too_large(keras.ops.ones(input_shape))
 
-    np.testing.assert_array_equal(np.asarray(first.kernel), before)
+    np.testing.assert_array_equal(to_numpy(first.kernel), before)
     assert first.kernel.shape == before.shape
 
 
@@ -219,13 +224,13 @@ def test_tied_kernel_bank_functional_save_load_preserves_sharing_and_optimizer(t
     sample = tensor(np.arange(5, dtype=np.float32).reshape(1, 5, 1))
     target = keras.ops.zeros((1, 5, 3))
     model.train_on_batch(sample, target)
-    reference = np.asarray(model(sample))
+    reference = to_numpy(model(sample))
 
     assert first_layer.kernel is second_layer.kernel
     assert len(first_layer.trainable_weights) == 1
     assert len(second_layer.trainable_weights) == 1
     assert len(model.trainable_variables) == 1
-    iterations = int(np.asarray(model.optimizer.iterations))
+    iterations = int(to_numpy(model.optimizer.iterations))
 
     clone = keras.models.clone_model(model)
     clone.set_weights(model.get_weights())
@@ -233,7 +238,7 @@ def test_tied_kernel_bank_functional_save_load_preserves_sharing_and_optimizer(t
         clone.get_layer("bank_first").kernel
         is clone.get_layer("bank_second").kernel
     )
-    np.testing.assert_allclose(np.asarray(clone(sample)), reference, rtol=1e-6)
+    np.testing.assert_allclose(to_numpy(clone(sample)), reference, rtol=1e-6)
 
     path = tmp_path / "tied-bank.keras"
     model.save(path)
@@ -245,10 +250,10 @@ def test_tied_kernel_bank_functional_save_load_preserves_sharing_and_optimizer(t
     assert len(restored_first.trainable_weights) == 1
     assert len(restored_second.trainable_weights) == 1
     assert len(restored.trainable_variables) == 1
-    assert int(np.asarray(restored.optimizer.iterations)) == iterations
-    np.testing.assert_allclose(np.asarray(restored(sample)), reference, rtol=1e-6)
+    assert int(to_numpy(restored.optimizer.iterations)) == iterations
+    np.testing.assert_allclose(to_numpy(restored(sample)), reference, rtol=1e-6)
     np.testing.assert_allclose(
-        np.asarray(restored_first.kernel), np.asarray(first_layer.kernel), rtol=1e-6
+        to_numpy(restored_first.kernel), to_numpy(first_layer.kernel), rtol=1e-6
     )
 
 
@@ -345,9 +350,9 @@ def test_low_precision_exact_matches_are_finite_for_every_conv_family(
     gradient = input_gradient(layer, value)
 
     assert keras.backend.standardize_dtype(output.dtype) == dtype
-    assert np.all(np.isfinite(np.asarray(output)))
-    assert np.all(np.asarray(output) >= 0)
-    assert np.all(np.isfinite(np.asarray(gradient)))
+    assert np.all(np.isfinite(to_numpy(output)))
+    assert np.all(to_numpy(output) >= 0)
+    assert np.all(np.isfinite(to_numpy(gradient)))
 
 
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
@@ -379,9 +384,9 @@ def test_low_precision_embedding_exact_match_preserves_policy_and_gradients(dtyp
         pytest.skip("gradient assertion is implemented for JAX and TensorFlow")
 
     assert keras.backend.standardize_dtype(output.dtype) == dtype
-    assert np.all(np.isfinite(np.asarray(output)))
-    assert np.all(np.asarray(output) >= 0)
-    assert np.all(np.isfinite(np.asarray(gradient)))
+    assert np.all(np.isfinite(to_numpy(output)))
+    assert np.all(to_numpy(output) >= 0)
+    assert np.all(np.isfinite(to_numpy(gradient)))
 
 
 @pytest.mark.skipif(BACKEND != "jax", reason="JAX cotangent regression")
@@ -398,7 +403,7 @@ def test_embed_shaped_exact_collision_reduces_epsilon_gradient_before_clipping(d
     gradient = jax.grad(lambda eps: jnp.sum(stable_yat_ratio(dot, distance, eps)))(
         epsilon
     )
-    gradient32 = np.asarray(gradient, dtype=np.float32)
+    gradient32 = to_numpy(gradient, dtype=np.float32)
 
     assert gradient.shape == epsilon.shape
     assert np.all(np.isfinite(gradient32))
@@ -406,7 +411,7 @@ def test_embed_shaped_exact_collision_reduces_epsilon_gradient_before_clipping(d
     if dtype == "float16":
         np.testing.assert_array_equal(gradient32, np.asarray(-65504.0))
     else:
-        epsilon32 = np.asarray(epsilon, dtype=np.float32)
+        epsilon32 = to_numpy(epsilon, dtype=np.float32)
         expected = -dot.size * 0.25 / np.square(epsilon32)
         np.testing.assert_allclose(gradient32, expected, rtol=2e-2)
 
@@ -446,8 +451,8 @@ def test_conv_exact_collision_has_finite_learnable_epsilon_gradient(dtype):
     gradient = jax.grad(loss)(trainable_values[epsilon_index])
 
     assert gradient.shape == layer.epsilon_param.shape
-    assert np.all(np.isfinite(np.asarray(gradient, dtype=np.float32)))
-    assert np.all(np.asarray(gradient, dtype=np.float32) < 0)
+    assert np.all(np.isfinite(to_numpy(gradient, dtype=np.float32)))
+    assert np.all(to_numpy(gradient, dtype=np.float32) < 0)
 
 
 @pytest.mark.parametrize(
@@ -490,8 +495,8 @@ def test_low_precision_conv_families_track_fp32_off_collision(
     conv32 = make_conv("float32")
     conv_low = make_conv(dtype)
     np.testing.assert_allclose(
-        np.asarray(conv_low(ops_cast(x32, dtype))),
-        np.asarray(conv32(x32)),
+        to_numpy(conv_low(ops_cast(x32, dtype))),
+        to_numpy(conv32(x32)),
         rtol=rtol,
         atol=atol,
     )
@@ -520,8 +525,8 @@ def test_low_precision_embedding_tracks_fp32_off_collision(dtype, rtol, atol):
     embed32 = make_embed("float32")
     embed_low = make_embed(dtype)
     np.testing.assert_allclose(
-        np.asarray(embed_low.attend(ops_cast(query32, dtype))),
-        np.asarray(embed32.attend(query32)),
+        to_numpy(embed_low.attend(ops_cast(query32, dtype))),
+        to_numpy(embed32.attend(query32)),
         rtol=rtol,
         atol=atol,
     )
@@ -559,16 +564,16 @@ def test_registered_layers_clone_and_full_model_round_trip(tmp_path):
     )(embedded)
     model = keras.Model(inputs, outputs)
     sample = keras.ops.convert_to_tensor([[0, 1, 2]], dtype="int32")
-    reference = np.asarray(model(sample))
+    reference = to_numpy(model(sample))
 
     clone = keras.models.clone_model(model)
     clone.set_weights(model.get_weights())
-    np.testing.assert_allclose(np.asarray(clone(sample)), reference, rtol=1e-6)
+    np.testing.assert_allclose(to_numpy(clone(sample)), reference, rtol=1e-6)
 
     path = tmp_path / "registered.keras"
     model.save(path)
     restored = keras.models.load_model(path)
-    np.testing.assert_allclose(np.asarray(restored(sample)), reference, rtol=1e-6)
+    np.testing.assert_allclose(to_numpy(restored(sample)), reference, rtol=1e-6)
     assert restored.get_layer("yat_embed").constant_alpha is True
     assert restored.get_layer("yat_embed").dtype_policy.name == "float32"
     assert restored.get_layer("yat_attention").constant_alpha == 1.25

--- a/tests/test_keras/test_low_precision_reductions.py
+++ b/tests/test_keras/test_low_precision_reductions.py
@@ -1,0 +1,305 @@
+"""Regression tests for low-precision Keras reduction boundaries."""
+
+from __future__ import annotations
+
+import keras
+from keras import ops
+import numpy as np
+import pytest
+
+from nmn.keras import (
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatEmbed,
+)
+from nmn.keras._yat_core import stable_yat_ratio
+
+
+BACKEND = keras.backend.backend()
+SUPPORTED_GRADIENT_BACKENDS = {"jax", "torch", "tensorflow"}
+CONV_CLASSES = (
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+
+
+def to_numpy(value):
+    return ops.convert_to_numpy(value)
+
+
+def rank_for(layer_cls):
+    if "1D" in layer_cls.__name__:
+        return 1
+    if "2D" in layer_cls.__name__:
+        return 2
+    return 3
+
+
+def is_transpose(layer_cls):
+    return "Transpose" in layer_cls.__name__
+
+
+def make_conv(layer_cls, dtype, epsilon, value, kernel_value):
+    rank = rank_for(layer_cls)
+    shape = (2,) + (3,) * rank + (2,)
+    inputs = ops.full(shape, value, dtype=dtype)
+    layer = layer_cls(
+        3,
+        (1,) * rank,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=epsilon,
+        learnable_epsilon=True,
+        kernel_initializer="zeros",
+        dtype=dtype,
+    )
+    layer(inputs)
+    if is_transpose(layer_cls):
+        kernel_shape = (1,) * rank + (3, 2)
+    else:
+        kernel_shape = (1,) * rank + (2, 3)
+    layer.kernel.assign(ops.full(kernel_shape, kernel_value, dtype=dtype))
+    return layer, inputs
+
+
+def keras_layer_value_and_gradients(layer, inputs):
+    """Return output plus input/kernel/epsilon gradients on JAX or Torch."""
+    if BACKEND == "jax":
+        import jax
+
+        variables = list(layer.trainable_variables)
+        values = [variable.value for variable in variables]
+        kernel_index = next(
+            i for i, variable in enumerate(variables) if variable is layer.kernel
+        )
+        epsilon_index = next(
+            i for i, variable in enumerate(variables) if variable is layer.epsilon_param
+        )
+
+        def evaluate(input_value, kernel_value, epsilon_value):
+            current = list(values)
+            current[kernel_index] = kernel_value
+            current[epsilon_index] = epsilon_value
+            output, _ = layer.stateless_call(
+                current, layer.non_trainable_variables, input_value
+            )
+            return ops.sum(output), output
+
+        (_, output), gradients = jax.value_and_grad(
+            evaluate, argnums=(0, 1, 2), has_aux=True
+        )(inputs, values[kernel_index], values[epsilon_index])
+        return output, gradients
+
+    if BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        input_value = inputs.detach().clone().requires_grad_(True)
+        output = layer(input_value)
+        gradients = torch.autograd.grad(
+            output.sum(),
+            (input_value, layer.kernel.value, layer.epsilon_param.value),
+        )
+        return output, gradients
+
+    if BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        input_value = tf.Variable(inputs)
+        with tf.GradientTape() as tape:
+            output = layer(input_value)
+            loss = ops.sum(output)
+        gradients = tape.gradient(
+            loss, (input_value, layer.kernel.value, layer.epsilon_param.value)
+        )
+        return output, gradients
+
+    pytest.skip("gradient regression requires a supported Keras autodiff backend")
+
+
+def keras_embed_value_and_gradients(layer, query):
+    if BACKEND == "jax":
+        import jax
+
+        variables = list(layer.trainable_variables)
+        values = [variable.value for variable in variables]
+        embedding_index = next(
+            i for i, variable in enumerate(variables) if variable is layer.embedding
+        )
+
+        def evaluate(query_value, embedding_value):
+            current = list(values)
+            current[embedding_index] = embedding_value
+            state_mapping = list(zip(variables, current))
+            with keras.StatelessScope(state_mapping):
+                output = layer.attend(query_value)
+            return ops.sum(output), output
+
+        (_, output), gradients = jax.value_and_grad(
+            evaluate, argnums=(0, 1), has_aux=True
+        )(query, values[embedding_index])
+        return output, gradients
+
+    if BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        query_value = query.detach().clone().requires_grad_(True)
+        output = layer.attend(query_value)
+        gradients = torch.autograd.grad(
+            output.sum(), (query_value, layer.embedding.value)
+        )
+        return output, gradients
+
+    if BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        query_value = tf.Variable(query)
+        with tf.GradientTape() as tape:
+            output = layer.attend(query_value)
+            loss = ops.sum(output)
+        gradients = tape.gradient(loss, (query_value, layer.embedding.value))
+        return output, gradients
+
+    pytest.skip("gradient regression requires a supported Keras autodiff backend")
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+@pytest.mark.parametrize("layer_cls", CONV_CLASSES)
+def test_fp16_multi_output_exact_collision_conv_gradients_are_finite(layer_cls):
+    layer, inputs = make_conv(layer_cls, "float16", 1e-5, 0.5, 0.5)
+    output, gradients = keras_layer_value_and_gradients(layer, inputs)
+
+    assert keras.backend.standardize_dtype(output.dtype) == "float16"
+    assert to_numpy(output).shape[-1] == 3
+    assert np.all(np.isfinite(to_numpy(output)))
+    for gradient in gradients:
+        assert np.all(np.isfinite(to_numpy(gradient)))
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+def test_fp16_multi_row_multi_embedding_exact_collision_gradients_are_finite():
+    query = ops.full((3, 4), 0.25, dtype="float16")
+    layer = YatEmbed(
+        5,
+        4,
+        use_alpha=False,
+        epsilon=1e-5,
+        embedding_initializer="zeros",
+        dtype="float16",
+    )
+    layer(ops.convert_to_tensor([0], dtype="int32"))
+    layer.embedding.assign(ops.full((5, 4), 0.25, dtype="float16"))
+
+    output, gradients = keras_embed_value_and_gradients(layer, query)
+
+    assert keras.backend.standardize_dtype(output.dtype) == "float16"
+    assert output.shape == (3, 5)
+    assert np.all(np.isfinite(to_numpy(output)))
+    for gradient in gradients:
+        assert np.all(np.isfinite(to_numpy(gradient)))
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+@pytest.mark.parametrize("layer_cls", CONV_CLASSES)
+def test_fp16_conv_off_collision_matches_fp32_forward_and_gradients(layer_cls):
+    reference, reference_inputs = make_conv(layer_cls, "float32", 0.1, 0.2, 0.35)
+    lowp, lowp_inputs = make_conv(layer_cls, "float16", 0.1, 0.2, 0.35)
+
+    reference_output, reference_gradients = keras_layer_value_and_gradients(
+        reference, reference_inputs
+    )
+    lowp_output, lowp_gradients = keras_layer_value_and_gradients(lowp, lowp_inputs)
+
+    np.testing.assert_allclose(
+        to_numpy(lowp_output), to_numpy(reference_output), rtol=3e-2, atol=3e-2
+    )
+    for lowp_gradient, reference_gradient in zip(lowp_gradients, reference_gradients):
+        np.testing.assert_allclose(
+            to_numpy(lowp_gradient),
+            to_numpy(reference_gradient),
+            rtol=5e-2,
+            atol=5e-2,
+        )
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+def test_fp16_embedding_off_collision_matches_fp32_forward_and_gradients():
+    def make(dtype):
+        query = ops.full((3, 4), 0.2, dtype=dtype)
+        layer = YatEmbed(
+            5,
+            4,
+            use_alpha=False,
+            epsilon=0.1,
+            embedding_initializer="zeros",
+            dtype=dtype,
+        )
+        layer(ops.convert_to_tensor([0], dtype="int32"))
+        layer.embedding.assign(ops.full((5, 4), 0.35, dtype=dtype))
+        return layer, query
+
+    reference, reference_query = make("float32")
+    lowp, lowp_query = make("float16")
+    reference_output, reference_gradients = keras_embed_value_and_gradients(
+        reference, reference_query
+    )
+    lowp_output, lowp_gradients = keras_embed_value_and_gradients(lowp, lowp_query)
+
+    np.testing.assert_allclose(
+        to_numpy(lowp_output), to_numpy(reference_output), rtol=3e-2, atol=3e-2
+    )
+    for lowp_gradient, reference_gradient in zip(lowp_gradients, reference_gradients):
+        np.testing.assert_allclose(
+            to_numpy(lowp_gradient),
+            to_numpy(reference_gradient),
+            rtol=5e-2,
+            atol=5e-2,
+        )
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+def test_low_precision_ratio_preserves_nan():
+    initial = ops.convert_to_tensor([[np.nan, 0.5]], dtype="float16")
+
+    if BACKEND == "jax":
+        import jax
+
+        def evaluate(dot):
+            return ops.sum(stable_yat_ratio(dot, ops.zeros_like(dot), 1e-5))
+
+        output = stable_yat_ratio(initial, ops.zeros_like(initial), 1e-5)
+        gradient = jax.grad(evaluate)(initial)
+    elif BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        dot = initial.detach().clone().requires_grad_(True)
+        output = stable_yat_ratio(dot, ops.zeros_like(dot), 1e-5)
+        (gradient,) = torch.autograd.grad(output.sum(), (dot,))
+    else:
+        tf = pytest.importorskip("tensorflow")
+        dot = tf.Variable(initial)
+        with tf.GradientTape() as tape:
+            output = stable_yat_ratio(dot, ops.zeros_like(dot), 1e-5)
+            loss = ops.sum(output)
+        gradient = tape.gradient(loss, dot)
+
+    assert np.isnan(to_numpy(output)[0, 0])
+    assert np.isfinite(to_numpy(output)[0, 1])
+    assert np.isnan(to_numpy(gradient)[0, 0])

--- a/tests/test_keras/test_squashers.py
+++ b/tests/test_keras/test_squashers.py
@@ -7,6 +7,8 @@ keras = pytest.importorskip("keras")
 
 from nmn.keras.squashers import softermax, softer_sigmoid, soft_tanh
 
+to_numpy = keras.ops.convert_to_numpy
+
 
 class TestSoftermax:
     def test_output_shape(self):
@@ -16,13 +18,13 @@ class TestSoftermax:
 
     def test_sums_to_one(self):
         x = np.random.rand(4, 8).astype(np.float32)
-        out = np.array(softermax(x))
+        out = to_numpy(softermax(x))
         sums = out.sum(axis=-1)
         np.testing.assert_allclose(sums, np.ones(4), atol=1e-5)
 
     def test_no_nan(self):
         x = np.random.rand(2, 16).astype(np.float32)
-        out = np.array(softermax(x, n=2.0))
+        out = to_numpy(softermax(x, n=2.0))
         assert not np.any(np.isnan(out))
 
     def test_invalid_power(self):
@@ -33,13 +35,13 @@ class TestSoftermax:
 class TestSofterSigmoid:
     def test_output_range(self):
         x = np.random.rand(4, 8).astype(np.float32)
-        out = np.array(softer_sigmoid(x))
+        out = to_numpy(softer_sigmoid(x))
         assert np.all(out >= 0)
         assert np.all(out < 1)
 
     def test_zero_input(self):
         x = np.zeros(4, dtype=np.float32)
-        out = np.array(softer_sigmoid(x))
+        out = to_numpy(softer_sigmoid(x))
         np.testing.assert_allclose(out, np.zeros(4), atol=1e-6)
 
     def test_invalid_power(self):
@@ -50,18 +52,18 @@ class TestSofterSigmoid:
 class TestSoftTanh:
     def test_output_range(self):
         x = np.random.rand(4, 8).astype(np.float32)
-        out = np.array(soft_tanh(x))
+        out = to_numpy(soft_tanh(x))
         assert np.all(out >= -1)
         assert np.all(out < 1)
 
     def test_zero_gives_minus_one(self):
         x = np.zeros(4, dtype=np.float32)
-        out = np.array(soft_tanh(x))
+        out = to_numpy(soft_tanh(x))
         np.testing.assert_allclose(out, -np.ones(4))
 
     def test_one_gives_zero(self):
         x = np.ones(4, dtype=np.float32)
-        out = np.array(soft_tanh(x))
+        out = to_numpy(soft_tanh(x))
         np.testing.assert_allclose(out, np.zeros(4), atol=1e-6)
 
     def test_invalid_power(self):


### PR DESCRIPTION
Fixes #55
Fixes #56
Fixes #73
Fixes #74
Fixes #75
Fixes #76
Fixes #78

Stabilizes low-precision YAT reductions and aggregated gradients, completes grouped/causal/dilated convolution semantics and canonical shape inference, makes shared banks thread-safe and serializable, registers embedding/attention layers, and corrects the standalone Keras extra/docs.

Verification:
- Keras/JAX: 125 passed, 71 skipped
- Keras/Torch: 104 passed, 92 skipped
- independent exact-collision and fp32 forward/all-gradient parity review across all six conv/transpose classes plus embedding
- clone/.keras/optimizer-state and threaded shared-bank probes
- new isolated clean-environment JAX/Torch CI matrix

TensorFlow was unavailable locally; merge is contingent on all TensorFlow CI jobs passing.