### PR TITLE
fix(nnx): stabilize layer precision and stochastic semantics

### DIFF
--- a/src/nmn/nnx/layers/_numerics.py
+++ b/src/nmn/nnx/layers/_numerics.py
@@ -1,0 +1,58 @@
+"""Shared numerical helpers for NNX YAT layers."""
+
+from __future__ import annotations
+
+import math
+
+import jax
+import jax.numpy as jnp
+
+
+def inverse_softplus(epsilon: float, dtype):
+  """Return a stable inverse-softplus initializer in ``dtype``."""
+  epsilon = float(epsilon)
+  if not math.isfinite(epsilon) or epsilon <= 0.0:
+    raise ValueError(f"epsilon must be finite and positive, got {epsilon}")
+  raw = epsilon + math.log(-math.expm1(-epsilon))
+  return jnp.asarray([raw], dtype=dtype)
+
+
+def fp32_if_low_precision(*values):
+  """Upcast fp16/bf16 arrays for cancellation-sensitive YAT arithmetic."""
+  low_precision = (jnp.float16, jnp.bfloat16)
+  return tuple(
+    _safe_fp32_upcast(value)
+    if value is not None and value.dtype in low_precision
+    else value
+    for value in values
+  )
+
+
+@jax.custom_vjp
+def _safe_fp32_upcast(value):
+  return value.astype(jnp.float32)
+
+
+def _safe_fp32_upcast_fwd(value):
+  return value.astype(jnp.float32), jnp.zeros((), dtype=value.dtype)
+
+
+def _safe_fp32_upcast_bwd(dtype_anchor, cotangent):
+  info = jnp.finfo(dtype_anchor.dtype)
+  cotangent = jnp.nan_to_num(
+    cotangent, nan=0.0, posinf=info.max, neginf=info.min
+  )
+  cotangent = jnp.clip(cotangent, info.min, info.max)
+  return (cotangent.astype(dtype_anchor.dtype),)
+
+
+_safe_fp32_upcast.defvjp(_safe_fp32_upcast_fwd, _safe_fp32_upcast_bwd)
+
+
+def finite_cast(value, dtype):
+  """Cast to a low-precision output dtype without creating infinities."""
+  if dtype not in (jnp.float16, jnp.bfloat16):
+    return value.astype(dtype)
+  info = jnp.finfo(dtype)
+  value = jnp.nan_to_num(value, nan=0.0, posinf=info.max, neginf=info.min)
+  return jnp.clip(value, info.min, info.max).astype(dtype)

--- a/src/nmn/nnx/layers/_numerics.py
+++ b/src/nmn/nnx/layers/_numerics.py
@@ -39,9 +39,8 @@ def _safe_fp32_upcast_fwd(value):
 
 def _safe_fp32_upcast_bwd(dtype_anchor, cotangent):
   info = jnp.finfo(dtype_anchor.dtype)
-  cotangent = jnp.nan_to_num(
-    cotangent, nan=0.0, posinf=info.max, neginf=info.min
-  )
+  cotangent = jnp.where(jnp.isposinf(cotangent), info.max, cotangent)
+  cotangent = jnp.where(jnp.isneginf(cotangent), info.min, cotangent)
   cotangent = jnp.clip(cotangent, info.min, info.max)
   return (cotangent.astype(dtype_anchor.dtype),)
 
@@ -49,10 +48,41 @@ def _safe_fp32_upcast_bwd(dtype_anchor, cotangent):
 _safe_fp32_upcast.defvjp(_safe_fp32_upcast_fwd, _safe_fp32_upcast_bwd)
 
 
+@jax.custom_vjp
+def _saturating_low_precision_cast(value, dtype_anchor):
+  return value.astype(dtype_anchor.dtype)
+
+
+def _saturating_low_precision_cast_fwd(value, dtype_anchor):
+  output = value.astype(dtype_anchor.dtype)
+  anchors = (jnp.zeros((), value.dtype), dtype_anchor)
+  return output, anchors
+
+
+def _saturating_low_precision_cast_bwd(anchors, cotangent):
+  input_anchor, output_anchor = anchors
+  info = jnp.finfo(output_anchor.dtype)
+  cotangent = jnp.where(jnp.isposinf(cotangent), info.max, cotangent)
+  cotangent = jnp.where(jnp.isneginf(cotangent), info.min, cotangent)
+  cotangent = jnp.clip(cotangent, info.min, info.max)
+  return (
+    cotangent.astype(input_anchor.dtype),
+    jnp.zeros_like(output_anchor),
+  )
+
+
+_saturating_low_precision_cast.defvjp(
+  _saturating_low_precision_cast_fwd,
+  _saturating_low_precision_cast_bwd,
+)
+
+
 def finite_cast(value, dtype):
   """Cast to a low-precision output dtype without creating infinities."""
   if dtype not in (jnp.float16, jnp.bfloat16):
     return value.astype(dtype)
   info = jnp.finfo(dtype)
-  value = jnp.nan_to_num(value, nan=0.0, posinf=info.max, neginf=info.min)
-  return jnp.clip(value, info.min, info.max).astype(dtype)
+  value = jnp.where(jnp.isposinf(value), info.max, value)
+  value = jnp.where(jnp.isneginf(value), info.min, value)
+  value = jnp.clip(value, info.min, info.max)
+  return _saturating_low_precision_cast(value, jnp.zeros((), dtype=dtype))

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -124,9 +124,9 @@ def _linear_general_with_kernel(
     return output
 
 
-def _dropconnect(kernel: Array, rng, rate: float) -> Array:
+def _dropconnect(kernel: Array, key: Array, rate: float) -> Array:
     keep_probability = 1.0 - rate
-    mask = jax.random.bernoulli(rng(), keep_probability, kernel.shape)
+    mask = jax.random.bernoulli(key, keep_probability, kernel.shape)
     return lax.select(mask, kernel / keep_probability, jnp.zeros_like(kernel))
 
 
@@ -461,20 +461,81 @@ class MultiHeadAttention(Module):
         else:
             is_deterministic = True
 
+        # Resolve and validate decoding before any stochastic projection.  A
+        # rejected call must not advance DropConnect streams or mutate caches.
+        decode = first_from(
+            decode,
+            self.decode,
+            error_msg=(
+                "No `decode` argument was provided to MultiHeadAttention "
+                "as either a __call__ argument, class attribute, or nnx.flag."
+            ),
+        )
+        decode_context = None
+        if decode:
+            if (
+                self.cached_key is None
+                or self.cached_value is None
+                or self.cache_index is None
+            ):
+                raise ValueError(
+                    "Autoregressive cache not initialized, call `init_cache` first."
+                )
+            (
+                *batch_dims,
+                max_length,
+                num_heads,
+                depth_per_head,
+            ) = self.cached_key[...].shape
+            expected_input_shape = tuple(batch_dims) + (1, self.in_features)
+            for name, tensor in (
+                ("query", inputs_q),
+                ("key", inputs_k),
+                ("value", inputs_v),
+            ):
+                if expected_input_shape != tensor.shape:
+                    raise ValueError(
+                        f"Autoregressive cache shape error, expected {name} input "
+                        f"shape {expected_input_shape} instead got {tensor.shape}."
+                    )
+            decode_mask_shape = tuple(batch_dims) + (
+                self.num_heads,
+                1,
+                max_length,
+            )
+            _validate_decode_mask(mask, decode_mask_shape)
+            cur_index = self.cache_index[...]
+            _check_cache_capacity(cur_index, max_length)
+            decode_context = (
+                tuple(batch_dims),
+                max_length,
+                num_heads,
+                depth_per_head,
+                cur_index,
+            )
+
         # Apply linear projections
         apply_dropconnect = (
             self.use_dropconnect
             and self.dropconnect_rate > 0.0
             and not is_deterministic
         )
+        pending_dropconnect_count = None
         if apply_dropconnect:
             assert self.dropconnect_rng is not None
+            base_key = self.dropconnect_rng.key[...]
+            count = self.dropconnect_rng.count[...]
+            dropconnect_keys = tuple(
+                jax.random.fold_in(base_key, count + offset)
+                for offset in range(4)
+            )
+            pending_dropconnect_count = count + 4
             query = _linear_general_with_kernel(
                 self.query,
                 inputs_q,
                 _dropconnect(
                     self.query.kernel[...],
-                    self.dropconnect_rng,
+                    dropconnect_keys[0],
                     self.dropconnect_rate,
                 ),
             )
@@ -483,7 +544,7 @@ class MultiHeadAttention(Module):
                 inputs_k,
                 _dropconnect(
                     self.key.kernel[...],
-                    self.dropconnect_rng,
+                    dropconnect_keys[1],
                     self.dropconnect_rate,
                 ),
             )
