### PR TITLE
fix(tf): support grouped convolution parity and SavedModel export

### DIFF
--- a/docs/guides/tensorflow.md
+++ b/docs/guides/tensorflow.md
@@ -146,10 +146,63 @@ ckpt.restore(tf.train.latest_checkpoint("/tmp"))
 
 ### SavedModel
 
+Native NMN TensorFlow modules expose an explicit `export` method. Pass a
+`tf.TensorSpec` with a known final feature/channel dimension; the exported
+`serving_default` signature is callable after loading and returns an
+`{"outputs": tensor}` mapping:
+
 ```python
-tf.saved_model.save(model, "yat_savedmodel")
+from nmn.tf import YatNMN
+
+layer = YatNMN(features=64)
+layer.export(
+    "yat_savedmodel",
+    tf.TensorSpec([None, 128], tf.float32),
+)
 
 restored = tf.saved_model.load("yat_savedmodel")
+outputs = restored.signatures["serving_default"](
+    inputs=tf.zeros([8, 128], tf.float32)
+)["outputs"]
+```
+
+`YatConv*` and `YatConvTranspose*` use the same
+`export(path, input_signature)` API. `YatEmbed.export` records both
+`serving_default` (lookup, argument name `inputs`) and `attend` (argument name
+`query`) signatures:
+
+```python
+from nmn.tf import YatEmbed
+
+embedding = YatEmbed(num_embeddings=32_000, features=256)
+embedding.export(
+    "embedding_savedmodel",
+    tf.TensorSpec([None, None], tf.int32),
+    tf.TensorSpec([None, 256], tf.float32),
+)
+restored = tf.saved_model.load("embedding_savedmodel")
+vectors = restored.signatures["serving_default"](inputs=token_ids)["outputs"]
+logits = restored.signatures["attend"](query=hidden_states)["outputs"]
+```
+
+For attention, omitting key/value specs exports self-attention. Provide both
+for cross-attention; inference export always fixes `training=False`:
+
+```python
+from nmn.tf import MultiHeadYatAttention
+
+attention = MultiHeadYatAttention(embed_dim=256, num_heads=8)
+sequence = tf.TensorSpec([None, None, 256], tf.float32)
+attention.export(
+    "attention_savedmodel",
+    sequence,
+    key_signature=sequence,
+    value_signature=sequence,
+)
+restored = tf.saved_model.load("attention_savedmodel")
+outputs = restored.signatures["serving_default"](
+    query=query, key=key, value=value
+)["outputs"]
 ```
 
 ### TFLite

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -13,6 +13,8 @@ from typing import Optional, Tuple, Union
 
 import tensorflow as tf
 
