### PR TITLE
fix(linen): align alpha and grouped convolution semantics

### DIFF
--- a/docs/guides/flax-linen.md
+++ b/docs/guides/flax-linen.md
@@ -151,6 +151,13 @@ class Block(nn.Module):
 
 `nmn.linen.MultiHeadAttention` mirrors `flax.linen.MultiHeadDotProductAttention` but with Yat-scored attention.
 
+Alpha always scales the Yat scores before attention normalization. This is the
+same operation whether alpha is learnable (`use_alpha=True`) or fixed
+(`constant_alpha=True` for $\sqrt{2}$, or `constant_alpha=1.5` for a custom
+value); switching between them changes trainability, not attention semantics.
+The default normalization is `"softmax"`; pass `normalization="l1"` for direct
+normalization of the non-negative Yat scores.
+
 ---
 
 ## 6. Saving & loading

--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -158,6 +158,9 @@ class MultiHeadAttention(Module):
         constant_alpha: If True, use sqrt(2). If float, use that value.
         normalize_qk: Whether to L2-normalize Q and K (default: False).
         spherical: If True, use spherical YAT formula (default: False).
+        normalization: Score normalization, either ``"softmax"`` (default) or
+            ``"l1"``. Constant and learnable alpha both scale scores before
+            this normalization.
         epsilon: Numerical stability constant (default: 1e-5).
         dtype: Computation dtype.
         param_dtype: Parameter dtype (default: float32).
@@ -174,6 +177,7 @@ class MultiHeadAttention(Module):
     constant_alpha: Optional[Any] = None
     normalize_qk: bool = False
     spherical: bool = False
+    normalization: str = "softmax"
     epsilon: float = 1e-5
     dtype: Optional[Any] = None
     param_dtype: Any = jnp.float32
@@ -258,13 +262,17 @@ class MultiHeadAttention(Module):
             k = k / (jnp.linalg.norm(k, axis=-1, keepdims=True) + 1e-8)
 
         # Alpha
-        _constant_alpha_value = None
         alpha_val = None
         if self.constant_alpha is not None and self.constant_alpha is not False:
             if self.constant_alpha is True:
-                _constant_alpha_value = DEFAULT_CONSTANT_ALPHA
+                constant_alpha_value = DEFAULT_CONSTANT_ALPHA
             else:
-                _constant_alpha_value = float(self.constant_alpha)
+                constant_alpha_value = float(self.constant_alpha)
+            # Constant and learnable alpha have identical semantics: both scale
+            # the YAT logits before attention normalization.  Keeping the
+            # constant as an array also lets ``promote_dtype`` honour the
+            # requested compute dtype.
+            alpha_val = jnp.asarray(constant_alpha_value, dtype=self.param_dtype)
         elif self.use_alpha:
             alpha_val = self.param("alpha", self.alpha_init, (1,), self.param_dtype)
 
@@ -278,11 +286,8 @@ class MultiHeadAttention(Module):
             deterministic=deterministic,
             epsilon=self.epsilon,
             alpha=alpha_val,
+            normalization=self.normalization,
         )
-
-        # Apply constant alpha
-        if _constant_alpha_value is not None:
-            x = x * _constant_alpha_value
 
         # Reshape back: (B, Q, H, D) -> (B, Q, E)
         x = x.reshape(x.shape[:-2] + (qkv_features,))

--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -9,7 +9,7 @@ Attention functions are re-exported from NNX (both use JAX).
 from __future__ import annotations
 
 import math
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional
 
 import jax.numpy as jnp
 from jax import Array