@@ -492,7 +553,7 @@ class MultiHeadAttention(Module):
                 inputs_v,
                 _dropconnect(
                     self.value.kernel[...],
-                    self.dropconnect_rng,
+                    dropconnect_keys[2],
                     self.dropconnect_rate,
                 ),
             )
@@ -511,33 +572,20 @@ class MultiHeadAttention(Module):
             query = _l2_normalize_per_head(query)
             key = _l2_normalize_per_head(key)
 
-        # Handle autoregressive decoding
-        decode = first_from(
-            decode,
-            self.decode,
-            error_msg=(
-                "No `decode` argument was provided to MultiHeadAttention "
-                "as either a __call__ argument, class attribute, or nnx.flag."
-            ),
-        )
-
         if decode:
-            if (
-                self.cached_key is None
-                or self.cached_value is None
-                or self.cache_index is None
-            ):
-                raise ValueError(
-                    "Autoregressive cache not initialized, call `init_cache` first."
-                )
+            assert decode_context is not None
             (
-                *batch_dims,
+                batch_dims,
                 max_length,
                 num_heads,
                 depth_per_head,
-            ) = self.cached_key[...].shape
+                cur_index,
+            ) = decode_context
+            assert self.cached_key is not None
+            assert self.cached_value is not None
+            assert self.cache_index is not None
 
-            expected_shape = tuple(batch_dims) + (1, num_heads, depth_per_head)
+            expected_shape = batch_dims + (1, num_heads, depth_per_head)
             for name, tensor in (
                 ("query", query),
                 ("key", key),
@@ -549,17 +597,8 @@ class MultiHeadAttention(Module):
                         f"{expected_shape} instead got {tensor.shape}."
                     )
 
-            decode_mask_shape = tuple(batch_dims) + (
-                self.num_heads,
-                1,
-                max_length,
-            )
-            _validate_decode_mask(mask, decode_mask_shape)
-
             # Build the next cache state locally.  It is committed only after
             # attention and output projection complete successfully.
-            cur_index = self.cache_index[...]
-            _check_cache_capacity(cur_index, max_length)
             zero = jnp.array(0, dtype=lax.dtype(cur_index.dtype))
             indices = (zero,) * len(batch_dims) + (cur_index, zero, zero)
             next_key = lax.dynamic_update_slice(self.cached_key[...], key, indices)
@@ -571,7 +610,7 @@ class MultiHeadAttention(Module):
 
             causal_mask = jnp.broadcast_to(
                 jnp.arange(max_length) <= cur_index,
-                tuple(batch_dims) + (1, 1, max_length),
+                batch_dims + (1, 1, max_length),
             )
             mask = combine_masks(mask, causal_mask)
             pending_cache = (next_key, next_value, cur_index + 1)
@@ -633,7 +672,7 @@ class MultiHeadAttention(Module):
                 x,
                 _dropconnect(
                     self.out.kernel[...],
-                    self.dropconnect_rng,
+                    dropconnect_keys[3],
                     self.dropconnect_rate,
                 ),
             )
@@ -648,6 +687,10 @@ class MultiHeadAttention(Module):
             self.cached_key[...] = next_key
             self.cached_value[...] = next_value
             self.cache_index[...] = next_index
+
+        if pending_dropconnect_count is not None:
+            assert self.dropconnect_rng is not None
+            self.dropconnect_rng.count[...] = pending_dropconnect_count
 
         return output
 

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -38,6 +38,7 @@ from jax import Array
 
 from .yat_attention import yat_attention
 from .masks import combine_masks
+from .._numerics import fp32_if_low_precision, inverse_softplus
 
 # Default constant alpha value (sqrt(2)), same as NMN
 DEFAULT_CONSTANT_ALPHA = jnp.sqrt(2.0)
@@ -83,6 +84,50 @@ def _validate_decode_mask(mask: Array | None, expected_shape: tuple[int, ...]) -
             f"Decode mask shape {mask.shape} would expand attention shape "
             f"{expected_shape} to {broadcast_shape}."
         )
+
+
+def _linear_general_with_kernel(
+    layer: LinearGeneral, inputs: Array, kernel: Array
+) -> Array:
+    """Apply ``LinearGeneral`` with an ephemeral DropConnect kernel."""
+    ndim = inputs.ndim
+    axis = tuple(ax if ax >= 0 else ndim + ax for ax in layer.axis)
+    batch_axes = tuple(
+        ax if ax >= 0 else ndim + ax for ax in layer.batch_axis.keys()
+    )
+    n_batch_dims = len(batch_axes)
+    expanded_batch_shape = tuple(
+        inputs.shape[ax] if ax in batch_axes else 1
+        for ax in range(ndim)
+        if ax not in axis
+    )
+    bias = layer.bias[...] if layer.bias is not None else None
+    inputs, kernel, bias = layer.promote_dtype(
+        (inputs, kernel, bias), dtype=layer.dtype
+    )
+    dot_general = layer.dot_general or lax.dot_general
+    if layer.dot_general_cls is not None:
+        dot_general = layer.dot_general_cls()
+    dot_general_kwargs = {"out_sharding": None}
+    if layer.preferred_element_type is not None:
+        dot_general_kwargs["preferred_element_type"] = layer.preferred_element_type
+    output = dot_general(
+        inputs,
+        kernel,
+        ((axis, tuple(range(n_batch_dims, len(axis) + n_batch_dims))),
+         (batch_axes, tuple(range(n_batch_dims)))),
+        precision=layer.precision,
+        **dot_general_kwargs,
+    )
+    if bias is not None:
+        output += jnp.reshape(bias, (*expanded_batch_shape, *layer.out_features))
+    return output
+
+
+def _dropconnect(kernel: Array, rng, rate: float) -> Array:
+    keep_probability = 1.0 - rate
+    mask = jax.random.bernoulli(rng(), keep_probability, kernel.shape)
+    return lax.select(mask, kernel / keep_probability, jnp.zeros_like(kernel))
 
 
 class MultiHeadAttention(Module):