+from .saved_model import ExportPath, export_attention
+
 __all__ = [
     "normalize_qk",
     "yat_attention_weights",
@@ -406,3 +408,26 @@ class MultiHeadYatAttention(tf.Module):
             x = self._linear(x, self.out_kernel, self.out_bias)
 
         return x
+
+    def export(
+        self,
+        export_dir: ExportPath,
+        query_signature: tf.TensorSpec,
+        *,
+        key_signature: Optional[tf.TensorSpec] = None,
+        value_signature: Optional[tf.TensorSpec] = None,
+        mask_signature: Optional[tf.TensorSpec] = None,
+    ) -> None:
+        """Export a callable inference SavedModel signature.
+
+        Omitting both key and value exports self-attention. Providing both
+        exports cross-attention. ``training`` is fixed to ``False``.
+        """
+        export_attention(
+            self,
+            export_dir,
+            query_signature,
+            key_signature=key_signature,
+            value_signature=value_signature,
+            mask_signature=mask_signature,
+        )

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -28,9 +28,10 @@ def _grouped_convolution(inputs, kernel, groups, convolution):
 
     TensorFlow's implicit grouped-convolution support differs by dimension and
     device (notably, grouped CPU gradients and grouped ``conv3d`` are not
-    universally available). Explicit splitting uses ordinary convolution ops
-    on every supported backend while preserving the usual contiguous group
-    ordering.
+    universally available). Explicit splitting removes those grouped-kernel
+    limitations while preserving the usual contiguous group ordering. Device
+    restrictions of the underlying ordinary convolution (for example some
+    CPU dilated-convolution gradients) still apply.
     """
     if groups == 1:
         return convolution(inputs, kernel)

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -5,9 +5,47 @@ import math
 from typing import Optional, Any, Tuple, Union, List, Callable
 
 from ._yat_core import yat_score
+from .saved_model import SingleInputSavedModelMixin
 
 
-class YatConv1D(tf.Module):
+def _validate_groups(filters: int, groups: int) -> None:
+    """Validate the statically known grouped-convolution configuration."""
+    if groups <= 0:
+        raise ValueError(f"groups must be a positive integer, got {groups}")
+    if filters % groups != 0:
+        raise ValueError(
+            f"Filters ({filters}) must be divisible by groups ({groups})"
+        )
+
+
+def _patch_norm_kernel(kernel_size, channels_per_group, groups, dtype):
+    """Return a grouped-convolution kernel producing one norm per group."""
+    return tf.ones(tuple(kernel_size) + (channels_per_group, groups), dtype=dtype)
+
+
+def _grouped_convolution(inputs, kernel, groups, convolution):
+    """Apply a convolution per channel group with portable gradients.
+
+    TensorFlow's implicit grouped-convolution support differs by dimension and
+    device (notably, grouped CPU gradients and grouped ``conv3d`` are not
+    universally available). Explicit splitting uses ordinary convolution ops
+    on every supported backend while preserving the usual contiguous group
+    ordering.
+    """
+    if groups == 1:
+        return convolution(inputs, kernel)
+    input_groups = tf.split(inputs, groups, axis=-1)
+    kernel_groups = tf.split(kernel, groups, axis=-1)
+    return tf.concat(
+        [
+            convolution(group_inputs, group_kernel)
+            for group_inputs, group_kernel in zip(input_groups, kernel_groups)
+        ],
+        axis=-1,
+    )
+
+
+class YatConv1D(SingleInputSavedModelMixin, tf.Module):
     """1D YAT convolution module using TensorFlow operations.
     
     This module implements 1D convolution using the YAT  algorithm,
@@ -49,6 +87,7 @@ class YatConv1D(tf.Module):
         self.strides = strides
         self.padding = padding.upper()
         self.dilation_rate = dilation_rate
+        _validate_groups(filters, groups)
         self.groups = groups
         self.use_alpha = use_alpha
         if epsilon <= 0:
@@ -91,11 +130,6 @@ class YatConv1D(tf.Module):
                 f"Input channels ({input_channels}) must be divisible by groups ({self.groups})"
             )
         
-        if self.filters % self.groups != 0:
-            raise ValueError(
-                f"Filters ({self.filters}) must be divisible by groups ({self.groups})"
-            )
-
         # Kernel shape: [kernel_size, input_channels_per_group, filters]
         channels_per_group = input_channels // self.groups
         kernel_shape = (self.kernel_size, channels_per_group, self.filters)
@@ -158,34 +192,40 @@ class YatConv1D(tf.Module):
         self._maybe_build(inputs)
 
         # Compute dot product using standard convolution
