### PR TITLE
fix(mlx): preserve epsilon gradients and SAME transpose shapes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,11 +297,14 @@ jobs:
         tests/test_mlx/test_all_layers.py
         -v
         -k "fused_yat_score_executes_metal_kernel_on_gpu or
+        gpu_array_epsilon_all_vjps_compile_and_softplus_chain or
+        gpu_compiled_fused_module_lazy_epsilon_chain or
         fused_yat_array_epsilon_all_gradients_match_eager_and_compile or
         yat_nmn_fused_learnable_epsilon_gradient_parity or
         compiled_yat_nmn_preserves_softplus_epsilon_parameter_chain or
         conv_transpose_same_exact_shape_all_dimensions or
         conv_transpose1d_same_math_parity or
+        gpu_conv_transpose_same_multidim_forward_and_gradient_parity or
         conv_transpose_same_multidim_forward_and_gradient_parity"
 
     - name: Run full MLX suite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,7 @@ jobs:
     - name: Install MLX test dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov
+        pip install numpy pytest pytest-cov
         pip install -e ".[mlx]"
 
     - name: Verify MLX Metal device

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,6 +249,64 @@ jobs:
     - name: Run Keras backend suite
       run: pytest tests/test_keras/ -v --cov=nmn --cov-report=xml
 