@@ -249,14 +294,21 @@ class MultiHeadAttention(Module):
         self.learnable_epsilon = learnable_epsilon
         self.epsilon_param: nnx.Param[Array] | None
         if learnable_epsilon:
-            raw_eps = jnp.log(jnp.exp(jnp.array(epsilon, dtype=param_dtype)) - 1.0)
-            self.epsilon_param = nnx.Param(raw_eps.reshape((1,)))
+            self.epsilon_param = nnx.Param(inverse_softplus(epsilon, param_dtype))
         else:
             self.epsilon_param = None
         self.use_softermax = use_softermax
         self.power = power
         self.use_dropconnect = use_dropconnect
         self.dropconnect_rate = dropconnect_rate
+        if not 0.0 <= dropconnect_rate < 1.0:
+            raise ValueError(
+                "dropconnect_rate must be in the half-open interval [0, 1), "
+                f"got {dropconnect_rate}"
+            )
+        self.dropconnect_rng = (
+            rngs.dropout.fork() if use_dropconnect else nnx.data(None)
+        )
 
         # Handle alpha configuration (same logic as YatNMN)
         # Priority: constant_alpha > use_alpha
@@ -410,9 +462,44 @@ class MultiHeadAttention(Module):
             is_deterministic = True
 
         # Apply linear projections
-        query = self.query(inputs_q)
-        key = self.key(inputs_k)
-        value = self.value(inputs_v)
+        apply_dropconnect = (
+            self.use_dropconnect
+            and self.dropconnect_rate > 0.0
+            and not is_deterministic
+        )
+        if apply_dropconnect:
+            assert self.dropconnect_rng is not None
+            query = _linear_general_with_kernel(
+                self.query,
+                inputs_q,
+                _dropconnect(
+                    self.query.kernel[...],
+                    self.dropconnect_rng,
+                    self.dropconnect_rate,
+                ),
+            )
+            key = _linear_general_with_kernel(
+                self.key,
+                inputs_k,
+                _dropconnect(
+                    self.key.kernel[...],
+                    self.dropconnect_rng,
+                    self.dropconnect_rate,
+                ),
+            )
+            value = _linear_general_with_kernel(
+                self.value,
+                inputs_v,
+                _dropconnect(
+                    self.value.kernel[...],
+                    self.dropconnect_rng,
+                    self.dropconnect_rate,
+                ),
+            )
+        else:
+            query = self.query(inputs_q)
+            key = self.key(inputs_k)
+            value = self.value(inputs_v)
 
         # Reshape to multi-head format: [batch..., length, num_heads, head_dim]
         query = query.reshape(query.shape[:-1] + (self.num_heads, self.head_dim))
@@ -511,7 +598,8 @@ class MultiHeadAttention(Module):
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
-            effective_epsilon = jax.nn.softplus(self.epsilon_param[...].astype(jnp.float32))
+            (raw_epsilon,) = fp32_if_low_precision(self.epsilon_param[...])
+            effective_epsilon = jax.nn.softplus(raw_epsilon)
         else:
             effective_epsilon = self.epsilon
 
@@ -538,7 +626,19 @@ class MultiHeadAttention(Module):
         if self._constant_alpha_value is not None:
             x = x * self._constant_alpha_value
 
-        output = self.out(x)
+        if apply_dropconnect:
+            assert self.dropconnect_rng is not None
+            output = _linear_general_with_kernel(
+                self.out,
+                x,
+                _dropconnect(
+                    self.out.kernel[...],
+                    self.dropconnect_rng,
+                    self.dropconnect_rate,
+                ),
+            )
+        else:
+            output = self.out(x)
 
         if pending_cache is not None:
             assert self.cached_key is not None

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -56,6 +56,7 @@ from .spherical_yat_performer import (
     yat_tp_attention,
     create_yat_tp_projection,
 )
+from .._numerics import fp32_if_low_precision, inverse_softplus
 from .maclaurin_yat import (
     _validate_linear_attention_mask,
     create_maclaurin_projection,
@@ -520,8 +521,7 @@ class RotaryYatAttention(Module):
         self.learnable_epsilon = learnable_epsilon
         self.epsilon_param: nnx.Param[Array] | None
         if learnable_epsilon:
-            raw_eps = jnp.log(jnp.exp(jnp.array(epsilon, dtype=param_dtype)) - 1.0)
-            self.epsilon_param = nnx.Param(raw_eps.reshape((1,)))
+            self.epsilon_param = nnx.Param(inverse_softplus(epsilon, param_dtype))
         else:
             self.epsilon_param = None
         self.use_softermax = use_softermax
@@ -843,7 +843,8 @@ class RotaryYatAttention(Module):
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
-            effective_epsilon = jax.nn.softplus(self.epsilon_param[...].astype(jnp.float32))
+            (raw_epsilon,) = fp32_if_low_precision(self.epsilon_param[...])
+            effective_epsilon = jax.nn.softplus(raw_epsilon)
         else:
             effective_epsilon = self.epsilon
 

--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -43,6 +43,7 @@ from .utils import (
     default_alpha_init,
     DEFAULT_CONSTANT_ALPHA,
 )
+from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 
 Array = jax.Array
 
@@ -156,6 +157,16 @@ class YatConv(Module):
         kernel_bank_id: str = "default",
         rngs: rnglib.Rngs,
     ):
+        if feature_group_count <= 0:
+            raise ValueError("feature_group_count must be positive")
+        if in_features % feature_group_count != 0:
+            raise ValueError(
+                "in_features must be a multiple of feature_group_count"
+            )
+        if out_features % feature_group_count != 0:
+            raise ValueError(
+                "out_features must be a multiple of feature_group_count"
+            )
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,)
         else:
@@ -287,8 +298,7 @@ class YatConv(Module):
         self.learnable_epsilon = learnable_epsilon
         self.epsilon_param: nnx.Param[jax.Array] | None
         if learnable_epsilon:
-            raw_eps = jnp.log(jnp.exp(jnp.array(epsilon, dtype=param_dtype)) - 1.0)
-            self.epsilon_param = nnx.Param(raw_eps.reshape((1,)))
+            self.epsilon_param = nnx.Param(inverse_softplus(epsilon, param_dtype))
         else:
             self.epsilon_param = None
         self.drop_rate = drop_rate
@@ -305,7 +315,7 @@ class YatConv(Module):
             self.kernel.value = kernel_val / (kernel_norm + 1e-8)
 
         if use_dropconnect:
-            self.dropconnect_key = rngs.params()
+            self.dropconnect_key = rngs.dropout.fork()
         else:
             self.dropconnect_key = None
 
@@ -382,7 +392,7 @@ class YatConv(Module):
         if self.use_dropconnect and not deterministic and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
             mask = jax.random.bernoulli(
-                self.dropconnect_key, p=keep_prob, shape=kernel_val.shape
+                self.dropconnect_key(), p=keep_prob, shape=kernel_val.shape
             )
             kernel_val = (kernel_val * mask) / keep_prob
 
@@ -426,6 +436,10 @@ class YatConv(Module):
         inputs_flat = inputs_promoted
         kernel_val = kernel_promoted
         bias_val = bias_promoted