-        dot_prod_map = tf.nn.conv1d(
-            inputs,
-            self.kernel,
+        convolution = lambda x, kernel: tf.nn.conv1d(
+            x,
+            kernel,
             stride=self.strides,
             padding=self.padding,
             dilations=self.dilation_rate,
+        )
+        dot_prod_map = _grouped_convolution(
+            inputs, self.kernel, self.groups, convolution
         )
 
         # Compute ||input_patches||^2 using convolution with ones kernel
         inputs_squared = inputs * inputs
         
         # Create ones kernel for computing patch squared sums
-        ones_kernel_shape = (self.kernel_size, self.input_channels // self.groups, 1)
-        ones_kernel = tf.ones(ones_kernel_shape, dtype=self.dtype)
+        ones_kernel = _patch_norm_kernel(
+            (self.kernel_size,),
+            self.input_channels // self.groups,
+            self.groups,
+            self.dtype,
+        )
         
-        patch_sq_sum_map_raw = tf.nn.conv1d(
+        patch_sq_sum_map_raw = _grouped_convolution(
             inputs_squared,
             ones_kernel,
-            stride=self.strides,
-            padding=self.padding,
-            dilations=self.dilation_rate,
+            self.groups,
+            convolution,
         )
 
-        # Handle grouped convolution
-        if self.groups > 1:
-            patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters // self.groups, axis=-1)
-        else:
-            patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
+        # The helper convolution emits one channel per group. Repeat each
+        # group's patch norm for that group's contiguous output-filter block.
+        patch_sq_sum_map = tf.repeat(
+            patch_sq_sum_map_raw, self.filters // self.groups, axis=-1
+        )
 
         # Compute ||kernel||^2 per filter
         kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1])  # Sum over spatial and input channel dims
@@ -198,7 +238,7 @@ class YatConv1D(tf.Module):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
 
-class YatConv2D(tf.Module):
+class YatConv2D(SingleInputSavedModelMixin, tf.Module):
     """2D YAT convolution module using TensorFlow operations.
     
     This module implements 2D convolution using the YAT  algorithm,
@@ -243,6 +283,7 @@ class YatConv2D(tf.Module):
         self.strides = strides if isinstance(strides, (list, tuple)) else (strides, strides)
         self.padding = padding.upper()
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate)
+        _validate_groups(filters, groups)
         self.groups = groups
         self.use_alpha = use_alpha
         if epsilon <= 0:
@@ -285,11 +326,6 @@ class YatConv2D(tf.Module):
                 f"Input channels ({input_channels}) must be divisible by groups ({self.groups})"
             )
         
-        if self.filters % self.groups != 0:
-            raise ValueError(
-                f"Filters ({self.filters}) must be divisible by groups ({self.groups})"
-            )
-
         # Kernel shape: [kernel_height, kernel_width, input_channels_per_group, filters]
         channels_per_group = input_channels // self.groups
         kernel_shape = self.kernel_size + (channels_per_group, self.filters)
@@ -352,34 +388,40 @@ class YatConv2D(tf.Module):
         self._maybe_build(inputs)
 
         # Compute dot product using standard convolution
-        dot_prod_map = tf.nn.conv2d(
-            inputs,
-            self.kernel,
+        convolution = lambda x, kernel: tf.nn.conv2d(
+            x,
+            kernel,
             strides=[1] + list(self.strides) + [1],
             padding=self.padding,
             dilations=[1] + list(self.dilation_rate) + [1],
+        )
+        dot_prod_map = _grouped_convolution(
+            inputs, self.kernel, self.groups, convolution
         )
 
         # Compute ||input_patches||^2 using convolution with ones kernel
         inputs_squared = inputs * inputs
         
         # Create ones kernel for computing patch squared sums
-        ones_kernel_shape = self.kernel_size + (self.input_channels // self.groups, 1)
-        ones_kernel = tf.ones(ones_kernel_shape, dtype=self.dtype)
+        ones_kernel = _patch_norm_kernel(
+            self.kernel_size,
+            self.input_channels // self.groups,
+            self.groups,
+            self.dtype,
+        )
         
-        patch_sq_sum_map_raw = tf.nn.conv2d(
+        patch_sq_sum_map_raw = _grouped_convolution(
             inputs_squared,
             ones_kernel,
-            strides=[1] + list(self.strides) + [1],
-            padding=self.padding,
-            dilations=[1] + list(self.dilation_rate) + [1],
+            self.groups,
+            convolution,
         )
 
-        # Handle grouped convolution
-        if self.groups > 1:
-            patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters // self.groups, axis=-1)
-        else:
-            patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
+        # The helper convolution emits one channel per group. Repeat each
+        # group's patch norm for that group's contiguous output-filter block.
+        patch_sq_sum_map = tf.repeat(
+            patch_sq_sum_map_raw, self.filters // self.groups, axis=-1
+        )
 
         # Compute ||kernel||^2 per filter
         kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1, 2])  # Sum over spatial and input channel dims
@@ -392,7 +434,7 @@ class YatConv2D(tf.Module):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
 
-class YatConv3D(tf.Module):
+class YatConv3D(SingleInputSavedModelMixin, tf.Module):
     """3D YAT convolution module using TensorFlow operations.
     
     This module implements 3D convolution using the YAT algorithm,
@@ -437,6 +479,7 @@ class YatConv3D(tf.Module):
         self.strides = strides if isinstance(strides, (list, tuple)) else (strides, strides, strides)
         self.padding = padding.upper()
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate, dilation_rate)
+        _validate_groups(filters, groups)
         self.groups = groups
         self.use_alpha = use_alpha
         if epsilon <= 0:
@@ -479,11 +522,6 @@ class YatConv3D(tf.Module):
                 f"Input channels ({input_channels}) must be divisible by groups ({self.groups})"
             )
         
-        if self.filters % self.groups != 0:
-            raise ValueError(
-                f"Filters ({self.filters}) must be divisible by groups ({self.groups})"
-            )
-
         # Kernel shape: [kernel_depth, kernel_height, kernel_width, input_channels_per_group, filters]
         channels_per_group = input_channels // self.groups
         kernel_shape = self.kernel_size + (channels_per_group, self.filters)
@@ -547,34 +585,40 @@ class YatConv3D(tf.Module):
         self._maybe_build(inputs)
 
         # Compute dot product using standard convolution
-        dot_prod_map = tf.nn.conv3d(
-            inputs,
-            self.kernel,
+        convolution = lambda x, kernel: tf.nn.conv3d(
+            x,
+            kernel,
             strides=[1] + list(self.strides) + [1],
             padding=self.padding,
             dilations=[1] + list(self.dilation_rate) + [1],
+        )
+        dot_prod_map = _grouped_convolution(
+            inputs, self.kernel, self.groups, convolution
         )
 
         # Compute ||input_patches||^2 using convolution with ones kernel
         inputs_squared = inputs * inputs
         
         # Create ones kernel for computing patch squared sums
-        ones_kernel_shape = self.kernel_size + (self.input_channels // self.groups, 1)
-        ones_kernel = tf.ones(ones_kernel_shape, dtype=self.dtype)
+        ones_kernel = _patch_norm_kernel(
+            self.kernel_size,
+            self.input_channels // self.groups,
+            self.groups,
+            self.dtype,
+        )
         
-        patch_sq_sum_map_raw = tf.nn.conv3d(
+        patch_sq_sum_map_raw = _grouped_convolution(
             inputs_squared,
             ones_kernel,
-            strides=[1] + list(self.strides) + [1],
-            padding=self.padding,
-            dilations=[1] + list(self.dilation_rate) + [1],
+            self.groups,
+            convolution,
         )
 
-        # Handle grouped convolution
-        if self.groups > 1:
-            patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters // self.groups, axis=-1)
-        else:
-            patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
+        # The helper convolution emits one channel per group. Repeat each
+        # group's patch norm for that group's contiguous output-filter block.
+        patch_sq_sum_map = tf.repeat(
+            patch_sq_sum_map_raw, self.filters // self.groups, axis=-1
+        )
 
         # Compute ||kernel||^2 per filter
         kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1, 2, 3])  # Sum over spatial and input channel dims
@@ -587,7 +631,7 @@ class YatConv3D(tf.Module):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
 
-class YatConvTranspose1D(tf.Module):
+class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
     """1D YAT transposed convolution (deconvolution) module using TensorFlow operations.
     
     This module implements 1D transposed convolution using the YAT algorithm.
@@ -768,7 +812,7 @@ class YatConvTranspose1D(tf.Module):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
 
-class YatConvTranspose2D(tf.Module):
+class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
     """2D YAT transposed convolution (deconvolution) module using TensorFlow operations.
     
     This module implements 2D transposed convolution using the YAT algorithm.
@@ -938,7 +982,7 @@ class YatConvTranspose2D(tf.Module):
         return yat_score(self, dot_prod_map, distance_sq_map)
 
 
-class YatConvTranspose3D(tf.Module):
+class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
     """3D YAT transposed convolution (deconvolution) module using TensorFlow operations.
     
     This module implements 3D transposed convolution using the YAT algorithm.

--- a/src/nmn/tf/embed.py
+++ b/src/nmn/tf/embed.py
@@ -11,6 +11,8 @@ from typing import Optional, Union, List
 
 import tensorflow as tf
 
+from .saved_model import ExportPath, export_embedding
+
 __all__ = ["YatEmbed"]
 
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
@@ -138,3 +140,22 @@ class YatEmbed(tf.Module):
             y = y * self.alpha
 
         return y
+
+    def export(
+        self,
+        export_dir: ExportPath,
+        lookup_signature: tf.TensorSpec,
+        attend_signature: Optional[tf.TensorSpec] = None,
+    ) -> None:
+        """Export callable embedding lookup and ``attend`` signatures.
+
+        If ``attend_signature`` is omitted, a rank-2 floating-point query with
+        the configured feature dimension is exported.
+        """
+        if attend_signature is None:
+            attend_signature = tf.TensorSpec(
+                [None, self.features], self.dtype, name="query"
+            )
+        export_embedding(
+            self, export_dir, lookup_signature, attend_signature
+        )

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -4,11 +4,13 @@ import tensorflow as tf
 import math
 from typing import Optional, Tuple, Union, List
 
+from .saved_model import SingleInputSavedModelMixin
+
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
 
-class YatNMN(tf.Module):
+class YatNMN(SingleInputSavedModelMixin, tf.Module):
     """Dense layer implementing the ⵟ-product (YAT) transformation.
 
     Computes ``y = (x·Wᵀ + b)² / (‖x − W‖² + ε)`` over the last dimension of

--- a/src/nmn/tf/saved_model.py
+++ b/src/nmn/tf/saved_model.py
@@ -1,0 +1,136 @@
+"""Utilities for exporting native NMN TensorFlow modules as SavedModels."""
+
+from __future__ import annotations
+
+from os import PathLike
+from typing import Any, Dict, Optional, Union
+
+import tensorflow as tf
+
+ExportPath = Union[str, bytes, PathLike]
+
+
+def _named_spec(spec: tf.TensorSpec, name: str) -> tf.TensorSpec:
+    if not isinstance(spec, tf.TensorSpec):
+        raise TypeError(f"{name}_signature must be a tf.TensorSpec, got {type(spec)!r}")
+    return tf.TensorSpec(spec.shape, spec.dtype, name=name)
+
+
+def _outputs(result):
+    if isinstance(result, tuple):
+        return {"outputs": result[0], "kernel": result[1]}
+    return {"outputs": result}
+
+
+def _save(module: tf.Module, export_dir: ExportPath, functions: Dict[str, Any]) -> None:
+    signatures = {
+        name: function.get_concrete_function() for name, function in functions.items()
+    }
+    tf.saved_model.save(module, export_dir, signatures=signatures)
+
+
+def export_single_input(
+    module: tf.Module,
+    export_dir: ExportPath,
+    input_signature: tf.TensorSpec,
+) -> None:
+    """Export a one-input NMN module with a callable default signature."""
+    inputs_spec = _named_spec(input_signature, "inputs")
+
+    @tf.function(input_signature=[inputs_spec])
+    def serving_default(inputs):
+        return _outputs(module(inputs))
+
+    _save(module, export_dir, {"serving_default": serving_default})
+
+
+def export_embedding(
+    module: tf.Module,
+    export_dir: ExportPath,
+    lookup_signature: tf.TensorSpec,
+    attend_signature: tf.TensorSpec,
+) -> None:
+    """Export embedding lookup and YAT attend as separate signatures."""
+    inputs_spec = _named_spec(lookup_signature, "inputs")
+    query_spec = _named_spec(attend_signature, "query")
+
+    @tf.function(input_signature=[inputs_spec])
+    def serving_default(inputs):
+        return {"outputs": module(inputs)}
+
+    @tf.function(input_signature=[query_spec])
+    def attend(query):
+        return {"outputs": module.attend(query)}
+
+    _save(
+        module,
+        export_dir,
+        {"serving_default": serving_default, "attend": attend},
+    )
+
+
+def export_attention(
+    module: tf.Module,
+    export_dir: ExportPath,
+    query_signature: tf.TensorSpec,
+    *,
+    key_signature: Optional[tf.TensorSpec] = None,
+    value_signature: Optional[tf.TensorSpec] = None,
+    mask_signature: Optional[tf.TensorSpec] = None,
+) -> None:
+    """Export self- or cross-attention with an inference-only signature."""
+    if (key_signature is None) != (value_signature is None):
+        raise ValueError(
+            "key_signature and value_signature must either both be provided "
+            "or both be omitted"
+        )
+
+    query_spec = _named_spec(query_signature, "query")
+    mask_spec = (
+        _named_spec(mask_signature, "mask") if mask_signature is not None else None
+    )
+
+    if key_signature is None:
+        if mask_spec is None:
+
+            @tf.function(input_signature=[query_spec])
+            def serving_default(query):
+                return {"outputs": module(query, training=False)}
+
+        else:
+
+            @tf.function(input_signature=[query_spec, mask_spec])
+            def serving_default(query, mask):
+                return {"outputs": module(query, mask=mask, training=False)}
+
+    else:
+        key_spec = _named_spec(key_signature, "key")
+        value_spec = _named_spec(value_signature, "value")
+        if mask_spec is None:
+
+            @tf.function(input_signature=[query_spec, key_spec, value_spec])
+            def serving_default(query, key, value):
+                return {"outputs": module(query, key=key, value=value, training=False)}
+
+        else:
+
+            @tf.function(input_signature=[query_spec, key_spec, value_spec, mask_spec])
+            def serving_default(query, key, value, mask):
+                return {
+                    "outputs": module(
+                        query,
+                        key=key,
+                        value=value,
+                        mask=mask,
+                        training=False,
+                    )
+                }
+
+    _save(module, export_dir, {"serving_default": serving_default})
+
+
+class SingleInputSavedModelMixin:
+    """Mixin implementing ``export`` for one-input TensorFlow modules."""
+
+    def export(self, export_dir: ExportPath, input_signature: tf.TensorSpec) -> None:
+        export_single_input(self, export_dir, input_signature)

--- a/tests/test_tf/test_grouped_conv_parity.py
+++ b/tests/test_tf/test_grouped_conv_parity.py
@@ -1,0 +1,128 @@
+"""Parity regressions for native TensorFlow grouped YAT convolutions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from nmn.tf.conv import YatConv1D, YatConv2D, YatConv3D
+
+CASES = [
+    (YatConv1D, 2, (1, 6)),
+    (YatConv2D, (2, 2), (1, 4, 4)),
+    (YatConv3D, (2, 2, 2), (1, 3, 3, 3)),
+]
+
+
+def _conv(layer, inputs, kernel):
+    if inputs.shape.rank == 3:
+        return tf.nn.conv1d(
+            inputs,
+            kernel,
+            stride=layer.strides,
+            padding=layer.padding,
+            dilations=layer.dilation_rate,
+        )
+    if inputs.shape.rank == 4:
+        return tf.nn.conv2d(
+            inputs,
+            kernel,
+            strides=[1, *layer.strides, 1],
+            padding=layer.padding,
+            dilations=[1, *layer.dilation_rate, 1],
+        )
+    return tf.nn.conv3d(
+        inputs,
+        kernel,
+        strides=[1, *layer.strides, 1],
+        padding=layer.padding,
+        dilations=[1, *layer.dilation_rate, 1],
+    )
+
+
+def _split_group_reference(layer, inputs):
+    """Apply each convolution group independently, then concatenate."""
+    input_groups = tf.split(inputs, layer.groups, axis=-1)
+    kernel_groups = tf.split(layer.kernel, layer.groups, axis=-1)
+    spatial_axes = list(range(layer.kernel.shape.rank - 2))
+    reduce_axes = spatial_axes + [layer.kernel.shape.rank - 2]
+    outputs = []
+
+    for group_inputs, group_kernel in zip(input_groups, kernel_groups):
+        dot = _conv(layer, group_inputs, group_kernel)
+        norm_kernel = tf.ones(tuple(group_kernel.shape[:-1]) + (1,), dtype=layer.dtype)
+        patch_norm = _conv(layer, tf.square(group_inputs), norm_kernel)
+        kernel_norm = tf.reduce_sum(tf.square(group_kernel), axis=reduce_axes)
+        broadcast_shape = [1] * (inputs.shape.rank - 1) + [-1]
+        distance = patch_norm + tf.reshape(kernel_norm, broadcast_shape) - 2.0 * dot
+        outputs.append(tf.square(dot) / (distance + layer.epsilon))
+
+    return tf.concat(outputs, axis=-1)
+
+
+def _value_and_gradients(forward, inputs, kernel):
+    with tf.GradientTape() as tape:
+        tape.watch(inputs)
+        output = forward(inputs)
+        loss = tf.reduce_sum(output)
+    input_grad, kernel_grad = tape.gradient(loss, (inputs, kernel))
+    return output, input_grad, kernel_grad
+
+
+@pytest.mark.parametrize("groups", [2, 4])
+@pytest.mark.parametrize("layer_cls,kernel_size,input_prefix", CASES)
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "tf_function"])
+def test_grouped_conv_matches_split_reference_forward_and_gradients(
+    layer_cls, kernel_size, input_prefix, groups, compiled
+):
+    channels = groups * 2
+    filters = groups * 2
+    shape = input_prefix + (channels,)
+    inputs = tf.constant(
+        np.linspace(-0.7, 0.9, num=int(np.prod(shape)), dtype=np.float32).reshape(shape)
+    )
+    layer = layer_cls(
+        filters=filters,
+        kernel_size=kernel_size,
+        groups=groups,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.2,
+    )
+    layer(inputs)
+    kernel_values = np.linspace(
+        -0.35, 0.45, num=int(np.prod(layer.kernel.shape)), dtype=np.float32
+    ).reshape(layer.kernel.shape)
+    layer.kernel.assign(kernel_values)
+
+    actual = lambda x: layer(x)
+    reference = lambda x: _split_group_reference(layer, x)
+    if compiled:
+        actual = tf.function(actual)
+        reference = tf.function(reference)
+
+    actual_result = _value_and_gradients(actual, inputs, layer.kernel)
+    reference_result = _value_and_gradients(reference, inputs, layer.kernel)
+
+    for actual_value, reference_value in zip(actual_result, reference_result):
+        np.testing.assert_allclose(
+            actual_value.numpy(), reference_value.numpy(), rtol=2e-5, atol=2e-5
+        )
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_prefix", CASES)
+def test_group_validation_errors_are_clear(layer_cls, kernel_size, input_prefix):
+    del input_prefix
+    with pytest.raises(ValueError, match="groups must be a positive integer"):
+        layer_cls(filters=4, kernel_size=kernel_size, groups=0)
+
+    with pytest.raises(ValueError, match=r"Filters \(5\).*groups \(2\)"):
+        layer_cls(filters=5, kernel_size=kernel_size, groups=2)
+
+    layer = layer_cls(filters=4, kernel_size=kernel_size, groups=2)
+    rank = len(kernel_size) if isinstance(kernel_size, tuple) else 1
+    bad_shape = (1,) + (4,) * rank + (3,)
+    with pytest.raises(ValueError, match=r"Input channels \(3\).*groups \(2\)"):
+        layer(tf.zeros(bad_shape))

--- a/tests/test_tf/test_saved_model_export.py
+++ b/tests/test_tf/test_saved_model_export.py
@@ -1,0 +1,126 @@
+"""Callable SavedModel export tests for native TensorFlow NMN modules."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from nmn.tf import MultiHeadYatAttention, YatConv2D, YatEmbed, YatNMN
+
+
+def _assert_outputs_match(expected, restored, signature_name, **inputs):
+    signature = restored.signatures[signature_name]
+    eager = signature(**inputs)["outputs"]
+
+    @tf.function
+    def graph_call():
+        return signature(**inputs)["outputs"]
+
+    graph = graph_call()
+    assert eager.shape == expected.shape
+    assert eager.dtype == expected.dtype
+    np.testing.assert_allclose(eager.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(graph.numpy(), expected.numpy(), rtol=1e-5, atol=1e-5)
+
+
+def _assert_variables_preserved(module, restored):
+    variable_names = [
+        name for name, value in vars(module).items() if isinstance(value, tf.Variable)
+    ]
+    assert variable_names
+    for name in variable_names:
+        expected = getattr(module, name)
+        actual = getattr(restored, name)
+        assert actual.shape == expected.shape
+        assert actual.dtype == expected.dtype
+        np.testing.assert_array_equal(actual.numpy(), expected.numpy())
+
+
+def test_yat_nmn_exports_callable_saved_model(tmp_path):
+    layer = YatNMN(features=4)
+    inputs = tf.reshape(tf.linspace(-1.0, 1.0, 6), (2, 3))
+
+    export_dir = tmp_path / "dense"
+    # Exporting a fresh lazy-built module must trace and create its variables.
+    layer.export(export_dir, tf.TensorSpec([None, 3], tf.float32))
+    expected = layer(inputs)
+    restored = tf.saved_model.load(export_dir)
+
+    assert set(restored.signatures) == {"serving_default"}
+    _assert_outputs_match(expected, restored, "serving_default", inputs=inputs)
+    _assert_variables_preserved(layer, restored)
+
+
+def test_yat_conv_exports_callable_saved_model(tmp_path):
+    layer = YatConv2D(filters=4, kernel_size=2, groups=2)
+    inputs = tf.reshape(tf.linspace(-0.5, 0.5, 64), (1, 4, 4, 4))
+    expected = layer(inputs)
+
+    export_dir = tmp_path / "conv"
+    layer.export(export_dir, tf.TensorSpec([None, 4, 4, 4], tf.float32))
+    restored = tf.saved_model.load(export_dir)
+
+    _assert_outputs_match(expected, restored, "serving_default", inputs=inputs)
+    _assert_variables_preserved(layer, restored)
+
+
+def test_yat_embedding_exports_lookup_and_attend(tmp_path):
+    layer = YatEmbed(num_embeddings=7, features=3)
+    token_ids = tf.constant([[0, 2], [5, 1]], dtype=tf.int32)
+    query = tf.reshape(tf.linspace(-0.4, 0.5, 6), (2, 3))
+    expected_lookup = layer(token_ids)
+    expected_attend = layer.attend(query)
+
+    export_dir = tmp_path / "embed"
+    layer.export(
+        export_dir,
+        tf.TensorSpec([None, None], tf.int32),
+        tf.TensorSpec([None, 3], tf.float32),
+    )
+    restored = tf.saved_model.load(export_dir)
+
+    assert set(restored.signatures) == {"serving_default", "attend"}
+    _assert_outputs_match(
+        expected_lookup, restored, "serving_default", inputs=token_ids
+    )
+    _assert_outputs_match(expected_attend, restored, "attend", query=query)
+    _assert_variables_preserved(layer, restored)
+
+
+def test_yat_attention_exports_cross_attention_signature(tmp_path):
+    layer = MultiHeadYatAttention(embed_dim=4, num_heads=2, dropout=0.2)
+    query = tf.reshape(tf.linspace(-0.7, 0.8, 8), (1, 2, 4))
+    key = tf.reshape(tf.linspace(-0.6, 0.9, 12), (1, 3, 4))
+    value = tf.reshape(tf.linspace(0.8, -0.5, 12), (1, 3, 4))
+    expected = layer(query, key=key, value=value, training=False)
+
+    export_dir = tmp_path / "attention"
+    layer.export(
+        export_dir,
+        tf.TensorSpec([None, None, 4], tf.float32),
+        key_signature=tf.TensorSpec([None, None, 4], tf.float32),
+        value_signature=tf.TensorSpec([None, None, 4], tf.float32),
+    )
+    restored = tf.saved_model.load(export_dir)
+
+    _assert_outputs_match(
+        expected,
+        restored,
+        "serving_default",
+        query=query,
+        key=key,
+        value=value,
+    )
+    _assert_variables_preserved(layer, restored)
+
+
+def test_attention_export_rejects_partial_cross_attention_signature(tmp_path):
+    layer = MultiHeadYatAttention(embed_dim=4, num_heads=2)
+    with pytest.raises(ValueError, match="both be provided"):
+        layer.export(
+            tmp_path / "invalid",
+            tf.TensorSpec([None, None, 4], tf.float32),
+            key_signature=tf.TensorSpec([None, None, 4], tf.float32),
+        )


### PR DESCRIPTION
Fixes #57
Fixes #58

Implements explicit grouped 1D/2D/3D convolution with correct per-group patch norms and adds callable SavedModel export APIs/signatures for dense, all convolution variants, embedding lookup/attend, and self/cross attention.

Verification (isolated Python 3.11 + TensorFlow 2.21):
- new tests: 20 passed
- full TensorFlow suite: 149 passed, 1 existing skip
- Keras suite: 130 passed
- independent eager + tf.function grouped forward and input/kernel/bias/alpha/epsilon gradient parity across groups 2/4, SAME/VALID, stride variants
- independent SavedModel dynamic-shape/dtype/signature round trips for every exported family
- backend-optional collection remains clean

Known upstream CPU limitation: TensorFlow 2.21 ordinary dilation>1 convolution backward is unsupported on CPU; this predates the grouped fix.