+  test-mlx:
+    name: Test MLX (Apple Silicon)
+    runs-on: macos-15
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Report Apple Silicon environment
+      run: |
+        uname -m
+        sw_vers
+        python -c "import platform; print(platform.platform()); print(platform.machine())"
+
+    - name: Install MLX test dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov
+        pip install -e ".[mlx]"
+
+    - name: Verify MLX Metal device
+      run: |
+        python - <<'PY'
+        import platform
+        import mlx.core as mx
+
+        print(f"architecture={platform.machine()}")
+        print(f"default_device={mx.default_device()}")
+        print(f"gpu_device={mx.gpu}")
+        assert platform.machine() == "arm64"
+        mx.set_default_device(mx.gpu)
+        value = mx.arange(4, dtype=mx.float32) ** 2
+        mx.eval(value)
+        print(f"metal_smoke={value}")
+        PY
+
+    - name: Run focused MLX regressions
+      run: >-
+        pytest
+        tests/test_mlx/test_fused.py
+        tests/test_mlx/test_all_layers.py
+        -v
+        -k "fused_yat_score_executes_metal_kernel_on_gpu or
+        fused_yat_array_epsilon_all_gradients_match_eager_and_compile or
+        yat_nmn_fused_learnable_epsilon_gradient_parity or
+        compiled_yat_nmn_preserves_softplus_epsilon_parameter_chain or
+        conv_transpose_same_exact_shape_all_dimensions or
+        conv_transpose1d_same_math_parity or
+        conv_transpose_same_multidim_forward_and_gradient_parity"
+
+    - name: Run full MLX suite
+      run: pytest tests/test_mlx/ -v --cov=nmn --cov-report=xml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/src/nmn/mlx/conv.py
+++ b/src/nmn/mlx/conv.py
@@ -12,8 +12,10 @@ Tensor layouts (MLX native, channels-last):
 * output : ``(N, *spatial', C_out)``
 
 Padding accepts ``"valid"`` / ``"same"`` strings or an integer / sequence
-of integers for explicit symmetric padding. Asymmetric padding for
-"same" is supported via ``mx.conv_general``'s tuple form.
+of integers for explicit symmetric padding. Forward convolution uses
+``mx.conv_general``'s asymmetric tuple form. Transposed ``"same"`` produces
+``input * stride + output_padding`` spatial sizes, using a high-side shape
+adjustment where MLX's symmetric-only native padding cannot express it.
 
 Limitations vs the NNX backend (to be lifted in later PRs):
 * No ``CIRCULAR`` / ``REFLECT`` / ``CAUSAL`` padding modes — only
@@ -152,6 +154,33 @@ def _prepad_input(
             parts.append(suffix)
         x = mx.concatenate(parts, axis=axis)
     return x
+
+
+def _resize_spatial_high(
+    x: mx.array,
+    target_spatial: Tuple[int, ...],
+) -> mx.array:
+    """Crop or zero-pad the high side of each spatial axis to ``target``.
+
+    MLX transposed convolution only accepts symmetric input padding. Some
+    ``SAME`` configurations require asymmetric effective padding, so we use
+    the closest symmetric native convolution and make the one-sided shape
+    adjustment explicitly. Applying this identically to the dot-product and
+    patch-norm maps preserves the YAT calculation at every retained position.
+    """
+    slices = [slice(None)]
+    for current, target in zip(x.shape[1:-1], target_spatial):
+        slices.append(slice(0, min(int(current), int(target))))
+    slices.append(slice(None))
+    x = x[tuple(slices)]
+
+    pad_width = [(0, 0)] * x.ndim
+    needs_padding = False
+    for axis, target in enumerate(target_spatial, start=1):
+        extra = max(int(target) - int(x.shape[axis]), 0)
+        pad_width[axis] = (0, extra)
+        needs_padding = needs_padding or extra > 0
+    return mx.pad(x, pad_width) if needs_padding else x
 
 
 def _take_slice(x: mx.array, axis: int, start: int, stop: int) -> mx.array:
@@ -546,17 +575,31 @@ class _YatConvTransposeBase(nn.Module):
             inputs = inputs.astype(self.dtype)
         self._maybe_build(inputs)
 
-        # MLX's conv_transpose*d takes integer / tuple padding. For "same"
-        # we approximate symmetric padding from the kernel size — works
-        # exactly for odd kernels with stride 1, slightly off otherwise.
+        # ``SAME`` is defined per axis as
+        # ``output = input * stride + output_padding``. MLX only accepts
+        # symmetric padding, while even effective kernels and some stride /
+        # dilation combinations require asymmetric padding. We therefore run
+        # with the closest symmetric padding and crop/pad the high side below.
+        same_target: Optional[Tuple[int, ...]] = None
         if isinstance(self.padding, str):
             mode = self.padding.upper()
             if mode == "VALID":
                 pad_arg: Union[int, Tuple[int, ...]] = 0
             elif mode == "SAME":
-                pad_arg = tuple(
-                    ((k - 1) * d) // 2
+                effective_kernel = tuple(
+                    (k - 1) * d + 1
                     for k, d in zip(self.kernel_size, self.dilation_rate)
+                )
+                native_padding = tuple(
+                    max(effective - stride, 0) // 2
+                    for effective, stride in zip(effective_kernel, self.strides)
+                )
+                pad_arg = native_padding if self._ndim > 1 else native_padding[0]
+                same_target = tuple(
+                    int(size) * stride + out_pad
+                    for size, stride, out_pad in zip(
+                        inputs.shape[1:-1], self.strides, self.output_padding
+                    )
                 )
             else:
                 raise ValueError(f"unknown padding mode: {self.padding!r}")
@@ -599,6 +642,11 @@ class _YatConvTransposeBase(nn.Module):
             dilation=self.dilation_rate if self._ndim > 1 else self.dilation_rate[0],
             output_padding=self.output_padding if self._ndim > 1 else self.output_padding[0],
         )
+        if same_target is not None:
+            dot_prod_map = _resize_spatial_high(dot_prod_map, same_target)
+            patch_sq_filter_map = _resize_spatial_high(
+                patch_sq_filter_map, same_target
+            )
         # All filter channels carry the same sum (the kernel was all ones)
         # — take channel 0 and broadcast.
         patch_sq_map_one = patch_sq_filter_map[..., :1]

--- a/src/nmn/mlx/fused.py
+++ b/src/nmn/mlx/fused.py
@@ -15,7 +15,7 @@ Use via the convenience helper :func:`fused_yat_score`, or pass
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 import mlx.core as mx
 
@@ -176,7 +176,7 @@ def fused_yat_score(
     w: mx.array,
     bias: Optional[mx.array] = None,
     alpha: Optional[mx.array] = None,
-    epsilon: float = 1e-5,
+    epsilon: Union[float, mx.array] = 1e-5,
 ) -> mx.array:
     """Convenience wrapper that fills in defaults and flattens batch dims.
 
@@ -187,7 +187,8 @@ def fused_yat_score(
             :class:`nmn.mlx.YatNMN.kernel`.
         bias: Optional ``(out_features,)``; defaults to all zeros.
         alpha: Optional scalar (or 1-element array); defaults to 1.0.
-        epsilon: Stability constant.
+        epsilon: Stability constant. May be a Python scalar or a scalar /
+            one-element MLX array. Array inputs are kept in the autodiff graph.
 
     Returns:
         ``(..., out_features)``.
@@ -207,7 +208,18 @@ def fused_yat_score(
         alpha = mx.ones((1,), dtype=x.dtype)
     elif alpha.ndim == 0:
         alpha = mx.reshape(alpha, (1,))
-    eps_arr = mx.array([epsilon], dtype=x.dtype)
+    # Do not unconditionally reconstruct epsilon with ``mx.array``: doing so
+    # detaches a learnable epsilon from the graph (and fails under tracing).
+    # Reshape/cast are differentiable MLX operations, so gradients from the
+    # custom VJP continue through softplus to ``epsilon_param``.
+    if hasattr(epsilon, "shape"):
+        if epsilon.size != 1:
+            raise ValueError(
+                f"epsilon must be scalar or have one element, got shape {epsilon.shape}"
+            )
+        eps_arr = mx.reshape(epsilon, (1,)).astype(x.dtype)
+    else:
+        eps_arr = mx.array([epsilon], dtype=x.dtype)
 
     out_flat = _fused_yat_core(flat_x, w, bias, alpha, eps_arr)
     return mx.reshape(out_flat, leading + (out_features,))

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -241,7 +241,9 @@ class YatNMN(nn.Module):
             else:
                 alpha_arr = mx.ones((1,), dtype=self.dtype)
             if self.learnable_epsilon and getattr(self, "epsilon_param", None) is not None:
-                eps_val = float(nn.softplus(self.epsilon_param)[0])
+                # Keep epsilon as an MLX array. Converting it to ``float``
+                # detaches epsilon_param from autodiff and breaks mx.compile.
+                eps_val = nn.softplus(self.epsilon_param)
             else:
                 eps_val = self.epsilon
             return fused_yat_score(inputs, kernel, bias=bias, alpha=alpha_arr,

--- a/tests/test_mlx/conftest.py
+++ b/tests/test_mlx/conftest.py
@@ -33,3 +33,18 @@ def _force_cpu():
     mlx_core.set_default_device(mlx_core.cpu)
     yield
     mlx_core.set_default_device(prev)
+
+
+@pytest.fixture
+def mlx_gpu(_force_cpu):
+    """Override the CPU fixture for tests that must execute Metal kernels."""
+    assert mlx_core is not None
+    previous = mlx_core.default_device()
+    mlx_core.set_default_device(mlx_core.gpu)
+    assert str(mlx_core.default_device()) == "Device(gpu, 0)"
+    try:
+        yield mlx_core.gpu
+        # Catch tests that accidentally switch back to the CPU before teardown.
+        assert str(mlx_core.default_device()) == "Device(gpu, 0)"
+    finally:
+        mlx_core.set_default_device(previous)

--- a/tests/test_mlx/test_all_layers.py
+++ b/tests/test_mlx/test_all_layers.py
@@ -76,6 +76,46 @@ def test_conv_transpose2d_same_shape():
     assert out.shape == (1, 16, 16, 4)
 
 
+@pytest.mark.parametrize(
+    "layer_cls,input_shape,kernel,stride,dilation,output_padding,expected",
+    [
+        (YatConvTranspose1D, (1, 5, 2), 3, 2, 1, 0, (1, 10, 3)),
+        (YatConvTranspose1D, (1, 5, 2), 4, 1, 1, 0, (1, 5, 3)),
+        (YatConvTranspose1D, (1, 5, 2), 2, 2, 2, 1, (1, 11, 3)),
+        (
+            YatConvTranspose2D,
+            (1, 4, 5, 2),
+            (4, 3),
+            (2, 1),
+            (1, 2),
+            (1, 0),
+            (1, 9, 5, 3),
+        ),
+        (
+            YatConvTranspose3D,
+            (1, 3, 4, 5, 2),
+            (2, 3, 4),
+            (2, 1, 2),
+            (2, 1, 1),
+            (0, 0, 0),
+            (1, 6, 4, 10, 3),
+        ),
+    ],
+)
+def test_conv_transpose_same_exact_shape_all_dimensions(
+    layer_cls, input_shape, kernel, stride, dilation, output_padding, expected
+):
+    layer = layer_cls(
+        filters=3,
+        kernel_size=kernel,
+        strides=stride,
+        dilation_rate=dilation,
+        output_padding=output_padding,
+        padding="same",
+    )
+    assert layer(mx.ones(input_shape)).shape == expected
+
+
 def test_conv_transpose3d_shape():
     layer = YatConvTranspose3D(filters=2, kernel_size=2, strides=2)
     x = mx.random.normal(shape=(1, 4, 4, 4, 2))
@@ -146,6 +186,57 @@ def test_conv_transpose1d_math_parity():
             ref[0, p, f] = a * (dot + b[f]) ** 2 / (dist + 1e-5)
 
     assert np.max(np.abs(y - ref)) < 1e-5
+
+
+@pytest.mark.parametrize("kernel_size,stride,dilation", [(3, 2, 1), (4, 1, 1), (2, 2, 2)])
+def test_conv_transpose1d_same_math_parity(kernel_size, stride, dilation):
+    """SAME uses a symmetric native transpose followed by a high-side
+    adjustment; compare its complete YAT result to that definition."""
+    layer = YatConvTranspose1D(
+        filters=2,
+        kernel_size=kernel_size,
+        strides=stride,
+        dilation_rate=dilation,
+        padding="same",
+        epsilon=0.02,
+    )
+    x = mx.array([[[0.2], [-0.4], [0.7], [0.1]]])
+    layer.build(1)
+    layer.kernel = mx.reshape(
+        mx.arange(1, 2 * kernel_size + 1, dtype=mx.float32) * 0.05,
+        (2, kernel_size, 1),
+    )
+    layer.bias = mx.array([0.1, -0.2])
+    layer.alpha = mx.array([1.3])
+    actual = np.array(layer(x))
+
+    xn = np.array(x)
+    weights = np.array(layer.kernel)
+    effective = (kernel_size - 1) * dilation + 1
+    native_pad = max(effective - stride, 0) // 2
+    full_size = (xn.shape[1] - 1) * stride + effective
+    dot_full = np.zeros((1, full_size, 2), dtype=np.float32)
+    patch_full = np.zeros_like(dot_full)
+    for index in range(xn.shape[1]):
+        for k in range(kernel_size):
+            out_index = index * stride + k * dilation
+            dot_full[0, out_index, :] += xn[0, index, 0] * weights[:, k, 0]
+            patch_full[0, out_index, :] += xn[0, index, 0] ** 2
+    native_stop = full_size - native_pad if native_pad else full_size
+    dot = dot_full[:, native_pad:native_stop, :]
+    patch_sq = patch_full[:, native_pad:native_stop, :]
+    target = xn.shape[1] * stride
+    dot = dot[:, :target, :]
+    patch_sq = patch_sq[:, :target, :]
+    if dot.shape[1] < target:
+        width = target - dot.shape[1]
+        dot = np.pad(dot, ((0, 0), (0, width), (0, 0)))
+        patch_sq = np.pad(patch_sq, ((0, 0), (0, width), (0, 0)))
+    kernel_sq = np.sum(weights * weights, axis=(1, 2))[None, None, :]
+    dist = np.maximum(patch_sq + kernel_sq - 2.0 * dot, 0.0)
+    expected = 1.3 * (dot + np.array([0.1, -0.2])) ** 2 / (dist + 0.02)
+    assert actual.shape == (1, target, 2)
+    assert np.allclose(actual, expected, rtol=2e-5, atol=2e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mlx/test_all_layers.py
+++ b/tests/test_mlx/test_all_layers.py
@@ -11,6 +11,8 @@ Covers:
 
 from __future__ import annotations
 
+import itertools
+
 import numpy as np
 import pytest
 
@@ -22,6 +24,62 @@ from nmn.mlx import (  # noqa: E402
     YatConv1D, YatConv2D, YatConv3D,
     YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
 )
+
+
+def _explicit_same_transpose_reference(
+    inputs, kernel, bias, alpha, epsilon, strides, dilation, output_padding
+):
+    """Differentiable definition of asymmetric SAME transpose convolution.
+
+    This intentionally does not call an MLX convolution or reproduce the
+    implementation's symmetric-convolution/crop strategy. Instead it applies
+    the defining scatter relation directly: input position ``i`` and kernel
+    position ``k`` contribute to ``i * stride + k * dilation - pad_low``.
+    """
+    spatial = tuple(int(size) for size in inputs.shape[1:-1])
+    kernel_size = tuple(int(size) for size in kernel.shape[1:-1])
+    strides = tuple(int(value) for value in strides)
+    dilation = tuple(int(value) for value in dilation)
+    output_padding = tuple(int(value) for value in output_padding)
+    effective = tuple(
+        (size - 1) * rate + 1 for size, rate in zip(kernel_size, dilation)
+    )
+    pad_low = tuple(
+        max(size - stride, 0) // 2 for size, stride in zip(effective, strides)
+    )
+    target = tuple(
+        size * stride + extra
+        for size, stride, extra in zip(spatial, strides, output_padding)
+    )
+    batch = inputs.shape[0]
+    filters = kernel.shape[0]
+    kernel_sq = mx.sum(kernel * kernel, axis=tuple(range(1, kernel.ndim)))
+    output_values = []
+    for out_coord in itertools.product(*(range(size) for size in target)):
+        dot = mx.zeros((batch, filters), dtype=inputs.dtype)
+        patch_sq = mx.zeros((batch, 1), dtype=inputs.dtype)
+        for input_coord in itertools.product(*(range(size) for size in spatial)):
+            x_value = inputs[(slice(None), *input_coord, slice(None))]
+            for kernel_coord in itertools.product(
+                *(range(size) for size in kernel_size)
+            ):
+                scattered = tuple(
+                    index * stride + offset * rate - low
+                    for index, stride, offset, rate, low in zip(
+                        input_coord, strides, kernel_coord, dilation, pad_low
+                    )
+                )
+                if scattered != out_coord:
+                    continue
+                kernel_value = kernel[(slice(None), *kernel_coord, slice(None))]
+                dot = dot + x_value @ kernel_value.T
+                patch_sq = patch_sq + mx.sum(
+                    x_value * x_value, axis=-1, keepdims=True
+                )
+        distance = mx.maximum(patch_sq + kernel_sq - 2.0 * dot, 0.0)
+        output_values.append(alpha * (dot + bias) ** 2 / (distance + epsilon))
+    flat = mx.stack(output_values, axis=1)
+    return mx.reshape(flat, (batch, *target, filters))
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +261,7 @@ def test_conv_transpose1d_same_math_parity(kernel_size, stride, dilation):
     x = mx.array([[[0.2], [-0.4], [0.7], [0.1]]])
     layer.build(1)
     layer.kernel = mx.reshape(
-        mx.arange(1, 2 * kernel_size + 1, dtype=mx.float32) * 0.05,
+        (mx.arange(2 * kernel_size, dtype=mx.float32) + 1) * 0.05,
         (2, kernel_size, 1),
     )
     layer.bias = mx.array([0.1, -0.2])
@@ -237,6 +295,109 @@ def test_conv_transpose1d_same_math_parity(kernel_size, stride, dilation):
     expected = 1.3 * (dot + np.array([0.1, -0.2])) ** 2 / (dist + 0.02)
     assert actual.shape == (1, target, 2)
     assert np.allclose(actual, expected, rtol=2e-5, atol=2e-6)
+
+
+@pytest.mark.parametrize(
+    "layer_cls,input_shape,kernel_size,strides,dilation,output_padding",
+    [
+        (
+            YatConvTranspose2D,
+            (1, 3, 2, 1),
+            (4, 3),
+            (2, 1),
+            (1, 2),
+            (1, 0),
+        ),
+        (
+            YatConvTranspose3D,
+            (1, 2, 2, 2, 1),
+            (3, 2, 2),
+            (1, 2, 2),
+            (1, 2, 1),
+            (0, 1, 1),
+        ),
+    ],
+)
+def test_conv_transpose_same_multidim_forward_and_gradient_parity(
+    layer_cls, input_shape, kernel_size, strides, dilation, output_padding
+):
+    """2D/3D mixed-axis SAME matches the explicit asymmetric definition.
+
+    Both cases combine odd and even kernels, non-unit stride/dilation, and
+    nonzero output padding. Input and kernel gradients are compared as well
+    as the complete forward tensor.
+    """
+    epsilon = 0.03
+    layer = layer_cls(
+        filters=2,
+        kernel_size=kernel_size,
+        strides=strides,
+        dilation_rate=dilation,
+        output_padding=output_padding,
+        padding="same",
+        epsilon=epsilon,
+    )
+    layer.build(input_shape[-1])
+    kernel_elements = int(np.prod(layer.kernel.shape))
+    layer.kernel = mx.reshape(
+        (mx.arange(kernel_elements, dtype=mx.float32) + 1) * 0.025,
+        layer.kernel.shape,
+    )
+    layer.bias = mx.array([0.08, -0.11])
+    layer.alpha = mx.array([1.2])
+    input_elements = int(np.prod(input_shape))
+    inputs = mx.reshape(
+        (mx.arange(input_elements, dtype=mx.float32) + 1) * 0.04 - 0.2,
+        input_shape,
+    )
+
+    def reference(value, kernel):
+        return _explicit_same_transpose_reference(
+            value,
+            kernel,
+            layer.bias,
+            layer.alpha,
+            epsilon,
+            strides,
+            dilation,
+            output_padding,
+        )
+
+    actual = layer(inputs)
+    expected = reference(inputs, layer.kernel)
+    cotangent = mx.reshape(
+        (mx.arange(actual.size, dtype=mx.float32) + 1) / actual.size,
+        actual.shape,
+    )
+
+    def layer_loss(model, value):
+        return mx.sum(model(value) * cotangent)
+
+    _, layer_grads = mlx_nn.value_and_grad(layer, layer_loss)(layer, inputs)
+    actual_input_grad = mx.grad(
+        lambda value: mx.sum(layer(value) * cotangent)
+    )(inputs)
+
+    def reference_loss(value, kernel):
+        return mx.sum(reference(value, kernel) * cotangent)
+
+    _, (expected_input_grad, expected_kernel_grad) = mx.value_and_grad(
+        reference_loss, argnums=(0, 1)
+    )(inputs, layer.kernel)
+
+    assert np.allclose(np.array(actual), np.array(expected), rtol=3e-5, atol=3e-6)
+    assert np.allclose(
+        np.array(actual_input_grad),
+        np.array(expected_input_grad),
+        rtol=8e-5,
+        atol=8e-6,
+    )
+    assert np.allclose(
+        np.array(layer_grads["kernel"]),
+        np.array(expected_kernel_grad),
+        rtol=8e-5,
+        atol=8e-6,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mlx/test_all_layers.py
+++ b/tests/test_mlx/test_all_layers.py
@@ -297,36 +297,40 @@ def test_conv_transpose1d_same_math_parity(kernel_size, stride, dilation):
     assert np.allclose(actual, expected, rtol=2e-5, atol=2e-6)
 
 
-@pytest.mark.parametrize(
-    "layer_cls,input_shape,kernel_size,strides,dilation,output_padding",
-    [
-        (
-            YatConvTranspose2D,
-            (1, 3, 2, 1),
-            (4, 3),
-            (2, 1),
-            (1, 2),
-            (1, 0),
-        ),
-        (
-            YatConvTranspose3D,
-            (1, 2, 2, 2, 1),
-            (3, 2, 2),
-            (1, 2, 2),
-            (1, 2, 1),
-            (0, 1, 1),
-        ),
-    ],
-)
-def test_conv_transpose_same_multidim_forward_and_gradient_parity(
-    layer_cls, input_shape, kernel_size, strides, dilation, output_padding
-):
-    """2D/3D mixed-axis SAME matches the explicit asymmetric definition.
+_SAME_MULTIDIM_CASES = [
+    (
+        YatConvTranspose2D,
+        (1, 3, 2, 1),
+        (4, 3),
+        (2, 1),
+        (1, 2),
+        (1, 0),
+    ),
+    (
+        YatConvTranspose3D,
+        (1, 2, 2, 2, 1),
+        (3, 2, 2),
+        (1, 2, 2),
+        (1, 2, 1),
+        (0, 1, 1),
+    ),
+]
 
-    Both cases combine odd and even kernels, non-unit stride/dilation, and
-    nonzero output padding. Input and kernel gradients are compared as well
-    as the complete forward tensor.
-    """
+
+def _assert_same_multidim_forward_and_gradient_parity(
+    layer_cls,
+    input_shape,
+    kernel_size,
+    strides,
+    dilation,
+    output_padding,
+    *,
+    forward_rtol,
+    forward_atol,
+    gradient_rtol,
+    gradient_atol,
+    require_gpu=False,
+):
     epsilon = 0.03
     layer = layer_cls(
         filters=2,
@@ -384,19 +388,86 @@ def test_conv_transpose_same_multidim_forward_and_gradient_parity(
     _, (expected_input_grad, expected_kernel_grad) = mx.value_and_grad(
         reference_loss, argnums=(0, 1)
     )(inputs, layer.kernel)
+    mx.eval(
+        actual,
+        expected,
+        actual_input_grad,
+        expected_input_grad,
+        layer_grads["kernel"],
+        expected_kernel_grad,
+    )
 
-    assert np.allclose(np.array(actual), np.array(expected), rtol=3e-5, atol=3e-6)
+    if require_gpu:
+        assert str(mx.default_device()) == "Device(gpu, 0)"
+    assert np.allclose(
+        np.array(actual),
+        np.array(expected),
+        rtol=forward_rtol,
+        atol=forward_atol,
+    )
     assert np.allclose(
         np.array(actual_input_grad),
         np.array(expected_input_grad),
-        rtol=8e-5,
-        atol=8e-6,
+        rtol=gradient_rtol,
+        atol=gradient_atol,
     )
     assert np.allclose(
         np.array(layer_grads["kernel"]),
         np.array(expected_kernel_grad),
-        rtol=8e-5,
-        atol=8e-6,
+        rtol=gradient_rtol,
+        atol=gradient_atol,
+    )
+
+
+@pytest.mark.parametrize(
+    "layer_cls,input_shape,kernel_size,strides,dilation,output_padding",
+    _SAME_MULTIDIM_CASES,
+)
+def test_conv_transpose_same_multidim_forward_and_gradient_parity(
+    layer_cls, input_shape, kernel_size, strides, dilation, output_padding
+):
+    """2D/3D mixed-axis SAME matches the explicit asymmetric definition."""
+    _assert_same_multidim_forward_and_gradient_parity(
+        layer_cls,
+        input_shape,
+        kernel_size,
+        strides,
+        dilation,
+        output_padding,
+        forward_rtol=3e-5,
+        forward_atol=3e-6,
+        gradient_rtol=8e-5,
+        gradient_atol=8e-6,
+    )
+
+
+@pytest.mark.parametrize(
+    "layer_cls,input_shape,kernel_size,strides,dilation,output_padding",
+    _SAME_MULTIDIM_CASES,
+)
+def test_gpu_conv_transpose_same_multidim_forward_and_gradient_parity(
+    mlx_gpu,
+    layer_cls,
+    input_shape,
+    kernel_size,
+    strides,
+    dilation,
+    output_padding,
+):
+    """Mixed-axis 2D/3D SAME output and gradients agree on Metal."""
+    del mlx_gpu
+    _assert_same_multidim_forward_and_gradient_parity(
+        layer_cls,
+        input_shape,
+        kernel_size,
+        strides,
+        dilation,
+        output_padding,
+        forward_rtol=3e-3,
+        forward_atol=3e-4,
+        gradient_rtol=6e-3,
+        gradient_atol=6e-4,
+        require_gpu=True,
     )
 
 

--- a/tests/test_mlx/test_fused.py
+++ b/tests/test_mlx/test_fused.py
@@ -183,6 +183,41 @@ def test_fused_yat_array_epsilon_all_gradients_match_eager_and_compile():
         mx.set_default_device(mx.cpu)
 
 
+def test_fused_yat_scalar_array_epsilon_vjp_matches_eager():
+    """A zero-dimensional MLX epsilon is a direct differentiable primal."""
+    mx.set_default_device(mx.cpu)
+    try:
+        x = mx.array([[0.2, -0.4], [0.5, 0.1]])
+        w = mx.array([[0.3, -0.2], [-0.5, 0.4]])
+        b = mx.array([0.1, -0.2])
+        alpha = mx.array([1.25])
+        eps = mx.array(0.07)
+
+        def eager_loss(value):
+            dot = x @ w.T
+            dist = mx.maximum(
+                mx.sum(x * x, axis=-1, keepdims=True)
+                + mx.sum(w * w, axis=-1)[None, :]
+                - 2.0 * dot,
+                0.0,
+            )
+            return mx.sum(alpha * (dot + b) ** 2 / (dist + value))
+
+        def fused_loss(value):
+            return mx.sum(
+                fused_yat_score(x, w, bias=b, alpha=alpha, epsilon=value)
+            )
+
+        expected = mx.grad(eager_loss)(eps)
+        actual = mx.grad(fused_loss)(eps)
+        assert actual.shape == ()
+        assert np.allclose(np.array(actual), np.array(expected), rtol=2e-5, atol=2e-6)
+        assert np.isfinite(float(actual))
+        assert float(actual) != 0.0
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
 # ---------------------------------------------------------------------------
 # YatNMN(fused=True) integration
 # ---------------------------------------------------------------------------
@@ -336,5 +371,65 @@ def test_yat_nmn_fused_learnable_epsilon_gradient_parity(lazy):
         eps_grad = np.array(fused_grads["epsilon_param"])
         assert np.all(np.isfinite(eps_grad))
         assert np.any(eps_grad != 0.0)
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+def test_compiled_yat_nmn_preserves_softplus_epsilon_parameter_chain():
+    """Compilation keeps the module's epsilon_param -> softplus -> fused VJP
+    chain intact, rather than merely differentiating a precomputed epsilon."""
+
+    def loss_fn(model, x):
+        return mx.sum(model(x))
+
+    mx.set_default_device(mx.cpu)
+    try:
+        layer = YatNMN(
+            features=2,
+            fused=True,
+            learnable_epsilon=True,
+            epsilon=0.07,
+        )
+        layer.build(3)
+        layer.kernel = mx.array([[0.3, -0.2, 0.6], [-0.5, 0.4, 0.2]])
+        layer.bias = mx.array([0.1, -0.2])
+        layer.alpha = mx.array([1.25])
+        inputs = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+
+        grad_fn = mlx_nn.value_and_grad(layer, loss_fn)
+        _, eager_grads = grad_fn(layer, inputs)
+        compiled_grad_fn = mx.compile(
+            lambda value: grad_fn(layer, value),
+            inputs=layer.trainable_parameters(),
+        )
+        _, compiled_grads = compiled_grad_fn(inputs)
+
+        constrained_epsilon = mlx_nn.softplus(layer.epsilon_param)
+        epsilon_grad = mx.grad(
+            lambda eps: mx.sum(
+                fused_yat_score(
+                    inputs,
+                    layer.kernel,
+                    bias=layer.bias,
+                    alpha=layer.alpha,
+                    epsilon=eps,
+                )
+            )
+        )(constrained_epsilon)
+        expected_param_grad = epsilon_grad * mx.sigmoid(layer.epsilon_param)
+
+        assert np.allclose(
+            np.array(compiled_grads["epsilon_param"]),
+            np.array(eager_grads["epsilon_param"]),
+            rtol=2e-5,
+            atol=2e-6,
+        )
+        assert np.allclose(
+            np.array(compiled_grads["epsilon_param"]),
+            np.array(expected_param_grad),
+            rtol=2e-5,
+            atol=2e-6,
+        )
+        assert np.any(np.array(compiled_grads["epsilon_param"]) != 0.0)
     finally:
         mx.set_default_device(mx.cpu)

--- a/tests/test_mlx/test_fused.py
+++ b/tests/test_mlx/test_fused.py
@@ -130,6 +130,59 @@ def test_fused_yat_gradient_matches_finite_difference():
         mx.set_default_device(mx.cpu)
 
 
+def test_fused_yat_array_epsilon_all_gradients_match_eager_and_compile():
+    """An array epsilon remains a differentiable argument, including when
+    the value-and-gradient function is compiled."""
+    mx.set_default_device(mx.cpu)
+    try:
+        x = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+        w = mx.array([[0.3, -0.2, 0.6], [-0.5, 0.4, 0.2]])
+        b = mx.array([0.1, -0.2])
+        alpha = mx.array([1.25])
+        eps = mx.array([0.07])
+
+        def eager_loss(x, w, b, alpha, eps):
+            dot = x @ w.T
+            dist = mx.maximum(
+                mx.sum(x * x, axis=-1, keepdims=True)
+                + mx.sum(w * w, axis=-1)[None, :]
+                - 2.0 * dot,
+                0.0,
+            )
+            return mx.sum(alpha * (dot + b) ** 2 / (dist + eps))
+
+        def fused_loss(x, w, b, alpha, eps):
+            return mx.sum(
+                fused_yat_score(x, w, bias=b, alpha=alpha, epsilon=eps)
+            )
+
+        argnums = (0, 1, 2, 3, 4)
+        eager_value, eager_grads = mx.value_and_grad(
+            eager_loss, argnums=argnums
+        )(x, w, b, alpha, eps)
+        fused_value, fused_grads = mx.value_and_grad(
+            fused_loss, argnums=argnums
+        )(x, w, b, alpha, eps)
+        compiled_value, compiled_grads = mx.compile(
+            mx.value_and_grad(fused_loss, argnums=argnums)
+        )(x, w, b, alpha, eps)
+
+        assert np.allclose(np.array(fused_value), np.array(eager_value), atol=1e-6)
+        assert np.allclose(np.array(compiled_value), np.array(eager_value), atol=1e-6)
+        for eager_grad, fused_grad, compiled_grad in zip(
+            eager_grads, fused_grads, compiled_grads
+        ):
+            assert np.allclose(
+                np.array(fused_grad), np.array(eager_grad), rtol=2e-5, atol=2e-6
+            )
+            assert np.allclose(
+                np.array(compiled_grad), np.array(eager_grad), rtol=2e-5, atol=2e-6
+            )
+        assert abs(float(np.array(fused_grads[-1])[0])) > 0.0
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
 # ---------------------------------------------------------------------------
 # YatNMN(fused=True) integration
 # ---------------------------------------------------------------------------
@@ -233,5 +286,55 @@ def test_yat_nmn_fused_gradient_flow():
         opt.update(layer, grads)
         mx.eval(layer.parameters())
         assert float(loss_fn(layer, x, y)) < float(loss)
+    finally:
+        mx.set_default_device(mx.cpu)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_yat_nmn_fused_learnable_epsilon_gradient_parity(lazy):
+    """Fused module gradients include the softplus epsilon parameter;
+    lazy mode freezes only the kernel."""
+
+    def loss_fn(model, x):
+        return mx.sum(model(x))
+
+    mx.set_default_device(mx.cpu)
+    try:
+        plain = YatNMN(
+            features=2, learnable_epsilon=True, epsilon=0.07, lazy=lazy
+        )
+        fused = YatNMN(
+            features=2, learnable_epsilon=True, epsilon=0.07,
+            fused=True, lazy=lazy,
+        )
+        plain.build(3)
+        fused.build(3)
+        fused.kernel = plain.kernel
+        fused.bias = plain.bias
+        fused.alpha = plain.alpha
+        fused.epsilon_param = plain.epsilon_param
+        x = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+
+        eager_out = plain(x)
+        fused_out = fused(x)
+        _, eager_grads = mlx_nn.value_and_grad(plain, loss_fn)(plain, x)
+        _, fused_grads = mlx_nn.value_and_grad(fused, loss_fn)(fused, x)
+
+        expected_keys = {"bias", "alpha", "epsilon_param"}
+        if not lazy:
+            expected_keys.add("kernel")
+        assert set(eager_grads) == expected_keys
+        assert set(fused_grads) == expected_keys
+        assert np.allclose(np.array(fused_out), np.array(eager_out), atol=1e-6)
+        for name in expected_keys:
+            assert np.allclose(
+                np.array(fused_grads[name]),
+                np.array(eager_grads[name]),
+                rtol=2e-5,
+                atol=2e-6,
+            )
+        eps_grad = np.array(fused_grads["epsilon_param"])
+        assert np.all(np.isfinite(eps_grad))
+        assert np.any(eps_grad != 0.0)
     finally:
         mx.set_default_device(mx.cpu)

--- a/tests/test_mlx/test_fused.py
+++ b/tests/test_mlx/test_fused.py
@@ -26,25 +26,163 @@ def _ref_yat(x_np, w_np, b_np, alpha, eps=1e-5):
     return alpha * (num ** 2) / (dist + eps)
 
 
-def test_fused_yat_score_executes_metal_kernel_on_gpu():
+def test_fused_yat_score_executes_metal_kernel_on_gpu(mlx_gpu):
     """The public Apple Silicon CI runner must execute the fused Metal path."""
-    previous_device = mx.default_device()
-    mx.set_default_device(mx.gpu)
-    try:
-        assert is_gpu_available()
-        x = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
-        w = mx.array([[0.3, -0.2, 0.6], [-0.5, 0.4, 0.2]])
-        bias = mx.array([0.1, -0.2])
-        alpha = mx.array([1.25])
-        actual = fused_yat_score(x, w, bias=bias, alpha=alpha, epsilon=0.07)
-        mx.eval(actual)
+    del mlx_gpu
+    assert is_gpu_available()
+    x = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+    w = mx.array([[0.3, -0.2, 0.6], [-0.5, 0.4, 0.2]])
+    bias = mx.array([0.1, -0.2])
+    alpha = mx.array([1.25])
+    actual = fused_yat_score(x, w, bias=bias, alpha=alpha, epsilon=0.07)
+    mx.eval(actual)
 
-        expected = _ref_yat(
-            np.array(x), np.array(w), np.array(bias), 1.25, eps=0.07
+    expected = _ref_yat(
+        np.array(x), np.array(w), np.array(bias), 1.25, eps=0.07
+    )
+    assert np.allclose(np.array(actual), expected, rtol=3e-3, atol=3e-4)
+
+
+def test_gpu_array_epsilon_all_vjps_compile_and_softplus_chain(mlx_gpu):
+    """Metal forward and VJP preserve every primal, including raw epsilon."""
+    del mlx_gpu
+    x = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+    w = mx.array([[0.3, -0.2, 0.6], [-0.5, 0.4, 0.2]])
+    bias = mx.array([0.1, -0.2])
+    alpha = mx.array([1.25])
+    epsilon_param = mx.array([-2.5])
+
+    def reference_loss(x, w, bias, alpha, epsilon_param):
+        epsilon = mlx_nn.softplus(epsilon_param)
+        dot = x @ w.T
+        distance = mx.maximum(
+            mx.sum(x * x, axis=-1, keepdims=True)
+            + mx.sum(w * w, axis=-1)[None, :]
+            - 2.0 * dot,
+            0.0,
         )
-        assert np.allclose(np.array(actual), expected, rtol=2e-5, atol=2e-6)
-    finally:
-        mx.set_default_device(previous_device)
+        return mx.sum(alpha * (dot + bias) ** 2 / (distance + epsilon))
+
+    def fused_loss(x, w, bias, alpha, epsilon_param):
+        return mx.sum(
+            fused_yat_score(
+                x,
+                w,
+                bias=bias,
+                alpha=alpha,
+                epsilon=mlx_nn.softplus(epsilon_param),
+            )
+        )
+
+    argnums = (0, 1, 2, 3, 4)
+    expected_value, expected_grads = mx.value_and_grad(
+        reference_loss, argnums=argnums
+    )(x, w, bias, alpha, epsilon_param)
+    actual_value, actual_grads = mx.value_and_grad(
+        fused_loss, argnums=argnums
+    )(x, w, bias, alpha, epsilon_param)
+    compiled_value, compiled_grads = mx.compile(
+        mx.value_and_grad(fused_loss, argnums=argnums)
+    )(x, w, bias, alpha, epsilon_param)
+    mx.eval(
+        expected_value,
+        *expected_grads,
+        actual_value,
+        *actual_grads,
+        compiled_value,
+        *compiled_grads,
+    )
+
+    assert is_gpu_available()
+    assert np.allclose(
+        np.array(actual_value), np.array(expected_value), rtol=3e-3, atol=3e-4
+    )
+    assert np.allclose(
+        np.array(compiled_value), np.array(expected_value), rtol=3e-3, atol=3e-4
+    )
+    for expected, actual, compiled in zip(
+        expected_grads, actual_grads, compiled_grads
+    ):
+        assert np.allclose(
+            np.array(actual), np.array(expected), rtol=6e-3, atol=6e-4
+        )
+        assert np.allclose(
+            np.array(compiled), np.array(expected), rtol=6e-3, atol=6e-4
+        )
+    epsilon_grad = np.array(compiled_grads[-1])
+    assert np.all(np.isfinite(epsilon_grad))
+    assert np.any(epsilon_grad != 0.0)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_gpu_compiled_fused_module_lazy_epsilon_chain(mlx_gpu, lazy):
+    """Compiled GPU modules retain softplus epsilon gradients in lazy mode."""
+    del mlx_gpu
+
+    def loss_fn(model, value):
+        return mx.sum(model(value))
+
+    plain = YatNMN(features=2, learnable_epsilon=True, epsilon=0.07, lazy=lazy)
+    fused = YatNMN(
+        features=2,
+        learnable_epsilon=True,
+        epsilon=0.07,
+        fused=True,
+        lazy=lazy,
+    )
+    plain.build(3)
+    fused.build(3)
+    fused.kernel = plain.kernel
+    fused.bias = plain.bias
+    fused.alpha = plain.alpha
+    fused.epsilon_param = plain.epsilon_param
+    inputs = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+
+    plain_value, plain_grads = mlx_nn.value_and_grad(plain, loss_fn)(plain, inputs)
+    grad_fn = mlx_nn.value_and_grad(fused, loss_fn)
+    fused_value, fused_grads = grad_fn(fused, inputs)
+    compiled_value, compiled_grads = mx.compile(
+        lambda value: grad_fn(fused, value),
+        inputs=fused.trainable_parameters(),
+    )(inputs)
+    mx.eval(
+        plain_value,
+        *plain_grads.values(),
+        fused_value,
+        *fused_grads.values(),
+        compiled_value,
+        *compiled_grads.values(),
+    )
+
+    expected_keys = {"bias", "alpha", "epsilon_param"}
+    if not lazy:
+        expected_keys.add("kernel")
+    assert is_gpu_available()
+    assert set(plain_grads) == expected_keys
+    assert set(fused_grads) == expected_keys
+    assert set(compiled_grads) == expected_keys
+    assert np.allclose(
+        np.array(fused_value), np.array(plain_value), rtol=3e-3, atol=3e-4
+    )
+    assert np.allclose(
+        np.array(compiled_value), np.array(plain_value), rtol=3e-3, atol=3e-4
+    )
+    for name in expected_keys:
+        assert np.allclose(
+            np.array(fused_grads[name]),
+            np.array(plain_grads[name]),
+            rtol=6e-3,
+            atol=6e-4,
+        )
+        assert np.allclose(
+            np.array(compiled_grads[name]),
+            np.array(plain_grads[name]),
+            rtol=6e-3,
+            atol=6e-4,
+        )
+    epsilon_grad = np.array(compiled_grads["epsilon_param"])
+    assert np.all(np.isfinite(epsilon_grad))
+    assert np.any(epsilon_grad != 0.0)
 
 
 def test_fused_yat_score_2d_matches_numpy_on_cpu():

--- a/tests/test_mlx/test_fused.py
+++ b/tests/test_mlx/test_fused.py
@@ -26,6 +26,27 @@ def _ref_yat(x_np, w_np, b_np, alpha, eps=1e-5):
     return alpha * (num ** 2) / (dist + eps)
 
 
+def test_fused_yat_score_executes_metal_kernel_on_gpu():
+    """The public Apple Silicon CI runner must execute the fused Metal path."""
+    previous_device = mx.default_device()
+    mx.set_default_device(mx.gpu)
+    try:
+        assert is_gpu_available()
+        x = mx.array([[0.2, -0.4, 0.7], [0.5, 0.1, -0.3]])
+        w = mx.array([[0.3, -0.2, 0.6], [-0.5, 0.4, 0.2]])
+        bias = mx.array([0.1, -0.2])
+        alpha = mx.array([1.25])
+        actual = fused_yat_score(x, w, bias=bias, alpha=alpha, epsilon=0.07)
+        mx.eval(actual)
+
+        expected = _ref_yat(
+            np.array(x), np.array(w), np.array(bias), 1.25, eps=0.07
+        )
+        assert np.allclose(np.array(actual), expected, rtol=2e-5, atol=2e-6)
+    finally:
+        mx.set_default_device(previous_device)
+
+
 def test_fused_yat_score_2d_matches_numpy_on_cpu():
     """On the CPU fallback the fused score must match a numpy reference
     to fp32 ULP."""


### PR DESCRIPTION
Fixes #59 and #77.

Implements fused epsilon autodiff chaining and asymmetric SAME transpose shape correction, with independent 1D/2D/3D numerical and gradient parity tests plus compiled softplus-chain coverage.

Validation includes independent source review and GitHub Actions on a macos-15-arm64 Apple Silicon runner with visible Metal: the dedicated GPU regressions passed and the complete MLX suite finished with 215 passed and 1 skipped. The rest of the cross-framework CI matrix is also green.