+        output_dtype = inputs_flat.dtype
+        inputs_flat, kernel_val, bias_val, alpha = fp32_if_low_precision(
+            inputs_flat, kernel_val, bias_val, alpha
+        )
 
         # Compute dot product via convolution
         dot_prod_map = self.conv_general_dilated(
@@ -445,7 +459,7 @@ class YatConv(Module):
         kernel_in_channels_for_sum_sq = self.kernel_shape[-2]
         kernel_for_patch_sq_sum_shape = self.kernel_size + (
             kernel_in_channels_for_sum_sq,
-            1,
+            self.feature_group_count,
         )
         kernel_for_patch_sq_sum = jnp.ones(
             kernel_for_patch_sq_sum_shape, dtype=kernel_val.dtype
@@ -495,12 +509,16 @@ class YatConv(Module):
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
-            eps = jax.nn.softplus(self.epsilon_param[...].astype(dot_prod_map.dtype))
+            (raw_epsilon,) = fp32_if_low_precision(self.epsilon_param[...])
+            eps = jax.nn.softplus(raw_epsilon)
         else:
             eps = self.epsilon
 
         # YAT formula: (x·W + b)² / (||x - W||² + ε)
-        distance_sq_map = patch_sq_sum_map + kernel_sq_sum_per_filter - 2 * dot_prod_raw
+        distance_sq_map = jnp.maximum(
+            patch_sq_sum_map + kernel_sq_sum_per_filter - 2 * dot_prod_raw,
+            0.0,
+        )
         y = dot_prod_map**2 / (distance_sq_map + eps)
 
         # Apply alpha scaling
@@ -511,10 +529,11 @@ class YatConv(Module):
             # Simple learnable alpha scaling
             y = y * alpha
 
+        y = finite_cast(y, output_dtype)
+
         # Reshape output if needed
         if num_batch_dimensions != 1:
             output_shape = input_batch_shape + y.shape[1:]
             y = jnp.reshape(y, output_shape)
 
         return y
-

--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -157,6 +157,11 @@ class YatConv(Module):
         kernel_bank_id: str = "default",
         rngs: rnglib.Rngs,
     ):
+        if not 0.0 <= drop_rate < 1.0:
+            raise ValueError(
+                "drop_rate must be in the half-open interval [0, 1), "
+                f"got {drop_rate}"
+            )
         if feature_group_count <= 0:
             raise ValueError("feature_group_count must be positive")
         if in_features % feature_group_count != 0:

--- a/src/nmn/nnx/layers/conv/yat_conv_transpose.py
+++ b/src/nmn/nnx/layers/conv/yat_conv_transpose.py
@@ -135,6 +135,11 @@ class YatConvTranspose(Module):
         drop_rate: float = 0.0,
         rngs: rnglib.Rngs,
     ):
+        if not 0.0 <= drop_rate < 1.0:
+            raise ValueError(
+                "drop_rate must be in the half-open interval [0, 1), "
+                f"got {drop_rate}"
+            )
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,)
         else:
@@ -420,4 +425,3 @@ class YatConvTranspose(Module):
             y = jnp.reshape(y, output_shape)
 
         return y
-

--- a/src/nmn/nnx/layers/conv/yat_conv_transpose.py
+++ b/src/nmn/nnx/layers/conv/yat_conv_transpose.py
@@ -35,6 +35,7 @@ from .utils import (
     default_alpha_init,
     DEFAULT_CONSTANT_ALPHA,
 )
+from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 
 Array = jax.Array
 
@@ -159,8 +160,7 @@ class YatConvTranspose(Module):
         self.learnable_epsilon = learnable_epsilon
         self.epsilon_param: nnx.Param | None
         if learnable_epsilon:
-            raw_eps = jnp.log(jnp.exp(jnp.array(epsilon, dtype=param_dtype)) - 1.0)
-            self.epsilon_param = nnx.Param(raw_eps.reshape((1,)))
+            self.epsilon_param = nnx.Param(inverse_softplus(epsilon, param_dtype))
         else:
             self.epsilon_param = None
         self.drop_rate = drop_rate
@@ -217,7 +217,7 @@ class YatConvTranspose(Module):
         self.constant_alpha = constant_alpha
 
         if use_dropconnect:
-            self.dropconnect_key = rngs.params()
+            self.dropconnect_key = rngs.dropout.fork()
         else:
             self.dropconnect_key = None
 
@@ -267,7 +267,7 @@ class YatConvTranspose(Module):
         if self.use_dropconnect and not deterministic and self.drop_rate > 0.0:
             keep_prob = 1.0 - self.drop_rate
             mask = jax.random.bernoulli(
-                self.dropconnect_key, p=keep_prob, shape=kernel_val.shape
+                self.dropconnect_key(), p=keep_prob, shape=kernel_val.shape
             )
             kernel_val = (kernel_val * mask) / keep_prob
 
@@ -305,6 +305,10 @@ class YatConvTranspose(Module):
         inputs_flat = inputs_promoted
         kernel_val = kernel_promoted
         bias_val = bias_promoted