@@ -23,7 +23,6 @@ from nmn.nnx.layers.attention.yat_attention import (
     normalize_qk,
     yat_attention_weights as _nnx_yat_attention_weights,
     yat_attention as _nnx_yat_attention,
-    yat_attention_normalized as _nnx_yat_attention_normalized,
 )
 
 __all__ = [
@@ -177,13 +176,15 @@ class MultiHeadAttention(Module):
     constant_alpha: Optional[Any] = None
     normalize_qk: bool = False
     spherical: bool = False
-    normalization: str = "softmax"
     epsilon: float = 1e-5
     dtype: Optional[Any] = None
     param_dtype: Any = jnp.float32
     kernel_init: Any = nn.initializers.xavier_normal()
     bias_init: Any = nn.initializers.zeros_init()
     alpha_init: Any = lambda key, shape, dtype: jnp.ones(shape, dtype)
+    # Appended after every pre-existing field to preserve the positional
+    # constructor ABI of Linen dataclass modules.
+    normalization: str = "softmax"
 
     @compact
     def __call__(
@@ -206,6 +207,11 @@ class MultiHeadAttention(Module):
         Returns:
             Output (batch, q_len, out_features).
         """
+        if self.normalization not in ("softmax", "l1"):
+            raise ValueError(
+                "normalization must be either 'softmax' or 'l1', got "
+                f"{self.normalization!r}"
+            )
         if inputs_k is None:
             inputs_k = inputs_q
         if inputs_v is None:

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -14,6 +14,24 @@ from typing import Any, Optional, Sequence, Union, Tuple
 from ._yat_core import yat_score
 
 
+def _validate_feature_groups(
+    input_channels: int, output_channels: int, feature_group_count: int
+) -> None:
+    """Validate grouped-convolution channel partitions with clear errors."""
+    if feature_group_count <= 0:
+        raise ValueError("feature_group_count must be a positive integer.")
+    if input_channels % feature_group_count != 0:
+        raise ValueError(
+            f"Input channels ({input_channels}) must be divisible by "
+            f"feature_group_count ({feature_group_count})."
+        )
+    if output_channels % feature_group_count != 0:
+        raise ValueError(
+            f"features ({output_channels}) must be divisible by "
+            f"feature_group_count ({feature_group_count})."
+        )
+
+
 class YatConv1D(Module):
     """1D YAT convolution layer for Flax Linen.
     
@@ -65,6 +83,9 @@ class YatConv1D(Module):
             Output tensor after YAT convolution.
         """
         input_channels = inputs.shape[-1]
+        _validate_feature_groups(
+            input_channels, self.features, self.feature_group_count
+        )
         
         # Kernel shape: [kernel_size, input_channels // groups, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, self.features)
@@ -113,7 +134,14 @@ class YatConv1D(Module):
         
         # Compute ||input_patches||^2
         inputs_squared = inputs * inputs
-        ones_kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, 1)
+        # Grouped convolution needs one patch-norm output per input group.  A
+        # single output feature is invalid in XLA when feature_group_count > 1
+        # (rhs output features must be divisible by the group count), and would
+        # lose the mapping between each output filter and its input group.
+        ones_kernel_shape = tuple(self.kernel_size) + (
+            input_channels // self.feature_group_count,
+            self.feature_group_count,
+        )
         ones_kernel = jnp.ones(ones_kernel_shape, dtype=kernel.dtype)
         
         patch_sq_sum_raw = lax.conv_general_dilated(
@@ -194,6 +222,9 @@ class YatConv2D(Module):
             Output tensor after YAT convolution.
         """
         input_channels = inputs.shape[-1]
+        _validate_feature_groups(
+            input_channels, self.features, self.feature_group_count
+        )
         
         # Kernel shape: [height, width, input_channels // groups, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, self.features)
@@ -242,7 +273,10 @@ class YatConv2D(Module):
         
         # Compute ||input_patches||^2
         inputs_squared = inputs * inputs
-        ones_kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, 1)
+        ones_kernel_shape = tuple(self.kernel_size) + (
+            input_channels // self.feature_group_count,
+            self.feature_group_count,
+        )
         ones_kernel = jnp.ones(ones_kernel_shape, dtype=kernel.dtype)
         
         patch_sq_sum_raw = lax.conv_general_dilated(
@@ -324,6 +358,9 @@ class YatConv3D(Module):
             Output tensor after YAT convolution.
         """
         input_channels = inputs.shape[-1]
+        _validate_feature_groups(
+            input_channels, self.features, self.feature_group_count
+        )
         
         # Kernel shape: [depth, height, width, input_channels // groups, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, self.features)
@@ -372,7 +409,10 @@ class YatConv3D(Module):
         
         # Compute ||input_patches||^2
         inputs_squared = inputs * inputs
-        ones_kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, 1)
+        ones_kernel_shape = tuple(self.kernel_size) + (
+            input_channels // self.feature_group_count,
+            self.feature_group_count,
+        )
         ones_kernel = jnp.ones(ones_kernel_shape, dtype=kernel.dtype)
         
         patch_sq_sum_raw = lax.conv_general_dilated(
@@ -760,7 +800,5 @@ YatConv3d = YatConv3D
 YatConvTranspose1d = YatConvTranspose1D
 YatConvTranspose2d = YatConvTranspose2D
 YatConvTranspose3d = YatConvTranspose3D
-
-
 
 

--- a/tests/test_linen/test_regression_issues_51_52.py
+++ b/tests/test_linen/test_regression_issues_51_52.py
@@ -1,0 +1,222 @@
+"""Regression tests for Linen attention alpha and grouped YAT convolution."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+pytest.importorskip("flax")
+jnp = jax.numpy
+from flax.core import unfreeze  # noqa: E402
+
+from nmn.linen import (  # noqa: E402
+    MultiHeadAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+)
+
+
+def _assert_tree_allclose(actual, expected, *, rtol=2e-5, atol=2e-6):
+    assert jax.tree.structure(actual) == jax.tree.structure(expected)
+    for actual_leaf, expected_leaf in zip(
+        jax.tree.leaves(actual), jax.tree.leaves(expected)
+    ):
+        np.testing.assert_allclose(
+            np.asarray(actual_leaf), np.asarray(expected_leaf), rtol=rtol, atol=atol
+        )
+
+
+@pytest.mark.parametrize("normalization", ["softmax", "l1"])
+def test_attention_constant_and_matched_learnable_alpha_have_same_stage_and_vjp(
+    normalization,
+):
+    """A constant alpha must scale logits, exactly like a matched parameter."""
+    alpha = 1.75
+    common = dict(
+        num_heads=2,
+        qkv_features=8,
+        out_features=6,
+        use_bias=True,
+        dropout_rate=0.0,
+        normalization=normalization,
+    )
+    learnable = MultiHeadAttention(**common)
+    constant = MultiHeadAttention(**common, constant_alpha=alpha)
+
+    q = jax.random.normal(jax.random.key(1), (2, 3, 6))
+    k = jax.random.normal(jax.random.key(2), (2, 4, 6))
+    v = jax.random.normal(jax.random.key(3), (2, 4, 6))
+    learnable_params = unfreeze(
+        learnable.init(jax.random.key(0), q, k, v)["params"]
+    )
+    learnable_params["alpha"] = jnp.asarray([alpha], dtype=jnp.float32)
+
+    # Synchronize every shared projection parameter.  The constant model must
+    # not register an alpha parameter of its own.
+    constant_params = dict(learnable_params)
+    constant_params.pop("alpha")
+    assert "alpha" not in constant.init(jax.random.key(9), q, k, v)["params"]
+
+    learned_out = learnable.apply({"params": learnable_params}, q, k, v)
+    constant_out = constant.apply({"params": constant_params}, q, k, v)
+    np.testing.assert_allclose(learned_out, constant_out, rtol=1e-6, atol=1e-6)
+
+    cotangent = jnp.linspace(-0.7, 0.9, learned_out.size).reshape(learned_out.shape)
+
+    def learned_loss(params, q_arg, k_arg, v_arg):
+        return jnp.vdot(
+            learnable.apply({"params": params}, q_arg, k_arg, v_arg), cotangent
+        )
+
+    def constant_loss(params, q_arg, k_arg, v_arg):
+        return jnp.vdot(
+            constant.apply({"params": params}, q_arg, k_arg, v_arg), cotangent
+        )
+
+    learned_grads = jax.grad(learned_loss, argnums=(0, 1, 2, 3))(
+        learnable_params, q, k, v
+    )
+    constant_grads = jax.grad(constant_loss, argnums=(0, 1, 2, 3))(
+        constant_params, q, k, v
+    )
+    learned_param_grads = unfreeze(learned_grads[0])
+    learned_param_grads.pop("alpha")
+
+    _assert_tree_allclose(learned_param_grads, constant_grads[0])
+    _assert_tree_allclose(learned_grads[1:], constant_grads[1:])
+
+
+_GROUPED_CASES = [
+    (YatConv1D, (1, 6, 4), (2,), ("NWC", "WIO", "NWC"), 2, 6),
+    (YatConv2D, (1, 4, 5, 4), (2, 2), ("NHWC", "HWIO", "NHWC"), 2, 6),
+    (
+        YatConv3D,
+        (1, 3, 4, 4, 4),
+        (2, 2, 2),
+        ("NDHWC", "DHWIO", "NDHWC"),
+        2,
+        6,
+    ),
+    # Also cover more than two groups, so the channel mapping is not merely a
+    # two-way special case.
+    (YatConv1D, (1, 5, 8), (2,), ("NWC", "WIO", "NWC"), 4, 8),
+]
+
+
+def _grouped_reference(params, inputs, kernel_size, dimension_spec, groups):
+    del dimension_spec  # The explicit reference intentionally does not call lax.conv.
+    kernel = params["kernel"]
+    output_spatial = tuple(
+        input_size - kernel_extent + 1
+        for input_size, kernel_extent in zip(inputs.shape[1:-1], kernel_size)
+    )
+    input_channels_per_group = inputs.shape[-1] // groups
+    output_channels_per_group = kernel.shape[-1] // groups
+    positions = []
+
+    # Explicitly extract each receptive-field patch.  This reference avoids
+    # conv_general_dilated so it independently verifies the group-to-filter
+    # mapping in both the forward pass and autodiff.
+    for output_index in np.ndindex(output_spatial):
+        spatial_slices = tuple(
+            slice(index, index + extent)
+            for index, extent in zip(output_index, kernel_size)
+        )
+        channels = []
+        for output_channel in range(kernel.shape[-1]):
+            group = output_channel // output_channels_per_group
+            channel_start = group * input_channels_per_group
+            channel_stop = channel_start + input_channels_per_group
+            patch = inputs[
+                (slice(None),)
+                + spatial_slices
+                + (slice(channel_start, channel_stop),)
+            ]
+            filter_kernel = kernel[..., output_channel]
+            reduction_axes = tuple(range(1, patch.ndim))
+            dot = jnp.sum(patch * filter_kernel, axis=reduction_axes)
+            distance = (
+                jnp.sum(patch**2, axis=reduction_axes)
+                + jnp.sum(filter_kernel**2)
+                - 2.0 * dot
+            )
+            score_dot = dot + params["bias"][output_channel]
+            channels.append(score_dot**2 / (distance + 1e-5))
+        positions.append(jnp.stack(channels, axis=-1))
+
+    scores = jnp.stack(positions, axis=1)
+    scores = scores.reshape(
+        (inputs.shape[0],) + output_spatial + (kernel.shape[-1],)
+    )
+    return scores * params["alpha"]
+
+
+@pytest.mark.parametrize(
+    "layer_type,input_shape,kernel_size,dimension_spec,groups,features",
+    _GROUPED_CASES,
+)
+def test_grouped_convolution_matches_synchronized_reference_forward_and_vjp(
+    layer_type, input_shape, kernel_size, dimension_spec, groups, features
+):
+    layer = layer_type(
+        features=features,
+        kernel_size=kernel_size,
+        feature_group_count=groups,
+        padding="VALID",
+    )
+    inputs = jax.random.normal(jax.random.key(21 + len(input_shape)), input_shape)
+    params = layer.init(jax.random.key(20), inputs)["params"]
+
+    actual = layer.apply({"params": params}, inputs)
+    expected = _grouped_reference(
+        params, inputs, kernel_size, dimension_spec, groups
+    )
+    np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-6)
+
+    cotangent = jnp.linspace(-0.8, 0.6, actual.size).reshape(actual.shape)
+
+    def module_loss(params_arg, inputs_arg):
+        return jnp.vdot(layer.apply({"params": params_arg}, inputs_arg), cotangent)
+
+    def reference_loss(params_arg, inputs_arg):
+        return jnp.vdot(
+            _grouped_reference(
+                params_arg, inputs_arg, kernel_size, dimension_spec, groups
+            ),
+            cotangent,
+        )
+
+    module_grads = jax.grad(module_loss, argnums=(0, 1))(params, inputs)
+    reference_grads = jax.grad(reference_loss, argnums=(0, 1))(params, inputs)
+    _assert_tree_allclose(module_grads, reference_grads, rtol=4e-5, atol=4e-6)
+
+
+@pytest.mark.parametrize(
+    "layer_type,input_shape,kernel_size",
+    [
+        (YatConv1D, (1, 5, 4), (2,)),
+        (YatConv2D, (1, 4, 4, 4), (2, 2)),
+        (YatConv3D, (1, 3, 3, 3, 4), (2, 2, 2)),
+    ],
+)
+@pytest.mark.parametrize(
+    "channels,features,match",
+    [
+        (3, 4, r"Input channels \(3\) must be divisible"),
+        (4, 5, r"features \(5\) must be divisible"),
+    ],
+)
+def test_grouped_convolution_rejects_invalid_channel_divisibility(
+    layer_type, input_shape, kernel_size, channels, features, match
+):
+    invalid_shape = input_shape[:-1] + (channels,)
+    inputs = jnp.ones(invalid_shape, dtype=jnp.float32)
+    layer = layer_type(
+        features=features,
+        kernel_size=kernel_size,
+        feature_group_count=2,
+    )
+    with pytest.raises(ValueError, match=match):
+        layer.init(jax.random.key(30), inputs)

--- a/tests/test_linen/test_regression_issues_51_52.py
+++ b/tests/test_linen/test_regression_issues_51_52.py
@@ -28,6 +28,19 @@ def _assert_tree_allclose(actual, expected, *, rtol=2e-5, atol=2e-6):
         )
 
 