+        output_dtype = inputs_flat.dtype
+        inputs_flat, kernel_val, bias_val, alpha = fp32_if_low_precision(
+            inputs_flat, kernel_val, bias_val, alpha
+        )
 
         # Compute transposed convolution (dot product)
         dot_prod_map = lax.conv_transpose(
@@ -320,11 +324,9 @@ class YatConvTranspose(Module):
         # Compute ||x||² for each patch via transposed convolution
         inputs_flat_squared = inputs_flat**2
         if self.transpose_kernel:
-            patch_kernel_in_features = self.out_features
+            kernel_for_patch_sq_sum_shape = self.kernel_size + (1, self.in_features)
         else:
-            patch_kernel_in_features = self.in_features
-
-        kernel_for_patch_sq_sum_shape = self.kernel_size + (patch_kernel_in_features, 1)
+            kernel_for_patch_sq_sum_shape = self.kernel_size + (self.in_features, 1)
         kernel_for_patch_sq_sum = jnp.ones(
             kernel_for_patch_sq_sum_shape, dtype=kernel_val.dtype
         )
@@ -362,12 +364,16 @@ class YatConvTranspose(Module):
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
-            eps = jax.nn.softplus(self.epsilon_param[...].astype(dot_prod_map.dtype))
+            (raw_epsilon,) = fp32_if_low_precision(self.epsilon_param[...])
+            eps = jax.nn.softplus(raw_epsilon)
         else:
             eps = self.epsilon
 
         # YAT formula: (x·W + b)² / (||x - W||² + ε)
-        distance_sq_map = patch_sq_sum_map + kernel_sq_sum_per_filter - 2 * dot_prod_map
+        distance_sq_map = jnp.maximum(
+            patch_sq_sum_map + kernel_sq_sum_per_filter - 2 * dot_prod_map,
+            0.0,
+        )
 
         # Add bias before squaring
         if self.use_bias and bias_val is not None:
@@ -382,6 +388,8 @@ class YatConvTranspose(Module):
         elif alpha is not None:
             # Simple learnable alpha scaling
             y = y * alpha
+
+        y = finite_cast(y, output_dtype)
 
         # Handle circular padding
         if self.padding == "CIRCULAR":
@@ -412,7 +420,4 @@ class YatConvTranspose(Module):
             y = jnp.reshape(y, output_shape)
 
         return y
-
-
-
 

--- a/src/nmn/nnx/layers/embed.py
+++ b/src/nmn/nnx/layers/embed.py
@@ -16,6 +16,8 @@ from flax.typing import (
   PromoteDtypeFn,
 )
 
+from ._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
+
 Array = jax.Array
 
 default_embed_init = initializers.variance_scaling(
@@ -146,8 +148,7 @@ class Embed(Module):
     self.learnable_epsilon = learnable_epsilon
     self.epsilon_param: nnx.Param[jax.Array] | None
     if learnable_epsilon:
-      raw_eps = jnp.log(jnp.exp(jnp.array(epsilon, dtype=param_dtype)) - 1.0)
-      self.epsilon_param = nnx.Param(raw_eps.reshape((1,)))
+      self.epsilon_param = nnx.Param(inverse_softplus(epsilon, param_dtype))
     else:
       self.epsilon_param = None
     self.spherical = spherical
@@ -210,12 +211,19 @@ class Embed(Module):
     # Spherical normalization (only if not using weight normalization)
     # weight_normalized only normalizes at init, doesn't maintain it during training
     if self.spherical:
-      query = query / jnp.linalg.norm(query, axis=-1, keepdims=True)
-      embedding = embedding / jnp.linalg.norm(embedding, axis=1, keepdims=True)
+      query_norm = jnp.linalg.norm(query.astype(jnp.float32), axis=-1, keepdims=True)
+      embedding_norm = jnp.linalg.norm(
+        embedding.astype(jnp.float32), axis=1, keepdims=True
+      )
+      tiny = jnp.finfo(jnp.float32).tiny
+      query = query / jnp.maximum(query_norm, tiny)
+      embedding = embedding / jnp.maximum(embedding_norm, tiny)
 
     query, embedding, alpha = self.promote_dtype(
       (query, embedding, alpha), dtype=self.dtype
     )
+    output_dtype = query.dtype
+    query, embedding, alpha = fp32_if_low_precision(query, embedding, alpha)
     
     # Compute dot product: query · embedding^T
     y = jnp.dot(query, embedding.T)
@@ -223,16 +231,19 @@ class Embed(Module):
     if self.spherical:
       # Spherical YAT: query and embedding are normalized
       # distances = ||query||² + ||embedding||² - 2(query · embedding) = 1 + 1 - 2(query · embedding) = 2 - 2(query · embedding)
-      distances = 2 - 2 * y
+      distances = jnp.maximum(2 - 2 * y, 0.0)
     else:
       # Compute squared Euclidean distance: ||query||² + ||embedding||² - 2(query · embedding)
       query_squared_sum = jnp.sum(query**2, axis=-1, keepdims=True)
       embedding_squared_sum = jnp.sum(embedding**2, axis=1, keepdims=True).T
-      distances = query_squared_sum + embedding_squared_sum - 2 * y
+      distances = jnp.maximum(
+        query_squared_sum + embedding_squared_sum - 2 * y, 0.0
+      )
 
     # Resolve effective epsilon (learnable via softplus, or constant)
     if self.learnable_epsilon and self.epsilon_param is not None:
-      eps = jax.nn.softplus(self.epsilon_param[...].astype(jnp.float32))
+      (raw_epsilon,) = fp32_if_low_precision(self.epsilon_param[...])
+      eps = jax.nn.softplus(raw_epsilon)
     else:
       eps = self.epsilon
 
@@ -247,4 +258,4 @@ class Embed(Module):
       # Learnable alpha scaling
       y = y * alpha
 
-    return y
+    return finite_cast(y, output_dtype)

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -170,6 +170,12 @@ class YatNMN(Module):
     rngs: rnglib.Rngs,
   ):
 
+    if not 0.0 <= drop_rate < 1.0:
+      raise ValueError(
+        "drop_rate must be in the half-open interval [0, 1), "
+        f"got {drop_rate}"
+      )
+
     # ── Lazy mode (issue #37): freeze ONLY the kernel ───────────────────────
     # `freeze_kernel` is an alias for `lazy`. When enabled, the kernel is stored
     # under FrozenParam (a non-Param nnx.Variable) so it is excluded from

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -21,6 +21,8 @@ from flax.typing import (
   PromoteDtypeFn,
 )
 
+from ._numerics import fp32_if_low_precision, inverse_softplus
+
 Array = jax.Array
 Axis = int
 Size = int
@@ -327,10 +329,7 @@ class YatNMN(Module):
       # Initialize so that softplus(raw) ≈ epsilon: raw = log(exp(eps) - 1)
       # Compute this in Python float precision before casting. Evaluating the
       # inverse in bf16/fp16 rounds exp(1e-5) to 1 and produces ``-inf``.
-      raw_eps = epsilon + math.log(-math.expm1(-epsilon))
-      self.epsilon_param = nnx.Param(
-        jnp.asarray([raw_eps], dtype=param_dtype)
-      )
+      self.epsilon_param = nnx.Param(inverse_softplus(epsilon, param_dtype))
     else:
       self.epsilon_param = None
     self.spherical = spherical
@@ -348,7 +347,7 @@ class YatNMN(Module):
       self.kernel.value = kernel_val / (kernel_norm + 1e-8)
 
     if use_dropconnect:
-      self.dropconnect_key = rngs.params()
+      self.dropconnect_key = rngs.dropout.fork()
     else:
       self.dropconnect_key = None
 
@@ -388,7 +387,9 @@ class YatNMN(Module):
 
     if self.use_dropconnect and not deterministic and self.drop_rate > 0.0:
       keep_prob = 1.0 - self.drop_rate
-      mask = jax.random.bernoulli(self.dropconnect_key, p=keep_prob, shape=kernel.shape)
+      mask = jax.random.bernoulli(
+        self.dropconnect_key(), p=keep_prob, shape=kernel.shape
+      )
       kernel = (kernel * mask) / keep_prob
 
     # Normalize kernel if weight normalization is enabled
@@ -405,7 +406,8 @@ class YatNMN(Module):
 
     # Resolve effective epsilon (learnable via softplus, or constant)
     if self.learnable_epsilon and self.epsilon_param is not None:
-      eps = jax.nn.softplus(self.epsilon_param[...].astype(jnp.float32))
+      (raw_epsilon,) = fp32_if_low_precision(self.epsilon_param[...])
+      eps = jax.nn.softplus(raw_epsilon)
     else:
       eps = self.epsilon
 

--- a/tests/test_nnx/test_nnx_layer_regressions.py
+++ b/tests/test_nnx/test_nnx_layer_regressions.py
@@ -1,0 +1,352 @@
+"""Regression tests for NNX convolution, embedding, epsilon and DropConnect."""
+
+from __future__ import annotations
+
+import itertools
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from nmn.nnx import (
+    Embed,
+    MultiHeadAttention,
+    RotaryYatAttention,
+    YatConv,
+    YatConvTranspose,
+    YatNMN,
+)
+
+
+def _dropconnect_cases(seed):
+    rngs = nnx.Rngs(params=0, dropout=seed)
+    return [
+        (
+            YatNMN(
+                16, 12, use_bias=False, use_alpha=False,
+                use_dropconnect=True, drop_rate=0.5, rngs=rngs,
+            ),
+            jnp.arange(32, dtype=jnp.float32).reshape(2, 16) / 32,
+        ),
+        (
+            YatConv(
+                4, 8, 3, use_bias=False, use_alpha=False,
+                use_dropconnect=True, drop_rate=0.5, rngs=rngs,
+            ),
+            jnp.arange(40, dtype=jnp.float32).reshape(2, 5, 4) / 40,
+        ),
+        (
+            YatConvTranspose(
+                4, 8, 3, use_bias=False, use_alpha=False,
+                use_dropconnect=True, drop_rate=0.5, rngs=rngs,
+            ),
+            jnp.arange(40, dtype=jnp.float32).reshape(2, 5, 4) / 40,
+        ),
+        (
+            MultiHeadAttention(
+                4, 16, use_bias=False, use_alpha=False,
+                use_dropconnect=True, dropconnect_rate=0.5,
+                deterministic=False, rngs=rngs,
+            ),
+            jnp.arange(96, dtype=jnp.float32).reshape(2, 3, 16) / 96,
+        ),
+    ]
+
+
+@pytest.mark.parametrize("case", range(4))
+def test_dropconnect_is_stochastic_deterministic_and_uses_dropout_stream(case):
+    model, x = _dropconnect_cases(1)[case]
+    first = model(x, deterministic=False)
+    second = model(x, deterministic=False)
+    assert not np.array_equal(first, second)
+    np.testing.assert_array_equal(
+        model(x, deterministic=True), model(x, deterministic=True)
+    )
+
+    same_params_other_stream, _ = _dropconnect_cases(2)[case]
+    assert not np.array_equal(
+        first, same_params_other_stream(x, deterministic=False)
+    )
+
+
+@pytest.mark.parametrize("case", range(4))
+def test_dropconnect_mutable_stream_works_under_nnx_jit(case):
+    model, x = _dropconnect_cases(7)[case]
+    call = nnx.jit(lambda module, value: module(value, deterministic=False))
+    first = call(model, x)
+    second = call(model, x)
+    assert not np.array_equal(first, second)
+
+
+def _epsilon_modules(dtype):
+    kwargs = dict(
+        epsilon=1e-5,
+        learnable_epsilon=True,
+        param_dtype=dtype,
+        rngs=nnx.Rngs(0),
+    )
+    return [
+        YatNMN(2, 2, **kwargs),
+        Embed(2, 2, **kwargs),
+        YatConv(2, 2, 1, **kwargs),
+        YatConvTranspose(2, 2, 1, **kwargs),
+        MultiHeadAttention(1, 2, **kwargs),
+        RotaryYatAttention(2, 1, max_seq_len=2, **kwargs),
+    ]
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16, jnp.float32])
+def test_learnable_epsilon_is_positive_and_close_to_requested_value(dtype):
+    for module in _epsilon_modules(dtype):
+        raw = module.epsilon_param[...]
+        effective = jax.nn.softplus(raw.astype(jnp.float32))
+        assert jnp.isfinite(raw).all()
+        assert float(effective[0]) > 0.0
+        np.testing.assert_allclose(float(effective[0]), 1e-5, rtol=0.03)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+def test_low_precision_learnable_epsilon_has_finite_aggregate_gradient(dtype):
+    layer = YatConv(
+        2, 1, 1, dtype=dtype, param_dtype=dtype, epsilon=1e-3,
+        learnable_epsilon=True, use_bias=False, use_alpha=False,
+        rngs=nnx.Rngs(0),
+    )
+    x = jnp.full((1, 128, 2), 0.25, dtype=dtype)
+    layer.kernel[...] = jnp.full_like(layer.kernel[...], 0.25)
+
+    def summed_score(module, value):
+        return jnp.sum(module(value).astype(jnp.float32))
+
+    _, grads = jax.value_and_grad(summed_score)(layer, x)
+    assert jnp.isfinite(grads.epsilon_param[...]).all()
+
+
+def _loss(module, x):
+    return jnp.mean(module(x).astype(jnp.float32) ** 2)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+@pytest.mark.parametrize("kind", ["conv", "transpose"])
+def test_low_precision_conv_collision_matches_synchronized_fp32(kind, dtype):
+    cls = YatConv if kind == "conv" else YatConvTranspose
+    low = cls(
+        2, 1, 1, dtype=dtype, param_dtype=dtype, epsilon=1e-3,
+        use_bias=False, use_alpha=False, rngs=nnx.Rngs(0),
+    )
+    ref = cls(
+        2, 1, 1, dtype=jnp.float32, param_dtype=jnp.float32, epsilon=1e-3,
+        use_bias=False, use_alpha=False, rngs=nnx.Rngs(1),
+    )
+    x = jnp.asarray([[[0.125, -0.25]]], dtype=dtype)
+    kernel = x[0].reshape(low.kernel[...].shape)
+    low.kernel[...] = kernel
+    ref.kernel[...] = kernel.astype(jnp.float32)
+
+    low_out = low(x)
+    ref_out = ref(x.astype(jnp.float32))
+    _, (low_grads, low_dx) = jax.value_and_grad(_loss, argnums=(0, 1))(low, x)
+    _, (ref_grads, ref_dx) = jax.value_and_grad(_loss, argnums=(0, 1))(
+        ref, x.astype(jnp.float32)
+    )
+
+    assert low_out.dtype == dtype
+    assert jnp.isfinite(low_out).all()
+    assert jnp.isfinite(low_dx).all()
+    assert jnp.isfinite(low_grads.kernel[...]).all()
+    np.testing.assert_allclose(
+        np.asarray(low_out, dtype=np.float32), np.asarray(ref_out), rtol=0.03, atol=0.03
+    )
+    np.testing.assert_allclose(
+        np.asarray(low_dx, dtype=np.float32), np.asarray(ref_dx), rtol=0.08, atol=0.08
+    )
+    np.testing.assert_allclose(
+        np.asarray(low_grads.kernel[...], dtype=np.float32),
+        np.asarray(ref_grads.kernel[...]), rtol=0.08, atol=0.08,
+    )
+
+
+@pytest.mark.parametrize("kind", ["conv", "transpose"])
+def test_fp16_large_exact_collision_saturates_with_finite_gradients(kind):
+    cls = YatConv if kind == "conv" else YatConvTranspose
+    layer = cls(
+        2, 1, 1, dtype=jnp.float16, param_dtype=jnp.float16,
+        epsilon=1e-5, use_bias=False, use_alpha=False, rngs=nnx.Rngs(0),
+    )
+    x = jnp.asarray([[[0.75, 0.75]]], dtype=jnp.float16)
+    layer.kernel[...] = x[0].reshape(layer.kernel[...].shape)
+    output = layer(x)
+    _, (grads, dx) = jax.value_and_grad(_loss, argnums=(0, 1))(layer, x)
+    assert output[0, 0, 0] == jnp.finfo(jnp.float16).max
+    assert all(jnp.isfinite(value).all() for value in (output, dx, grads.kernel[...]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+def test_low_precision_embed_collision_and_gradients_match_fp32(dtype):
+    low = Embed(
+        2, 3, dtype=dtype, param_dtype=dtype, epsilon=1e-3,
+        use_alpha=False, rngs=nnx.Rngs(0),
+    )
+    ref = Embed(
+        2, 3, dtype=jnp.float32, param_dtype=jnp.float32, epsilon=1e-3,
+        use_alpha=False, rngs=nnx.Rngs(1),
+    )
+    values = jnp.asarray([[0.125, -0.25, 0.375], [-0.25, 0.5, 0.125]], dtype=dtype)
+    low.embedding[...] = values
+    ref.embedding[...] = values.astype(jnp.float32)
+    query = values[:1]
+
+    def loss(module, value):
+        return jnp.mean(module.attend(value).astype(jnp.float32) ** 2)
+
+    low_out = low.attend(query)
+    ref_out = ref.attend(query.astype(jnp.float32))
+    _, (low_grads, low_dq) = jax.value_and_grad(loss, argnums=(0, 1))(low, query)
+    _, (ref_grads, ref_dq) = jax.value_and_grad(loss, argnums=(0, 1))(
+        ref, query.astype(jnp.float32)
+    )
+    assert low_out.dtype == dtype
+    assert all(jnp.isfinite(x).all() for x in (low_out, low_dq, low_grads.embedding[...]))
+    np.testing.assert_allclose(
+        np.asarray(low_out, dtype=np.float32), np.asarray(ref_out), rtol=0.03, atol=0.03
+    )
+    np.testing.assert_allclose(
+        np.asarray(low_dq, dtype=np.float32), np.asarray(ref_dq), rtol=0.08, atol=0.08
+    )
+    np.testing.assert_allclose(
+        np.asarray(low_grads.embedding[...], dtype=np.float32),
+        np.asarray(ref_grads.embedding[...]), rtol=0.08, atol=0.08,
+    )
+
+
+def test_fp16_embed_large_collision_saturates_with_finite_gradients():
+    layer = Embed(
+        1, 2, dtype=jnp.float16, param_dtype=jnp.float16,
+        epsilon=1e-5, use_alpha=False, rngs=nnx.Rngs(0),
+    )
+    query = jnp.asarray([[0.75, 0.75]], dtype=jnp.float16)
+    layer.embedding[...] = query
+
+    def loss(module, value):
+        return jnp.mean(module.attend(value).astype(jnp.float32) ** 2)
+
+    output = layer.attend(query)
+    _, (grads, dq) = jax.value_and_grad(loss, argnums=(0, 1))(layer, query)
+    assert output[0, 0] == jnp.finfo(jnp.float16).max
+    assert all(jnp.isfinite(value).all() for value in (output, dq, grads.embedding[...]))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16, jnp.float32])
+def test_spherical_embed_zero_vectors_are_finite(dtype):
+    layer = Embed(3, 4, dtype=dtype, param_dtype=dtype, spherical=True, rngs=nnx.Rngs(0))
+    layer.embedding[...] = jnp.zeros_like(layer.embedding[...])
+    output = layer.attend(jnp.zeros((2, 4), dtype=dtype))
+    assert output.dtype == dtype
+    assert jnp.isfinite(output).all()
+
+
+def _explicit_grouped_reference(x, kernel, strides, padding, dilation, epsilon):
+    spatial_ndim = kernel.ndim - 2
+    groups = x.shape[-1] // kernel.shape[-2]
+    filters_per_group = kernel.shape[-1] // groups
+    pad_width = ((0, 0), *padding, (0, 0))
+    padded = jnp.pad(x, pad_width)
+    effective = tuple((k - 1) * d + 1 for k, d in zip(kernel.shape[:-2], dilation))
+    output_spatial = tuple(
+        (padded.shape[axis + 1] - effective[axis]) // strides[axis] + 1
+        for axis in range(spatial_ndim)
+    )
+    batches = []
+    for batch in range(x.shape[0]):
+        positions = []
+        for output_index in itertools.product(*(range(size) for size in output_spatial)):
+            spatial_indices = [
+                output_index[axis] * strides[axis]
+                + jnp.arange(kernel.shape[axis]) * dilation[axis]
+                for axis in range(spatial_ndim)
+            ]
+            patch = padded[(batch, *jnp.ix_(*spatial_indices))]
+            scores = []
+            for group in range(groups):
+                patch_group = patch[..., group * kernel.shape[-2]:(group + 1) * kernel.shape[-2]]
+                for offset in range(filters_per_group):
+                    filter_index = group * filters_per_group + offset
+                    filter_value = kernel[..., filter_index]
+                    dot = jnp.sum(patch_group * filter_value)
+                    distance = jnp.maximum(
+                        jnp.sum(patch_group**2) + jnp.sum(filter_value**2) - 2 * dot,
+                        0.0,
+                    )
+                    scores.append(dot**2 / (distance + epsilon))
+            positions.append(jnp.stack(scores))
+        batches.append(jnp.stack(positions).reshape((*output_spatial, kernel.shape[-1])))
+    return jnp.stack(batches)
+
+
+@pytest.mark.parametrize(
+    "spatial,kernel_size,strides,padding,dilation",
+    [
+        ((6,), (2,), (2,), ((1, 0),), (2,)),
+        ((5, 6), (2, 2), (2, 1), ((1, 0), (0, 1)), (1, 2)),
+        ((4, 5, 4), (2, 2, 2), (1, 2, 1), ((0, 1), (1, 0), (1, 1)), (1, 1, 2)),
+    ],
+)
+def test_grouped_conv_forward_and_gradients_match_explicit_patches(
+    spatial, kernel_size, strides, padding, dilation
+):
+    layer = YatConv(
+        4, 4, kernel_size, strides=strides, padding=padding,
+        kernel_dilation=dilation, feature_group_count=2, epsilon=1e-3,
+        use_bias=False, use_alpha=False, rngs=nnx.Rngs(0),
+    )
+    x = jnp.arange(np.prod((1, *spatial, 4)), dtype=jnp.float32).reshape((1, *spatial, 4)) / 50
+    kernel = jnp.arange(layer.kernel[...].size, dtype=jnp.float32).reshape(layer.kernel[...].shape) / 30
+    layer.kernel[...] = kernel
+    reference = lambda value, weights: _explicit_grouped_reference(
+        value, weights, strides, padding, dilation, 1e-3
+    )
+    actual = layer(x)
+    expected = reference(x, kernel)
+    np.testing.assert_allclose(actual, expected, rtol=2e-5, atol=2e-5)
+
+    _, (actual_grads, actual_dx) = jax.value_and_grad(_loss, argnums=(0, 1))(layer, x)
+    ref_loss = lambda value, weights: jnp.mean(reference(value, weights) ** 2)
+    _, (expected_dx, expected_dw) = jax.value_and_grad(ref_loss, argnums=(0, 1))(x, kernel)
+    np.testing.assert_allclose(actual_dx, expected_dx, rtol=5e-4, atol=5e-4)
+    np.testing.assert_allclose(actual_grads.kernel[...], expected_dw, rtol=5e-4, atol=5e-4)
+
+
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_transpose_kernel_layout_forward_and_gradient_parity(ndim):
+    kernel_size = (2,) * ndim
+    shape = (1, *((3,) * ndim), 2)
+    normal = YatConvTranspose(
+        2, 3, kernel_size, padding="VALID", epsilon=1e-3,
+        transpose_kernel=False, use_bias=False, use_alpha=False, rngs=nnx.Rngs(0),
+    )
+    transposed = YatConvTranspose(
+        2, 3, kernel_size, padding="VALID", epsilon=1e-3,
+        transpose_kernel=True, use_bias=False, use_alpha=False, rngs=nnx.Rngs(1),
+    )
+    kernel = jnp.arange(normal.kernel[...].size, dtype=jnp.float32).reshape(normal.kernel[...].shape) / 20
+    transform = lambda value: jnp.swapaxes(
+        jnp.flip(value, axis=tuple(range(ndim))), -1, -2
+    )
+    normal.kernel[...] = kernel
+    transposed.kernel[...] = transform(kernel)
+    x = jnp.arange(np.prod(shape), dtype=jnp.float32).reshape(shape) / 20
+
+    np.testing.assert_allclose(normal(x), transposed(x), rtol=2e-5, atol=2e-5)
+    _, (normal_grads, normal_dx) = jax.value_and_grad(_loss, argnums=(0, 1))(normal, x)
+    _, (transposed_grads, transposed_dx) = jax.value_and_grad(
+        _loss, argnums=(0, 1)
+    )(transposed, x)
+    np.testing.assert_allclose(normal_dx, transposed_dx, rtol=1e-4, atol=1e-2)
+    np.testing.assert_allclose(
+        transform(normal_grads.kernel[...]),
+        transposed_grads.kernel[...],
+        rtol=1e-4,
+        atol=1e-2,
+    )