+def test_attention_normalization_preserves_positional_epsilon_abi_and_validates():
+    layer = MultiHeadAttention(
+        2, None, None, 0.0, True, True, None, False, False, 1e-4
+    )
+    assert layer.epsilon == 1e-4
+    assert layer.normalization == "softmax"
+
+    inputs = jnp.ones((1, 2, 4), dtype=jnp.float32)
+    invalid = MultiHeadAttention(num_heads=2, normalization="typo")
+    with pytest.raises(ValueError, match="normalization must be"):
+        invalid.init(jax.random.key(99), inputs)
+
+
 @pytest.mark.parametrize("normalization", ["softmax", "l1"])
 def test_attention_constant_and_matched_learnable_alpha_have_same_stage_and_vjp(
     normalization,


### PR DESCRIPTION
Fixes #51
Fixes #52

Corrects grouped patch-norm channel mapping across Linen 1D/2D/3D convolution and applies constant/learnable attention alpha at the same pre-normalization stage. Adds explicit softmax/L1 validation while preserving the pre-existing positional constructor ABI.

Verification:
- focused regressions: 13 passed
- full Linen suite: 111 passed
- independent softmax/L1 forward and all projection/Q/K/V VJP parity
- independent grouped forward and all parameter/input VJP parity across multiple groups, padding, stride, RHS dilation, SAME, and LHS dilation
- Ruff and diff checks clean