--- a/tests/test_nnx/test_nnx_layer_regressions.py
+++ b/tests/test_nnx/test_nnx_layer_regressions.py
@@ -80,6 +80,78 @@ def test_dropconnect_mutable_stream_works_under_nnx_jit(case):
     assert not np.array_equal(first, second)
 
 
+def test_decode_validation_does_not_advance_dropconnect_or_cache():
+    module = MultiHeadAttention(
+        2, 8, decode=True, deterministic=False, use_alpha=False,
+        use_dropconnect=True, dropconnect_rate=0.5,
+        rngs=nnx.Rngs(params=0, dropout=1),
+    )
+    module.init_cache((1, 3, 8))
+    rng_count = int(module.dropconnect_rng.count[...])
+    cache = (
+        np.asarray(module.cached_key[...]).copy(),
+        np.asarray(module.cached_value[...]).copy(),
+        int(module.cache_index[...]),
+    )
+
+    invalid_mask = jnp.ones((1, 1, 2, 3), dtype=jnp.bool_)
+    with pytest.raises(ValueError, match="[Mm]ask shape"):
+        module(
+            jnp.ones((1, 1, 8)),
+            mask=invalid_mask,
+            deterministic=False,
+        )
+
+    assert int(module.dropconnect_rng.count[...]) == rng_count
+    np.testing.assert_array_equal(module.cached_key[...], cache[0])
+    np.testing.assert_array_equal(module.cached_value[...], cache[1])
+    assert int(module.cache_index[...]) == cache[2]
+
+
+def test_attention_failure_does_not_commit_dropconnect_or_cache():
+    def failing_attention(*args, **kwargs):
+        raise RuntimeError("attention failed")
+
+    module = MultiHeadAttention(
+        2, 8, decode=True, deterministic=False, use_alpha=False,
+        use_dropconnect=True, dropconnect_rate=0.5,
+        attention_fn=failing_attention,
+        rngs=nnx.Rngs(params=0, dropout=1),
+    )
+    module.init_cache((1, 3, 8))
+    rng_count = int(module.dropconnect_rng.count[...])
+    cache = (
+        np.asarray(module.cached_key[...]).copy(),
+        np.asarray(module.cached_value[...]).copy(),
+        int(module.cache_index[...]),
+    )
+
+    with pytest.raises(RuntimeError, match="attention failed"):
+        module(jnp.ones((1, 1, 8)), deterministic=False)
+
+    assert int(module.dropconnect_rng.count[...]) == rng_count
+    np.testing.assert_array_equal(module.cached_key[...], cache[0])
+    np.testing.assert_array_equal(module.cached_value[...], cache[1])
+    assert int(module.cache_index[...]) == cache[2]
+
+
+@pytest.mark.parametrize("drop_rate", [-0.1, 1.0, np.nan, np.inf])
+@pytest.mark.parametrize("kind", ["dense", "conv", "transpose"])
+def test_invalid_dropconnect_rates_are_rejected(kind, drop_rate):
+    kwargs = dict(
+        use_dropconnect=True,
+        drop_rate=drop_rate,
+        rngs=nnx.Rngs(0),
+    )
+    with pytest.raises(ValueError, match="drop_rate"):
+        if kind == "dense":
+            YatNMN(2, 2, **kwargs)
+        elif kind == "conv":
+            YatConv(2, 2, 1, **kwargs)
+        else:
+            YatConvTranspose(2, 2, 1, **kwargs)
+
+
 def _epsilon_modules(dtype):
     kwargs = dict(
         epsilon=1e-5,
@@ -236,6 +308,32 @@ def test_fp16_embed_large_collision_saturates_with_finite_gradients():
     _, (grads, dq) = jax.value_and_grad(loss, argnums=(0, 1))(layer, query)
     assert output[0, 0] == jnp.finfo(jnp.float16).max
     assert all(jnp.isfinite(value).all() for value in (output, dq, grads.embedding[...]))
+
+
+@pytest.mark.parametrize("kind", ["conv", "transpose", "embed"])
+def test_low_precision_nan_forward_and_cotangent_are_preserved(kind):
+    if kind == "embed":
+        module = Embed(
+            2, 2, dtype=jnp.float16, param_dtype=jnp.float16,
+            use_alpha=False, rngs=nnx.Rngs(0),
+        )
+        call = lambda value: module.attend(value)
+        clean = jnp.ones((1, 2), dtype=jnp.float16)
+    else:
+        cls = YatConv if kind == "conv" else YatConvTranspose
+        module = cls(
+            2, 2, 1, dtype=jnp.float16, param_dtype=jnp.float16,
+            use_bias=False, use_alpha=False, rngs=nnx.Rngs(0),
+        )
+        call = lambda value: module(value)
+        clean = jnp.ones((1, 2, 2), dtype=jnp.float16)
+
+    with_nan = clean.at[(0,) * (clean.ndim - 1) + (0,)].set(jnp.nan)
+    assert jnp.isnan(call(with_nan)).any()
+
+    output, pullback = jax.vjp(call, clean)
+    (cotangent,) = pullback(jnp.full_like(output, jnp.nan))
+    assert jnp.isnan(cotangent).any()
 
 
 @pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16, jnp.float32])


### PR DESCRIPTION
Fixes #61
Fixes #62
Fixes #63
Fixes #64
Fixes #65

Repairs DropConnect randomness and failure atomicity, stable learnable-epsilon initialization/gradients, low-precision conv/transpose/embed math, grouped patch-norm mapping, and transpose-kernel layout across NNX layers. Genuine NaNs remain visible while representable overflow is saturated.

Verification:
- new regression suite: 48 passed
- combined attention/layer/precision regressions: 106 passed
- full NNX suite: 402 passed, 1 skipped
- independent eager/JIT RNG/cache transactionality and NaN/VJP review
- grouped and transpose-kernel forward/all-gradient parity against independent references

CPU/JAX validation only; no TPU/GPU execution is claimed.