### PR TITLE
fix(attention): zero fully masked rows across backends

### DIFF
--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -101,9 +101,18 @@ def yat_attention_weights(
         attn_weights = attn_weights * scale
 
     if mask is not None:
-        attn_weights = ops.where(mask, attn_weights, -1e9)
+        mask = ops.cast(mask, "bool")
+        row_has_key = ops.any(mask, axis=-1, keepdims=True)
+        # -1e4 is finite in float16 and exp(-1e4) underflows to zero for every
+        # supported floating dtype; the exact zero is enforced after softmax.
+        attn_weights = ops.where(mask, attn_weights, -1e4)
+        attn_weights = ops.where(
+            row_has_key, attn_weights, ops.zeros_like(attn_weights)
+        )
 
     attn_weights = ops.softmax(attn_weights, axis=-1)
+    if mask is not None:
+        attn_weights = ops.where(mask, attn_weights, ops.zeros_like(attn_weights))
 
     if dropout_rate > 0.0 and training:
         from keras.src import random
@@ -360,6 +369,12 @@ class MultiHeadYatAttention(Layer):
 
         if self.out_kernel is not None:
             x = self._linear(x, self.out_kernel, self.out_bias)
+
+        if mask is not None:
+            query_has_key = ops.any(ops.cast(mask, "bool"), axis=(-3, -1))
+            x = ops.where(
+                ops.expand_dims(query_has_key, -1), x, ops.zeros_like(x)
+            )
 
         return x
 

--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -101,11 +101,11 @@ def yat_attention_weights(
         attn_weights = attn_weights * scale
 
     if mask is not None:
-        mask = ops.cast(mask, "bool")
+        mask = ops.broadcast_to(
+            ops.cast(mask, "bool"), ops.shape(attn_weights)
+        )
         row_has_key = ops.any(mask, axis=-1, keepdims=True)
-        # -1e4 is finite in float16 and exp(-1e4) underflows to zero for every
-        # supported floating dtype; the exact zero is enforced after softmax.
-        attn_weights = ops.where(mask, attn_weights, -1e4)
+        attn_weights = ops.where(mask, attn_weights, -float("inf"))
         attn_weights = ops.where(
             row_has_key, attn_weights, ops.zeros_like(attn_weights)
         )
@@ -353,10 +353,17 @@ class MultiHeadYatAttention(Layer):
             elif self.alpha_param is not None:
                 alpha_val = self.alpha_param
 
+        effective_mask = None
+        if mask is not None:
+            effective_mask = ops.broadcast_to(
+                ops.cast(mask, "bool"),
+                (batch_size, self.num_heads, q_len, kv_len),
+            )
+
         dropout = self.dropout_rate if training else 0.0
         x = yat_attention(
             q, k, v,
-            mask=mask,
+            mask=effective_mask,
             dropout_rate=dropout,
             training=training,
             epsilon=self.epsilon,
@@ -370,8 +377,8 @@ class MultiHeadYatAttention(Layer):
         if self.out_kernel is not None:
             x = self._linear(x, self.out_kernel, self.out_bias)
 
-        if mask is not None:
-            query_has_key = ops.any(ops.cast(mask, "bool"), axis=(-3, -1))
+        if effective_mask is not None:
+            query_has_key = ops.any(effective_mask, axis=(-3, -1))
             x = ops.where(
                 ops.expand_dims(query_has_key, -1), x, ops.zeros_like(x)
             )

--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -284,10 +284,16 @@ class MultiHeadAttention(Module):
 
         q, k, v, alpha_val = promote_dtype(q, k, v, alpha_val, dtype=self.dtype)
 
+        effective_mask = None
+        if mask is not None:
+            effective_mask = jnp.broadcast_to(
+                mask, q.shape[:-3] + (q.shape[-2], q.shape[-3], k.shape[-3])
+            )
+
         # YAT attention (using NNX functions under the hood)
         x = _nnx_yat_attention(
             q, k, v,
-            mask=mask,
+            mask=effective_mask,
             dropout_rate=self.dropout_rate,
             deterministic=deterministic,
             epsilon=self.epsilon,
@@ -309,8 +315,8 @@ class MultiHeadAttention(Module):
             name="out",
         )(x)
 
-        if mask is not None:
-            query_has_key = jnp.any(mask, axis=(-3, -1))
+        if effective_mask is not None:
+            query_has_key = jnp.any(effective_mask, axis=(-3, -1))
             x = jnp.where(query_has_key[..., None], x, jnp.zeros_like(x))
 
         return x

--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -309,4 +309,8 @@ class MultiHeadAttention(Module):
             name="out",
         )(x)
 
+        if mask is not None:
+            query_has_key = jnp.any(mask, axis=(-3, -1))
+            x = jnp.where(query_has_key[..., None], x, jnp.zeros_like(x))
+
         return x

--- a/src/nmn/mlx/attention.py
+++ b/src/nmn/mlx/attention.py
@@ -31,7 +31,7 @@ __all__ = [
 
 
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
-_MASK_FILL = -1e4  # finite in float16; exp(-1e4) underflows to exact zero
+_MASK_FILL = -math.inf
 
 
 def normalize_qk(
@@ -86,7 +86,7 @@ def yat_attention_weights(
         attn = attn * scale
 
     if mask is not None:
-        mask = mask.astype(mx.bool_)
+        mask = mx.broadcast_to(mask.astype(mx.bool_), attn.shape)
         row_has_key = mx.any(mask, axis=-1, keepdims=True)
         attn = mx.where(
             mask,
@@ -311,9 +311,15 @@ class MultiHeadYatAttention(nn.Module):
             elif getattr(self, "alpha", None) is not None:
                 alpha_val = self.alpha
 
+        effective_mask = None
+        if mask is not None:
+            effective_mask = mx.broadcast_to(
+                mask.astype(mx.bool_), (B, self.num_heads, Q, K_len)
+            )
+
         x = yat_attention(
             q, k, v,
-            mask=mask,
+            mask=effective_mask,
             dropout_rate=self.dropout if training else 0.0,
             training=training,
             epsilon=self.epsilon,
@@ -326,7 +332,7 @@ class MultiHeadYatAttention(nn.Module):
 
         if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
             x = self._linear(x, self.out_kernel, getattr(self, "out_bias", None))
-        if mask is not None:
-            query_has_key = mx.any(mask.astype(mx.bool_), axis=(-3, -1))
+        if effective_mask is not None:
+            query_has_key = mx.any(effective_mask, axis=(-3, -1))
             x = mx.where(query_has_key[..., None], x, mx.zeros_like(x))
         return x

--- a/src/nmn/mlx/attention.py
+++ b/src/nmn/mlx/attention.py
@@ -31,7 +31,7 @@ __all__ = [
 
 
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
-_MASK_FILL = -1e9
+_MASK_FILL = -1e4  # finite in float16; exp(-1e4) underflows to exact zero
 
 
 def normalize_qk(
@@ -86,13 +86,18 @@ def yat_attention_weights(
         attn = attn * scale
 
     if mask is not None:
+        mask = mask.astype(mx.bool_)
+        row_has_key = mx.any(mask, axis=-1, keepdims=True)
         attn = mx.where(
             mask,
             attn,
             mx.array(_MASK_FILL, dtype=attn.dtype),
         )
+        attn = mx.where(row_has_key, attn, mx.zeros_like(attn))
 
     attn = mx.softmax(attn, axis=-1)
+    if mask is not None:
+        attn = mx.where(mask, attn, mx.zeros_like(attn))
 
     if dropout_rate > 0.0 and training:
         keep = 1.0 - dropout_rate
@@ -321,4 +326,7 @@ class MultiHeadYatAttention(nn.Module):
 
         if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
             x = self._linear(x, self.out_kernel, getattr(self, "out_bias", None))
+        if mask is not None:
+            query_has_key = mx.any(mask.astype(mx.bool_), axis=(-3, -1))
+            x = mx.where(query_has_key[..., None], x, mx.zeros_like(x))
         return x

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -460,8 +460,13 @@ class RotaryYatAttention(nn.Module):
             out = self._linear(out, self.out_kernel, getattr(self, "out_bias", None))
         effective_mask = full_mask if self.decode and L > 1 else mask
         if effective_mask is not None:
+            attention_k_len = cache_new if self.decode else K_len
+            effective_mask = mx.broadcast_to(
+                effective_mask.astype(mx.bool_),
+                (B, self.num_heads, L, attention_k_len),
+            )
             query_has_key = mx.any(
-                effective_mask.astype(mx.bool_), axis=(-3, -1)
+                effective_mask, axis=(-3, -1)
             )
             out = mx.where(query_has_key[..., None], out, mx.zeros_like(out))
         return out

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -458,6 +458,12 @@ class RotaryYatAttention(nn.Module):
         out = mx.reshape(out, (B, L, self.embed_dim))
         if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
             out = self._linear(out, self.out_kernel, getattr(self, "out_bias", None))
+        effective_mask = full_mask if self.decode and L > 1 else mask
+        if effective_mask is not None:
+            query_has_key = mx.any(
+                effective_mask.astype(mx.bool_), axis=(-3, -1)
+            )
+            out = mx.where(query_has_key[..., None], out, mx.zeros_like(out))
         return out
 
     # ------------------------------------------------------------------

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -458,9 +458,9 @@ class RotaryYatAttention(nn.Module):
         out = mx.reshape(out, (B, L, self.embed_dim))
         if self.use_out_proj and getattr(self, "out_kernel", None) is not None:
             out = self._linear(out, self.out_kernel, getattr(self, "out_bias", None))
-        effective_mask = full_mask if self.decode and L > 1 else mask
+        effective_mask = full_mask if decode else mask
         if effective_mask is not None:
-            attention_k_len = cache_new if self.decode else K_len
+            attention_k_len = cache_new if decode else L
             effective_mask = mx.broadcast_to(
                 effective_mask.astype(mx.bool_),
                 (B, self.num_heads, L, attention_k_len),

--- a/src/nmn/nnx/layers/attention/_attention_core.py
+++ b/src/nmn/nnx/layers/attention/_attention_core.py
@@ -25,6 +25,10 @@ masked positions are zeroed (not set to -inf) and the final divide is
 normalization mode today; the other two callers always pass
 ``"softmax"`` (and the ``use_softermax`` shortcut for backward
 compatibility).
+
+Boolean masks and negative-infinity additive-bias entries follow one policy:
+masked weights are exact zero, and a query row with no eligible keys has zero
+weights and a zero readout with finite gradients.
 """
 
 from __future__ import annotations
@@ -88,16 +92,32 @@ def finalize_attention_weights(
     if alpha is not None:
         attn_weights = attn_weights * alpha
 
+    additive_mask = None
     if bias is not None:
         attn_weights = attn_weights + bias
+        # Negative infinity is the standard additive-mask sentinel.  Treat it
+        # exactly like a False boolean mask so an entirely disabled row has a
+        # defined zero result instead of NaNs.
+        additive_mask = jnp.logical_not(jnp.isneginf(bias))
 
-    if mask is not None:
-        if normalization == "l1":
-            # L1: scores are non-negative; mask by zeroing masked positions.
-            attn_weights = jnp.where(mask, attn_weights, 0.0)
+    effective_mask = mask
+    if additive_mask is not None:
+        effective_mask = (
+            additive_mask
+            if effective_mask is None
+            else jnp.logical_and(effective_mask, additive_mask)
+        )
+
+    if effective_mask is not None:
+        if normalization == "l1" or use_softermax or normalization == "softermax":
+            # L1/softermax operate on non-negative scores; zero is their mask
+            # identity and naturally makes a fully masked row all-zero.
+            attn_weights = jnp.where(effective_mask, attn_weights, 0.0)
         else:
             big_neg = jnp.finfo(attn_weights.dtype).min
-            attn_weights = jnp.where(mask, attn_weights, big_neg)
+            row_has_key = jnp.any(effective_mask, axis=-1, keepdims=True)
+            attn_weights = jnp.where(effective_mask, attn_weights, big_neg)
+            attn_weights = jnp.where(row_has_key, attn_weights, 0.0)
 
     if normalization == "l1":
         attn_sum = jnp.sum(attn_weights, axis=-1, keepdims=True)
@@ -106,6 +126,14 @@ def finalize_attention_weights(
         attn_weights = softermax(attn_weights, n=power).astype(dtype)
     else:
         attn_weights = jax.nn.softmax(attn_weights).astype(dtype)
+
+    if effective_mask is not None:
+        # Exact zeros are important both for the readout and its value
+        # gradient.  This also turns the finite placeholder distribution used
+        # for a fully masked softmax row into the documented zero policy.
+        attn_weights = jnp.where(
+            effective_mask, attn_weights, jnp.zeros_like(attn_weights)
+        )
 
     if module is not None:
         module.sow(nnx.Intermediate, "attention_weights", attn_weights)

--- a/src/nmn/nnx/layers/attention/_attention_core.py
+++ b/src/nmn/nnx/layers/attention/_attention_core.py
@@ -109,6 +109,9 @@ def finalize_attention_weights(
         )
 
     if effective_mask is not None:
+        effective_mask = jnp.broadcast_to(effective_mask, attn_weights.shape)
+
+    if effective_mask is not None:
         if normalization == "l1" or use_softermax or normalization == "softermax":
             # L1/softermax operate on non-negative scores; zero is their mask
             # identity and naturally makes a fully masked row all-zero.

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -679,6 +679,12 @@ class MultiHeadAttention(Module):
         else:
             output = self.out(x)
 
+        if mask is not None:
+            query_has_key = jnp.any(mask, axis=(-3, -1))
+            output = jnp.where(
+                query_has_key[..., None], output, jnp.zeros_like(output)
+            )
+
         if pending_cache is not None:
             assert self.cached_key is not None
             assert self.cached_value is not None

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -642,11 +642,24 @@ class MultiHeadAttention(Module):
         else:
             effective_epsilon = self.epsilon
 
+        # Materialize the user mask at the actual score shape before both the
+        # attention call and the post-projection zero-row policy.  Reducing an
+        # unbroadcast rank-1/2 mask would otherwise confuse query/head axes.
+        effective_mask = None
+        if mask is not None:
+            effective_mask = jnp.broadcast_to(
+                mask,
+                query.shape[:-3]
+                + (query.shape[-2], query.shape[-3], key.shape[-3]),
+            )
+
         # Apply attention (YAT by default)
         x = self.attention_fn(
             query,
             key,
             value,
+            # Preserve the user/custom attention_fn mask ABI; the built-in
+            # attention core materializes broadcasting internally.
             mask=mask,
             dropout_rng=dropout_rng,
             dropout_rate=self.dropout_rate,
@@ -679,8 +692,8 @@ class MultiHeadAttention(Module):
         else:
             output = self.out(x)
 
-        if mask is not None:
-            query_has_key = jnp.any(mask, axis=(-3, -1))
+        if effective_mask is not None:
+            query_has_key = jnp.any(effective_mask, axis=(-3, -1))
             output = jnp.where(
                 query_has_key[..., None], output, jnp.zeros_like(output)
             )

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -858,6 +858,13 @@ class RotaryYatAttention(Module):
             elif self.alpha is not None:
                 alpha_value = self.alpha[...]
 
+        effective_mask = None
+        if mask is not None:
+            effective_mask = jnp.broadcast_to(
+                mask,
+                q.shape[:-3] + (q.shape[-2], q.shape[-3], k.shape[-3]),
+            )
+
         # Apply Rotary YAT attention
         if self.use_performer and self.performer_kind == "slay":
             # Performer mode (SLAY anchor approximation): O(n) complexity
@@ -939,7 +946,7 @@ class RotaryYatAttention(Module):
                 v,
                 freqs_cos,
                 freqs_sin,
-                mask=mask,
+                mask=effective_mask,
                 dropout_rng=dropout_rng,
                 dropout_rate=self.dropout_rate,
                 broadcast_dropout=self.broadcast_dropout,
@@ -967,8 +974,8 @@ class RotaryYatAttention(Module):
         if self.o_proj is not None:
             output = self.o_proj(output)
 
-        if mask is not None:
-            query_has_key = jnp.any(mask, axis=(-3, -1))
+        if effective_mask is not None:
+            query_has_key = jnp.any(effective_mask, axis=(-3, -1))
             output = jnp.where(
                 query_has_key[..., None], output, jnp.zeros_like(output)
             )

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -967,6 +967,12 @@ class RotaryYatAttention(Module):
         if self.o_proj is not None:
             output = self.o_proj(output)
 
+        if mask is not None:
+            query_has_key = jnp.any(mask, axis=(-3, -1))
+            output = jnp.where(
+                query_has_key[..., None], output, jnp.zeros_like(output)
+            )
+
         if pending_cache is not None:
             assert self.cached_key is not None
             assert self.cached_value is not None

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -110,10 +110,22 @@ def yat_attention_weights(
 
     # Mask
     if mask is not None:
-        attn_weights = tf.where(mask, attn_weights, tf.constant(-1e9, dtype=attn_weights.dtype))
+        mask = tf.cast(mask, tf.bool)
+        row_has_key = tf.reduce_any(mask, axis=-1, keepdims=True)
+        attn_weights = tf.where(
+            mask,
+            attn_weights,
+            # Finite in float16 while still underflowing through softmax.
+            tf.constant(-1e4, dtype=attn_weights.dtype),
+        )
+        attn_weights = tf.where(
+            row_has_key, attn_weights, tf.zeros_like(attn_weights)
+        )
 
     # Softmax
     attn_weights = tf.nn.softmax(attn_weights, axis=-1)
+    if mask is not None:
+        attn_weights = tf.where(mask, attn_weights, tf.zeros_like(attn_weights))
 
     # Dropout
     if dropout_rate > 0.0 and training:
@@ -413,6 +425,14 @@ class MultiHeadYatAttention(tf.Module):
         # Output projection
         if self.out_kernel is not None:
             x = self._linear(x, self.out_kernel, self.out_bias)
+
+        if mask is not None:
+            query_has_key = tf.reduce_any(
+                tf.cast(mask, tf.bool), axis=(-3, -1)
+            )
+            x = tf.where(
+                tf.expand_dims(query_has_key, -1), x, tf.zeros_like(x)
+            )
 
         return x
 

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -110,13 +110,12 @@ def yat_attention_weights(
 
     # Mask
     if mask is not None:
-        mask = tf.cast(mask, tf.bool)
+        mask = tf.broadcast_to(tf.cast(mask, tf.bool), tf.shape(attn_weights))
         row_has_key = tf.reduce_any(mask, axis=-1, keepdims=True)
         attn_weights = tf.where(
             mask,
             attn_weights,
-            # Finite in float16 while still underflowing through softmax.
-            tf.constant(-1e4, dtype=attn_weights.dtype),
+            tf.constant(-float("inf"), dtype=attn_weights.dtype),
         )
         attn_weights = tf.where(
             row_has_key, attn_weights, tf.zeros_like(attn_weights)
@@ -406,11 +405,18 @@ class MultiHeadYatAttention(tf.Module):
             elif self.alpha is not None:
                 alpha_val = self.alpha
 
+        effective_mask = None
+        if mask is not None:
+            effective_mask = tf.broadcast_to(
+                tf.cast(mask, tf.bool),
+                tf.stack([batch_size, self.num_heads, q_len, kv_len]),
+            )
+
         # Apply YAT attention
         dropout_rate = self.dropout if training else 0.0
         x = yat_attention(
             q, k, v,
-            mask=mask,
+            mask=effective_mask,
             dropout_rate=dropout_rate,
             training=training,
             epsilon=self.epsilon,
@@ -426,10 +432,8 @@ class MultiHeadYatAttention(tf.Module):
         if self.out_kernel is not None:
             x = self._linear(x, self.out_kernel, self.out_bias)
 
-        if mask is not None:
-            query_has_key = tf.reduce_any(
-                tf.cast(mask, tf.bool), axis=(-3, -1)
-            )
+        if effective_mask is not None:
+            query_has_key = tf.reduce_any(effective_mask, axis=(-3, -1))
             x = tf.where(
                 tf.expand_dims(query_has_key, -1), x, tf.zeros_like(x)
             )

--- a/src/nmn/torch/attention/multi_head.py
+++ b/src/nmn/torch/attention/multi_head.py
@@ -226,10 +226,16 @@ class MultiHeadYatAttention(nn.Module):
         (q, k, v, alpha) = self._promote_dtype(q, k, v, alpha)
 
         # Apply YAT attention
+        effective_mask = None
+        if mask is not None:
+            effective_mask = torch.broadcast_to(
+                mask.to(dtype=torch.bool),
+                (batch_size, self.num_heads, q_len, kv_len),
+            )
         dropout_p = self.dropout if self.training and not deterministic else 0.0
         x = yat_attention(
             q, k, v,
-            mask=mask,
+            mask=effective_mask,
             dropout_p=dropout_p,
             training=self.training and not deterministic,
             epsilon=self.epsilon,
@@ -247,8 +253,8 @@ class MultiHeadYatAttention(nn.Module):
 
         # A projection bias must not reintroduce a value for a query whose
         # every key is masked in every head.
-        if mask is not None:
-            query_has_key = mask.to(dtype=torch.bool).any(dim=(-3, -1))
+        if effective_mask is not None:
+            query_has_key = effective_mask.any(dim=(-3, -1))
             x = torch.where(query_has_key.unsqueeze(-1), x, torch.zeros_like(x))
 
         return x

--- a/src/nmn/torch/attention/multi_head.py
+++ b/src/nmn/torch/attention/multi_head.py
@@ -245,4 +245,10 @@ class MultiHeadYatAttention(nn.Module):
         if self.out_proj is not None:
             x = self._linear(x, self.out_proj)
 
+        # A projection bias must not reintroduce a value for a query whose
+        # every key is masked in every head.
+        if mask is not None:
+            query_has_key = mask.to(dtype=torch.bool).any(dim=(-3, -1))
+            x = torch.where(query_has_key.unsqueeze(-1), x, torch.zeros_like(x))
+
         return x

--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -138,10 +138,23 @@ def yat_attention_weights(
 
     # Apply mask
     if mask is not None:
+        mask = mask.to(dtype=torch.bool)
+        row_has_key = mask.any(dim=-1, keepdim=True)
         attn_weights = attn_weights.masked_fill(~mask, float("-inf"))
+        # Softmax(all -inf) is NaN.  Replace only fully masked rows with a
+        # finite constant before normalization, then zero every masked entry
+        # afterwards.  This keeps both the forward pass and its Jacobian
+        # finite while preserving ordinary masked-softmax semantics.
+        attn_weights = torch.where(
+            row_has_key, attn_weights, torch.zeros_like(attn_weights)
+        )
 
     # Softmax normalization
     attn_weights = F.softmax(attn_weights, dim=-1)
+    if mask is not None:
+        attn_weights = torch.where(
+            mask, attn_weights, torch.zeros_like(attn_weights)
+        )
 
     # Dropout
     if dropout_p > 0.0 and training:
@@ -251,10 +264,19 @@ def yat_attention_normalized(
 
     # Mask
     if mask is not None:
+        mask = mask.to(dtype=torch.bool)
+        row_has_key = mask.any(dim=-1, keepdim=True)
         attn_weights = attn_weights.masked_fill(~mask, float("-inf"))
+        attn_weights = torch.where(
+            row_has_key, attn_weights, torch.zeros_like(attn_weights)
+        )
 
     # Softmax
     attn_weights = F.softmax(attn_weights, dim=-1)
+    if mask is not None:
+        attn_weights = torch.where(
+            mask, attn_weights, torch.zeros_like(attn_weights)
+        )
 
     # Dropout
     if dropout_p > 0.0 and training:

--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -138,7 +138,9 @@ def yat_attention_weights(
 
     # Apply mask
     if mask is not None:
-        mask = mask.to(dtype=torch.bool)
+        mask = torch.broadcast_to(
+            mask.to(dtype=torch.bool), attn_weights.shape
+        )
         row_has_key = mask.any(dim=-1, keepdim=True)
         attn_weights = attn_weights.masked_fill(~mask, float("-inf"))
         # Softmax(all -inf) is NaN.  Replace only fully masked rows with a
@@ -264,7 +266,9 @@ def yat_attention_normalized(
 
     # Mask
     if mask is not None:
-        mask = mask.to(dtype=torch.bool)
+        mask = torch.broadcast_to(
+            mask.to(dtype=torch.bool), attn_weights.shape
+        )
         row_has_key = mask.any(dim=-1, keepdim=True)
         attn_weights = attn_weights.masked_fill(~mask, float("-inf"))
         attn_weights = torch.where(

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -97,15 +97,27 @@ def test_fully_masked_attention_is_zero_differentiable_and_backend_stable(dtype)
     )
 
 
+def test_negative_scale_cannot_make_masked_key_win_softmax():
+    query = tensor(np.ones((1, 1, 1, 4), dtype=np.float32))
+    key = tensor(np.ones((1, 2, 1, 4), dtype=np.float32))
+    mask = tensor([True, False], dtype="bool")
+    weights = to_numpy(yat_attention_weights(query, key, mask=mask, scale=-1.0))
+    np.testing.assert_array_equal(weights, [[[[1.0, 0.0]]]])
+
+
+@pytest.mark.parametrize("mask_rank", [2, 4])
 @pytest.mark.parametrize("cross_attention", [False, True])
-def test_attention_layer_zeroes_fully_masked_rows_after_projection(cross_attention):
+def test_attention_layer_zeroes_fully_masked_rows_after_projection(
+    cross_attention, mask_rank
+):
     layer = MultiHeadYatAttention(embed_dim=8, num_heads=2)
     query = keras.random.normal((1, 2, 8), seed=73)
     context = keras.random.normal((1, 3, 8), seed=74)
     _ = layer(query)
     layer.out_bias.assign(np.full(layer.out_bias.shape, 3.0, dtype=np.float32))
     kv_length = 3 if cross_attention else 2
-    mask_np = np.ones((1, 1, 2, kv_length), dtype=bool)
+    shape = (2, kv_length) if mask_rank == 2 else (1, 1, 2, kv_length)
+    mask_np = np.ones(shape, dtype=bool)
     mask_np[..., 0, :] = False
     mask = tensor(mask_np, dtype="bool")
     output = (

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -24,10 +24,97 @@ from nmn.keras import (
     YatConvTranspose2D,
     YatConvTranspose3D,
     YatEmbed,
+    yat_attention,
+    yat_attention_weights,
 )
 from nmn.keras._yat_core import stable_yat_ratio
 
 BACKEND = keras.backend.backend()
+
+
+def _attention_value_and_gradients(query, key, value, mask):
+    if BACKEND == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        apply = jax.jit(lambda q, k, v: yat_attention(q, k, v, mask=mask))
+        output = apply(query, key, value)
+        grads = jax.grad(lambda q, k, v: jnp.sum(apply(q, k, v)), (0, 1, 2))(
+            query, key, value
+        )
+        return output, grads
+    if BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        query.requires_grad_(True)
+        key.requires_grad_(True)
+        value.requires_grad_(True)
+        apply = torch.compile(
+            lambda q, k, v: yat_attention(q, k, v, mask=mask), backend="eager"
+        )
+        output = apply(query, key, value)
+        return output, torch.autograd.grad(output.sum(), (query, key, value))
+    tf = pytest.importorskip("tensorflow")
+    apply = tf.function(lambda q, k, v: yat_attention(q, k, v, mask=mask))
+    with tf.GradientTape() as tape:
+        tape.watch((query, key, value))
+        output = apply(query, key, value)
+        loss = tf.reduce_sum(output)
+    return output, tape.gradient(loss, (query, key, value))
+
+
+@pytest.mark.parametrize("dtype", ["float32", "float16"])
+def test_fully_masked_attention_is_zero_differentiable_and_backend_stable(dtype):
+    rng = np.random.default_rng(70)
+    query = tensor(rng.normal(size=(1, 2, 2, 4)).astype(np.float32), dtype=dtype)
+    key = tensor(rng.normal(size=(1, 3, 2, 4)).astype(np.float32), dtype=dtype)
+    value = tensor(rng.normal(size=(1, 3, 2, 5)).astype(np.float32), dtype=dtype)
+    mask_np = np.array([[[[False, False, False], [True, False, True]]]])
+    mask = tensor(mask_np, dtype="bool")
+
+    output, grads = _attention_value_and_gradients(query, key, value, mask)
+    weights = to_numpy(yat_attention_weights(query, key, mask=mask))
+
+    np.testing.assert_array_equal(to_numpy(output)[:, 0], 0.0)
+    np.testing.assert_array_equal(weights[..., 0, :], 0.0)
+    assert all(np.all(np.isfinite(to_numpy(grad))) for grad in grads)
+
+    # Independent NumPy oracle for the partially masked row.  Fixed operands
+    # make this a parity contract shared by the JAX/Torch/TF Keras CI jobs.
+    q = to_numpy(query)
+    k = to_numpy(key)
+    dot = np.einsum("bqhd,bkhd->bhqk", q, k)
+    q_sq = np.sum(q * q, axis=-1).transpose(0, 2, 1)[..., None]
+    k_sq = np.sum(k * k, axis=-1).transpose(0, 2, 1)[:, :, None, :]
+    scores = dot**2 / ((np.maximum(q_sq + k_sq - 2.0 * dot, 0.0) + 1e-5) * 2.0)
+    scores = np.where(mask_np, scores, -np.inf)
+    row = scores[..., 1, :]
+    expected = np.exp(row - np.max(row, axis=-1, keepdims=True))
+    expected = np.where(mask_np[..., 1, :], expected, 0.0)
+    expected /= np.sum(expected, axis=-1, keepdims=True)
+    tolerance = 5e-3 if dtype == "float16" else 2e-5
+    np.testing.assert_allclose(
+        weights[..., 1, :], expected, rtol=tolerance, atol=tolerance
+    )
+
+
+@pytest.mark.parametrize("cross_attention", [False, True])
+def test_attention_layer_zeroes_fully_masked_rows_after_projection(cross_attention):
+    layer = MultiHeadYatAttention(embed_dim=8, num_heads=2)
+    query = keras.random.normal((1, 2, 8), seed=73)
+    context = keras.random.normal((1, 3, 8), seed=74)
+    _ = layer(query)
+    layer.out_bias.assign(np.full(layer.out_bias.shape, 3.0, dtype=np.float32))
+    kv_length = 3 if cross_attention else 2
+    mask_np = np.ones((1, 1, 2, kv_length), dtype=bool)
+    mask_np[..., 0, :] = False
+    mask = tensor(mask_np, dtype="bool")
+    output = (
+        layer(query, key=context, value=context, mask=mask)
+        if cross_attention
+        else layer(query, mask=mask)
+    )
+    np.testing.assert_array_equal(to_numpy(output)[:, 0], 0.0)
+    assert np.all(np.isfinite(to_numpy(output)))
 
 
 def tensor(value, dtype="float32"):

--- a/tests/test_linen/test_attention.py
+++ b/tests/test_linen/test_attention.py
@@ -66,10 +66,11 @@ class TestAttentionFunctions:
 
 
 class TestMultiHeadAttention:
+    @pytest.mark.parametrize("mask_rank", [2, 4])
     @pytest.mark.parametrize("normalization", ["softmax", "l1"])
     @pytest.mark.parametrize("cross_attention", [False, True])
     def test_fully_masked_rows_stay_zero_after_biased_projection(
-        self, normalization, cross_attention
+        self, normalization, cross_attention, mask_rank
     ):
         model = MultiHeadAttention(
             num_heads=2,
@@ -79,7 +80,8 @@ class TestMultiHeadAttention:
         query = jax.random.normal(jax.random.key(73), (1, 2, 8))
         context = jax.random.normal(jax.random.key(74), (1, 3, 8))
         kv_length = 3 if cross_attention else 2
-        mask = jnp.ones((1, 1, 2, kv_length), dtype=jnp.bool_).at[..., 0, :].set(False)
+        shape = (2, kv_length) if mask_rank == 2 else (1, 1, 2, kv_length)
+        mask = jnp.ones(shape, dtype=jnp.bool_).at[..., 0, :].set(False)
         args = (query, context, context) if cross_attention else (query,)
         variables = model.init(jax.random.key(75), *args, mask=mask)
         output = jax.jit(lambda variables, *args: model.apply(variables, *args, mask=mask))(

--- a/tests/test_linen/test_attention.py
+++ b/tests/test_linen/test_attention.py
@@ -16,6 +16,25 @@ from nmn.linen.attention import (
 
 
 class TestAttentionFunctions:
+    @pytest.mark.parametrize("spherical", [False, True])
+    def test_fully_masked_rows_are_zero_with_finite_jit_gradients(self, spherical):
+        q = jax.random.normal(jax.random.key(70), (1, 2, 2, 4))
+        k = jax.random.normal(jax.random.key(71), (1, 3, 2, 4))
+        v = jax.random.normal(jax.random.key(72), (1, 3, 2, 5))
+        mask = jnp.array([[[[False, False, False], [True, False, True]]]])
+
+        def apply(q, k, v):
+            return yat_attention(q, k, v, mask=mask, spherical=spherical)
+
+        eager = apply(q, k, v)
+        compiled = jax.jit(apply)(q, k, v)
+        grads = jax.jit(jax.grad(lambda q, k, v: jnp.sum(apply(q, k, v)), (0, 1, 2)))(
+            q, k, v
+        )
+        np.testing.assert_array_equal(np.asarray(eager[:, 0]), 0.0)
+        np.testing.assert_allclose(compiled, eager, rtol=2e-7, atol=1e-7)
+        assert all(np.all(np.isfinite(np.asarray(grad))) for grad in grads)
+
     def test_normalize_qk(self):
         q = jax.random.normal(jax.random.PRNGKey(0), (2, 5, 4, 8))
         k = jax.random.normal(jax.random.PRNGKey(1), (2, 5, 4, 8))
@@ -47,6 +66,38 @@ class TestAttentionFunctions:
 
 
 class TestMultiHeadAttention:
+    @pytest.mark.parametrize("normalization", ["softmax", "l1"])
+    @pytest.mark.parametrize("cross_attention", [False, True])
+    def test_fully_masked_rows_stay_zero_after_biased_projection(
+        self, normalization, cross_attention
+    ):
+        model = MultiHeadAttention(
+            num_heads=2,
+            normalization=normalization,
+            bias_init=jax.nn.initializers.constant(3.0),
+        )
+        query = jax.random.normal(jax.random.key(73), (1, 2, 8))
+        context = jax.random.normal(jax.random.key(74), (1, 3, 8))
+        kv_length = 3 if cross_attention else 2
+        mask = jnp.ones((1, 1, 2, kv_length), dtype=jnp.bool_).at[..., 0, :].set(False)
+        args = (query, context, context) if cross_attention else (query,)
+        variables = model.init(jax.random.key(75), *args, mask=mask)
+        output = jax.jit(lambda variables, *args: model.apply(variables, *args, mask=mask))(
+            variables, *args
+        )
+        np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+        assert np.all(np.isfinite(np.asarray(output)))
+        if cross_attention:
+            grads = jax.grad(
+                lambda q, c: jnp.sum(model.apply(variables, q, c, c, mask=mask)),
+                (0, 1),
+            )(query, context)
+        else:
+            grads = (jax.grad(
+                lambda q: jnp.sum(model.apply(variables, q, mask=mask))
+            )(query),)
+        assert all(np.all(np.isfinite(np.asarray(grad))) for grad in grads)
+
     def test_self_attention(self):
         model = MultiHeadAttention(num_heads=4)
         x = jax.random.normal(jax.random.PRNGKey(1), (2, 10, 32))

--- a/tests/test_mlx/test_attention.py
+++ b/tests/test_mlx/test_attention.py
@@ -100,6 +100,26 @@ def test_yat_attention_spherical_shape():
     assert out.shape == (B, Q, H, D)
 
 
+@pytest.mark.parametrize("dtype", [mx.float32, mx.float16])
+@pytest.mark.parametrize("spherical", [False, True])
+def test_fully_masked_rows_are_zero_with_finite_gradients(spherical, dtype):
+    q = mx.random.normal(shape=(1, 2, 2, 4)).astype(dtype)
+    k = mx.random.normal(shape=(1, 3, 2, 4)).astype(dtype)
+    v = mx.random.normal(shape=(1, 3, 2, 5)).astype(dtype)
+    mask = mx.array([[[[False, False, False], [True, False, True]]]])
+
+    def loss(q, k, v):
+        return mx.sum(yat_attention(q, k, v, mask=mask, spherical=spherical))
+
+    output = yat_attention(q, k, v, mask=mask, spherical=spherical)
+    weights = yat_attention_weights(q, k, mask=mask, spherical=spherical)
+    grads = mx.value_and_grad(loss, argnums=(0, 1, 2))(q, k, v)[1]
+    mx.eval(output, weights, *grads)
+    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    np.testing.assert_array_equal(np.asarray(weights[..., 0, :]), 0.0)
+    assert all(np.all(np.isfinite(np.asarray(grad))) for grad in grads)
+
+
 # ---------------------------------------------------------------------------
 # MultiHeadYatAttention
 # ---------------------------------------------------------------------------
@@ -116,6 +136,31 @@ def test_mha_cross_attn_shape():
     q = mx.random.normal(shape=(2, 5, 16))
     ctx = mx.random.normal(shape=(2, 11, 16))
     assert mha(q, ctx, ctx).shape == (2, 5, 16)
+
+
+@pytest.mark.parametrize("cross_attention", [False, True])
+def test_mha_fully_masked_rows_stay_zero_after_biased_projection(cross_attention):
+    mha = MultiHeadYatAttention(embed_dim=8, num_heads=2)
+    query = mx.random.normal(shape=(1, 2, 8))
+    context = mx.random.normal(shape=(1, 3, 8))
+    _ = mha(query)
+    mha.out_bias = mx.full(mha.out_bias.shape, 3.0)
+    kv_length = 3 if cross_attention else 2
+    mask_np = np.ones((1, 1, 2, kv_length), dtype=bool)
+    mask_np[..., 0, :] = False
+    mask = mx.array(mask_np)
+    output = mha(query, context, context, mask=mask) if cross_attention else mha(query, mask=mask)
+    mx.eval(output)
+    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    assert np.all(np.isfinite(np.asarray(output)))
+    if cross_attention:
+        grads = mx.grad(
+            lambda q, c: mx.sum(mha(q, c, c, mask=mask)), argnums=(0, 1)
+        )(query, context)
+    else:
+        grads = (mx.grad(lambda q: mx.sum(mha(q, mask=mask)))(query),)
+    mx.eval(*grads)
+    assert all(np.all(np.isfinite(np.asarray(grad))) for grad in grads)
 
 
 def test_mha_invalid_dim_rejected():

--- a/tests/test_mlx/test_attention.py
+++ b/tests/test_mlx/test_attention.py
@@ -100,6 +100,16 @@ def test_yat_attention_spherical_shape():
     assert out.shape == (B, Q, H, D)
 
 
+def test_negative_scale_cannot_make_masked_key_win_softmax():
+    q = mx.ones((1, 1, 1, 4))
+    k = mx.ones((1, 2, 1, 4))
+    weights = yat_attention_weights(
+        q, k, mask=mx.array([True, False]), scale=-1.0
+    )
+    mx.eval(weights)
+    np.testing.assert_array_equal(np.asarray(weights), [[[[1.0, 0.0]]]])
+
+
 @pytest.mark.parametrize("dtype", [mx.float32, mx.float16])
 @pytest.mark.parametrize("spherical", [False, True])
 def test_fully_masked_rows_are_zero_with_finite_gradients(spherical, dtype):
@@ -138,15 +148,19 @@ def test_mha_cross_attn_shape():
     assert mha(q, ctx, ctx).shape == (2, 5, 16)
 
 
+@pytest.mark.parametrize("mask_rank", [2, 4])
 @pytest.mark.parametrize("cross_attention", [False, True])
-def test_mha_fully_masked_rows_stay_zero_after_biased_projection(cross_attention):
+def test_mha_fully_masked_rows_stay_zero_after_biased_projection(
+    cross_attention, mask_rank
+):
     mha = MultiHeadYatAttention(embed_dim=8, num_heads=2)
     query = mx.random.normal(shape=(1, 2, 8))
     context = mx.random.normal(shape=(1, 3, 8))
     _ = mha(query)
     mha.out_bias = mx.full(mha.out_bias.shape, 3.0)
     kv_length = 3 if cross_attention else 2
-    mask_np = np.ones((1, 1, 2, kv_length), dtype=bool)
+    shape = (2, kv_length) if mask_rank == 2 else (1, 1, 2, kv_length)
+    mask_np = np.ones(shape, dtype=bool)
     mask_np[..., 0, :] = False
     mask = mx.array(mask_np)
     output = mha(query, context, context, mask=mask) if cross_attention else mha(query, mask=mask)

--- a/tests/test_mlx/test_rotary.py
+++ b/tests/test_mlx/test_rotary.py
@@ -196,6 +196,19 @@ def test_module_no_out_proj():
     assert "out_kernel" not in mha.parameters()
 
 
+def test_module_fully_masked_row_stays_zero_after_biased_projection():
+    mha = RotaryYatAttention(embed_dim=8, num_heads=2, max_seq_len=8)
+    x = mx.random.normal(shape=(1, 2, 8))
+    _ = mha(x)
+    mha.out_bias = mx.full(mha.out_bias.shape, 3.0)
+    mask_np = np.ones((1, 1, 2, 2), dtype=bool)
+    mask_np[..., 0, :] = False
+    output = mha(x, mask=mx.array(mask_np))
+    mx.eval(output)
+    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    assert np.all(np.isfinite(np.asarray(output)))
+
+
 def test_module_gradient_reduces_loss():
     def loss_fn(model, x, y):
         return mx.mean((model(x) - y) ** 2)

--- a/tests/test_mlx/test_rotary.py
+++ b/tests/test_mlx/test_rotary.py
@@ -196,12 +196,14 @@ def test_module_no_out_proj():
     assert "out_kernel" not in mha.parameters()
 
 
-def test_module_fully_masked_row_stays_zero_after_biased_projection():
+@pytest.mark.parametrize("mask_rank", [2, 4])
+def test_module_fully_masked_row_stays_zero_after_biased_projection(mask_rank):
     mha = RotaryYatAttention(embed_dim=8, num_heads=2, max_seq_len=8)
     x = mx.random.normal(shape=(1, 2, 8))
     _ = mha(x)
     mha.out_bias = mx.full(mha.out_bias.shape, 3.0)
-    mask_np = np.ones((1, 1, 2, 2), dtype=bool)
+    shape = (2, 2) if mask_rank == 2 else (1, 1, 2, 2)
+    mask_np = np.ones(shape, dtype=bool)
     mask_np[..., 0, :] = False
     output = mha(x, mask=mx.array(mask_np))
     mx.eval(output)

--- a/tests/test_mlx_rotary_source.py
+++ b/tests/test_mlx_rotary_source.py
@@ -1,0 +1,66 @@
+"""Static regressions for MLX rotary paths that cannot run without Metal."""
+
+import ast
+from pathlib import Path
+
+
+ROTARY_SOURCE = Path(__file__).parents[1] / "src" / "nmn" / "mlx" / "rotary.py"
+
+
+def _rotary_call():
+    source = ROTARY_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(ROTARY_SOURCE))
+    rotary_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "RotaryYatAttention"
+    )
+    return next(
+        node
+        for node in rotary_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == "__call__"
+    )
+
+
+def test_rotary_call_mask_gate_uses_only_defined_decode_lengths():
+    call = _rotary_call()
+    loaded_names = {
+        node.id
+        for node in ast.walk(call)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+    }
+    self_attributes = {
+        node.attr
+        for node in ast.walk(call)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    }
+
+    assert "decode" in {arg.arg for arg in call.args.kwonlyargs}
+    assert "decode" in loaded_names
+    assert "K_len" not in loaded_names
+    assert "decode" not in self_attributes
+
+
+def test_rotary_mask_gate_selects_cached_or_sequence_key_length():
+    call = _rotary_call()
+    conditional_assignments = {
+        node.targets[0].id: node.value
+        for node in ast.walk(call)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and isinstance(node.value, ast.IfExp)
+    }
+
+    effective_mask = conditional_assignments["effective_mask"]
+    assert ast.unparse(effective_mask) == "full_mask if decode else mask"
+
+    attention_k_len = conditional_assignments["attention_k_len"]
+    assert ast.unparse(attention_k_len) == "cache_new if decode else L"
+
+
+def test_rotary_source_compiles_without_importing_mlx():
+    source = ROTARY_SOURCE.read_text(encoding="utf-8")
+    compile(source, str(ROTARY_SOURCE), "exec")

--- a/tests/test_nnx/test_fully_masked_attention.py
+++ b/tests/test_nnx/test_fully_masked_attention.py
@@ -1,0 +1,203 @@
+"""Cross-normalization regressions for fully masked attention rows (#70)."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from nmn.nnx.layers.attention import (
+    MultiHeadAttention,
+    RotaryYatAttention,
+    yat_attention,
+    yat_attention_normalized,
+    yat_attention_weights,
+)
+
+
+def _inputs():
+    q = jax.random.normal(jax.random.key(70), (1, 2, 2, 4))
+    k = jax.random.normal(jax.random.key(71), (1, 3, 2, 4))
+    v = jax.random.normal(jax.random.key(72), (1, 3, 2, 5))
+    mask = jnp.array(
+        [[[[False, False, False], [True, False, True]]]], dtype=jnp.bool_
+    )
+    return q, k, v, mask
+
+
+@pytest.mark.parametrize("normalization", ["softmax", "l1", "softermax"])
+def test_boolean_mask_zero_policy_is_jitted_differentiable_and_exact(normalization):
+    q, k, v, mask = _inputs()
+
+    def apply(q, k, v):
+        return yat_attention(
+            q,
+            k,
+            v,
+            mask=mask,
+            deterministic=True,
+            normalization=normalization,
+        )
+
+    eager = apply(q, k, v)
+    compiled = jax.jit(apply)(q, k, v)
+    weights = yat_attention_weights(
+        q, k, mask=mask, deterministic=True, normalization=normalization
+    )
+    grads = jax.jit(jax.grad(lambda q, k, v: jnp.sum(apply(q, k, v)), (0, 1, 2)))(
+        q, k, v
+    )
+
+    np.testing.assert_array_equal(np.asarray(weights[..., 0, :]), 0.0)
+    np.testing.assert_array_equal(np.asarray(eager[:, 0]), 0.0)
+    np.testing.assert_allclose(compiled, eager, rtol=2e-7, atol=1e-7)
+    for grad in grads:
+        assert np.all(np.isfinite(np.asarray(grad)))
+
+
+def test_negative_infinity_additive_mask_matches_boolean_mask_and_gradients():
+    q, k, v, mask = _inputs()
+    bias = jnp.where(mask, 0.0, -jnp.inf)
+
+    def boolean_apply(q, k, v):
+        return yat_attention(q, k, v, mask=mask, deterministic=True)
+
+    def additive_apply(q, k, v, bias):
+        return yat_attention(q, k, v, bias=bias, deterministic=True)
+
+    expected = jax.jit(boolean_apply)(q, k, v)
+    actual = jax.jit(additive_apply)(q, k, v, bias)
+    grads = jax.grad(lambda q, k, v, b: jnp.sum(additive_apply(q, k, v, b)),
+                     (0, 1, 2, 3))(q, k, v, bias)
+
+    np.testing.assert_allclose(actual, expected, rtol=0.0, atol=0.0)
+    for grad in grads:
+        assert np.all(np.isfinite(np.asarray(grad)))
+
+
+@pytest.mark.parametrize("use_softermax", [False, True])
+def test_normalized_qk_implementation_has_the_same_zero_policy(use_softermax):
+    q, k, v, mask = _inputs()
+
+    def apply(q, k, v):
+        return yat_attention_normalized(
+            q,
+            k,
+            v,
+            mask=mask,
+            use_softermax=use_softermax,
+            deterministic=True,
+        )
+
+    output = jax.jit(apply)(q, k, v)
+    grads = jax.grad(lambda q, k, v: jnp.sum(apply(q, k, v)), (0, 1, 2))(
+        q, k, v
+    )
+    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    for grad in grads:
+        assert np.all(np.isfinite(np.asarray(grad)))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float16, jnp.bfloat16])
+def test_low_precision_fully_masked_softmax_is_finite(dtype):
+    q, k, v, mask = _inputs()
+    q, k, v = q.astype(dtype), k.astype(dtype), v.astype(dtype)
+
+    def apply(q, k, v):
+        return yat_attention(q, k, v, mask=mask, deterministic=True)
+
+    output = jax.jit(apply)(q, k, v)
+    grads = jax.grad(lambda q, k, v: jnp.sum(apply(q, k, v).astype(jnp.float32)),
+                     (0, 1, 2))(q, k, v)
+    np.testing.assert_array_equal(np.asarray(output[:, 0], dtype=np.float32), 0.0)
+    for grad in grads:
+        assert np.all(np.isfinite(np.asarray(grad, dtype=np.float32)))
+
+
+def test_fully_masked_output_and_gradient_parity_with_torch():
+    torch = pytest.importorskip("torch")
+    from nmn.torch.attention import (
+        yat_attention as torch_yat_attention,
+        yat_attention_weights as torch_yat_attention_weights,
+    )
+
+    q, k, v, mask = _inputs()
+    tq = torch.tensor(np.asarray(q), requires_grad=True)
+    tk = torch.tensor(np.asarray(k), requires_grad=True)
+    tv = torch.tensor(np.asarray(v), requires_grad=True)
+    tm = torch.tensor(np.asarray(mask))
+
+    def jax_loss(q, k, v):
+        return jnp.sum(yat_attention(q, k, v, mask=mask, deterministic=True) ** 2)
+
+    jax_output = jax.jit(
+        lambda q, k, v: yat_attention(q, k, v, mask=mask, deterministic=True)
+    )(q, k, v)
+    jax_weights = yat_attention_weights(q, k, mask=mask, deterministic=True)
+    jax_grads = jax.grad(jax_loss, (0, 1, 2))(q, k, v)
+
+    torch_output = torch_yat_attention(tq, tk, tv, mask=tm)
+    torch_weights = torch_yat_attention_weights(tq, tk, mask=tm)
+    torch_grads = torch.autograd.grad((torch_output**2).sum(), (tq, tk, tv))
+
+    np.testing.assert_allclose(torch_output.detach(), jax_output, rtol=2e-6, atol=2e-6)
+    np.testing.assert_allclose(torch_weights.detach(), jax_weights, rtol=2e-6, atol=2e-6)
+    for torch_grad, jax_grad in zip(torch_grads, jax_grads):
+        np.testing.assert_allclose(
+            torch_grad.detach(), jax_grad, rtol=3e-5, atol=3e-6
+        )
+
+
+@pytest.mark.parametrize("cross_attention", [False, True])
+def test_multi_head_module_zeroes_fully_masked_rows_after_projection(cross_attention):
+    module = MultiHeadAttention(
+        num_heads=2,
+        in_features=8,
+        out_bias_init=nnx.initializers.constant(3.0),
+        rngs=nnx.Rngs(70),
+    )
+    query = jax.random.normal(jax.random.key(73), (1, 2, 8))
+    context = jax.random.normal(jax.random.key(74), (1, 3, 8))
+    kv_length = 3 if cross_attention else 2
+    mask = jnp.ones((1, 1, 2, kv_length), dtype=jnp.bool_).at[..., 0, :].set(False)
+
+    @nnx.jit
+    def apply(module, query, context, mask):
+        if cross_attention:
+            return module(query, context, context, mask=mask, deterministic=True)
+        return module(query, mask=mask, deterministic=True)
+
+    output = apply(module, query, context, mask)
+    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    assert np.all(np.isfinite(np.asarray(output)))
+    if cross_attention:
+        grads = jax.grad(
+            lambda q, c: jnp.sum(module(q, c, c, mask=mask, deterministic=True)),
+            (0, 1),
+        )(query, context)
+    else:
+        grads = (jax.grad(
+            lambda q: jnp.sum(module(q, mask=mask, deterministic=True))
+        )(query),)
+    assert all(np.all(np.isfinite(np.asarray(grad))) for grad in grads)
+
+
+@pytest.mark.parametrize("normalization", ["softmax", "l1", "softermax"])
+def test_rotary_module_zeroes_fully_masked_rows_for_every_normalization(normalization):
+    module = RotaryYatAttention(
+        embed_dim=8,
+        num_heads=2,
+        max_seq_len=4,
+        normalization=normalization,
+        use_bias=True,
+        rngs=nnx.Rngs(75),
+    )
+    # Make the projection-bias regression observable.
+    module.o_proj.bias[...] = 2.0
+    x = jax.random.normal(jax.random.key(76), (1, 2, 8))
+    mask = jnp.ones((1, 1, 2, 2), dtype=jnp.bool_).at[..., 0, :].set(False)
+    output = nnx.jit(lambda m, x, mask: m(x, mask=mask, deterministic=True))(
+        module, x, mask
+    )
+    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    assert np.all(np.isfinite(np.asarray(output)))

--- a/tests/test_nnx/test_fully_masked_attention.py
+++ b/tests/test_nnx/test_fully_masked_attention.py
@@ -25,6 +25,23 @@ def _inputs():
     return q, k, v, mask
 
 
+def _broadcast_mask(rank, batch, heads, q_length, kv_length):
+    if rank == 1:
+        mask = jnp.zeros((kv_length,), dtype=jnp.bool_)
+    elif rank == 2:
+        mask = jnp.ones((q_length, kv_length), dtype=jnp.bool_)
+        mask = mask.at[0, :].set(False)
+    elif rank == 3:
+        mask = jnp.ones((heads, q_length, kv_length), dtype=jnp.bool_)
+        mask = mask.at[:, 0, :].set(False)
+    else:
+        mask = jnp.ones((batch, heads, q_length, kv_length), dtype=jnp.bool_)
+        mask = mask.at[0, :, 0, :].set(False)
+        mask = mask.at[1, :, 1, :].set(False)
+    effective = jnp.broadcast_to(mask, (batch, heads, q_length, kv_length))
+    return mask, jnp.any(effective, axis=(1, 3))
+
+
 @pytest.mark.parametrize("normalization", ["softmax", "l1", "softermax"])
 def test_boolean_mask_zero_policy_is_jitted_differentiable_and_exact(normalization):
     q, k, v, mask = _inputs()
@@ -114,6 +131,16 @@ def test_low_precision_fully_masked_softmax_is_finite(dtype):
         assert np.all(np.isfinite(np.asarray(grad, dtype=np.float32)))
 
 
+def test_negative_scale_cannot_make_a_masked_key_win_softmax():
+    q = jnp.ones((1, 1, 1, 4), dtype=jnp.float32)
+    k = jnp.ones((1, 2, 1, 4), dtype=jnp.float32)
+    mask = jnp.array([True, False])
+    weights = yat_attention_weights(
+        q, k, mask=mask, alpha=jnp.array(-1.0), deterministic=True
+    )
+    np.testing.assert_array_equal(np.asarray(weights), [[[[1.0, 0.0]]]])
+
+
 def test_fully_masked_output_and_gradient_parity_with_torch():
     torch = pytest.importorskip("torch")
     from nmn.torch.attention import (
@@ -148,18 +175,21 @@ def test_fully_masked_output_and_gradient_parity_with_torch():
         )
 
 
+@pytest.mark.parametrize("mask_rank", [1, 2, 3, 4])
 @pytest.mark.parametrize("cross_attention", [False, True])
-def test_multi_head_module_zeroes_fully_masked_rows_after_projection(cross_attention):
+def test_multi_head_module_zeroes_fully_masked_rows_after_projection(
+    cross_attention, mask_rank
+):
     module = MultiHeadAttention(
         num_heads=2,
         in_features=8,
         out_bias_init=nnx.initializers.constant(3.0),
         rngs=nnx.Rngs(70),
     )
-    query = jax.random.normal(jax.random.key(73), (1, 2, 8))
-    context = jax.random.normal(jax.random.key(74), (1, 3, 8))
+    query = jax.random.normal(jax.random.key(73), (2, 2, 8))
+    context = jax.random.normal(jax.random.key(74), (2, 3, 8))
     kv_length = 3 if cross_attention else 2
-    mask = jnp.ones((1, 1, 2, kv_length), dtype=jnp.bool_).at[..., 0, :].set(False)
+    mask, expected_valid = _broadcast_mask(mask_rank, 2, 2, 2, kv_length)
 
     @nnx.jit
     def apply(module, query, context, mask):
@@ -168,7 +198,9 @@ def test_multi_head_module_zeroes_fully_masked_rows_after_projection(cross_atten
         return module(query, mask=mask, deterministic=True)
 
     output = apply(module, query, context, mask)
-    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    np.testing.assert_array_equal(
+        np.asarray(output)[~np.asarray(expected_valid)], 0.0
+    )
     assert np.all(np.isfinite(np.asarray(output)))
     if cross_attention:
         grads = jax.grad(
@@ -182,8 +214,11 @@ def test_multi_head_module_zeroes_fully_masked_rows_after_projection(cross_atten
     assert all(np.all(np.isfinite(np.asarray(grad))) for grad in grads)
 
 
+@pytest.mark.parametrize("mask_rank", [1, 2, 3, 4])
 @pytest.mark.parametrize("normalization", ["softmax", "l1", "softermax"])
-def test_rotary_module_zeroes_fully_masked_rows_for_every_normalization(normalization):
+def test_rotary_module_zeroes_fully_masked_rows_for_every_normalization(
+    normalization, mask_rank
+):
     module = RotaryYatAttention(
         embed_dim=8,
         num_heads=2,
@@ -194,10 +229,12 @@ def test_rotary_module_zeroes_fully_masked_rows_for_every_normalization(normaliz
     )
     # Make the projection-bias regression observable.
     module.o_proj.bias[...] = 2.0
-    x = jax.random.normal(jax.random.key(76), (1, 2, 8))
-    mask = jnp.ones((1, 1, 2, 2), dtype=jnp.bool_).at[..., 0, :].set(False)
+    x = jax.random.normal(jax.random.key(76), (2, 2, 8))
+    mask, expected_valid = _broadcast_mask(mask_rank, 2, 2, 2, 2)
     output = nnx.jit(lambda m, x, mask: m(x, mask=mask, deterministic=True))(
         module, x, mask
     )
-    np.testing.assert_array_equal(np.asarray(output[:, 0]), 0.0)
+    np.testing.assert_array_equal(
+        np.asarray(output)[~np.asarray(expected_valid)], 0.0
+    )
     assert np.all(np.isfinite(np.asarray(output)))

--- a/tests/test_tf/test_attention.py
+++ b/tests/test_tf/test_attention.py
@@ -15,6 +15,14 @@ from nmn.tf.attention import (
 
 
 class TestAttentionFunctions:
+    def test_negative_scale_cannot_make_masked_key_win_softmax(self):
+        q = tf.ones((1, 1, 1, 4))
+        k = tf.ones((1, 2, 1, 4))
+        weights = yat_attention_weights(
+            q, k, mask=tf.constant([True, False]), scale=-1.0
+        )
+        np.testing.assert_array_equal(weights.numpy(), [[[[1.0, 0.0]]]])
+
     @pytest.mark.parametrize("dtype", [tf.float32, tf.float16])
     @pytest.mark.parametrize("spherical", [False, True])
     def test_fully_masked_rows_are_zero_with_finite_tf_function_gradients(
@@ -112,15 +120,19 @@ class TestAttentionFunctions:
 
 
 class TestMultiHeadYatAttention:
+    @pytest.mark.parametrize("mask_rank", [2, 4])
     @pytest.mark.parametrize("cross_attention", [False, True])
-    def test_fully_masked_rows_stay_zero_after_biased_projection(self, cross_attention):
+    def test_fully_masked_rows_stay_zero_after_biased_projection(
+        self, cross_attention, mask_rank
+    ):
         attn = MultiHeadYatAttention(embed_dim=8, num_heads=2)
         query = tf.Variable(tf.random.normal((1, 2, 8), seed=73))
         context = tf.Variable(tf.random.normal((1, 3, 8), seed=74))
         _ = attn(query)
         attn.out_bias.assign(tf.fill(attn.out_bias.shape, 3.0))
         kv_length = 3 if cross_attention else 2
-        mask_array = np.ones((1, 1, 2, kv_length), dtype=bool)
+        shape = (2, kv_length) if mask_rank == 2 else (1, 1, 2, kv_length)
+        mask_array = np.ones(shape, dtype=bool)
         mask_array[..., 0, :] = False
         mask = tf.constant(mask_array)
 

--- a/tests/test_tf/test_attention.py
+++ b/tests/test_tf/test_attention.py
@@ -15,6 +15,30 @@ from nmn.tf.attention import (
 
 
 class TestAttentionFunctions:
+    @pytest.mark.parametrize("dtype", [tf.float32, tf.float16])
+    @pytest.mark.parametrize("spherical", [False, True])
+    def test_fully_masked_rows_are_zero_with_finite_tf_function_gradients(
+        self, spherical, dtype
+    ):
+        q = tf.Variable(tf.random.normal((1, 2, 2, 4), seed=70, dtype=dtype))
+        k = tf.Variable(tf.random.normal((1, 3, 2, 4), seed=71, dtype=dtype))
+        v = tf.Variable(tf.random.normal((1, 3, 2, 5), seed=72, dtype=dtype))
+        mask = tf.constant([[[[False, False, False], [True, False, True]]]])
+
+        @tf.function
+        def apply(q, k, v):
+            return yat_attention(q, k, v, mask=mask, spherical=spherical)
+
+        with tf.GradientTape() as tape:
+            output = apply(q, k, v)
+            loss = tf.reduce_sum(output)
+        grads = tape.gradient(loss, (q, k, v))
+        weights = yat_attention_weights(q, k, mask=mask, spherical=spherical)
+
+        np.testing.assert_array_equal(output[:, 0].numpy(), 0.0)
+        np.testing.assert_array_equal(weights[..., 0, :].numpy(), 0.0)
+        assert all(np.all(np.isfinite(grad.numpy())) for grad in grads)
+
     def test_normalize_qk(self):
         q = tf.random.normal((2, 5, 4, 8))
         k = tf.random.normal((2, 5, 4, 8))
@@ -88,6 +112,33 @@ class TestAttentionFunctions:
 
 
 class TestMultiHeadYatAttention:
+    @pytest.mark.parametrize("cross_attention", [False, True])
+    def test_fully_masked_rows_stay_zero_after_biased_projection(self, cross_attention):
+        attn = MultiHeadYatAttention(embed_dim=8, num_heads=2)
+        query = tf.Variable(tf.random.normal((1, 2, 8), seed=73))
+        context = tf.Variable(tf.random.normal((1, 3, 8), seed=74))
+        _ = attn(query)
+        attn.out_bias.assign(tf.fill(attn.out_bias.shape, 3.0))
+        kv_length = 3 if cross_attention else 2
+        mask_array = np.ones((1, 1, 2, kv_length), dtype=bool)
+        mask_array[..., 0, :] = False
+        mask = tf.constant(mask_array)
+
+        @tf.function
+        def apply(query, context, mask):
+            if cross_attention:
+                return attn(query, key=context, value=context, mask=mask)
+            return attn(query, mask=mask)
+
+        with tf.GradientTape() as tape:
+            output = apply(query, context, mask)
+            loss = tf.reduce_sum(tf.square(output))
+        operands = (query, context) if cross_attention else (query,)
+        grads = tape.gradient(loss, operands)
+        np.testing.assert_array_equal(output[:, 0].numpy(), 0.0)
+        assert np.all(np.isfinite(output.numpy()))
+        assert all(np.all(np.isfinite(grad.numpy())) for grad in grads)
+
     def test_self_attention(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4)
         x = tf.random.normal((2, 10, 32))

--- a/tests/test_torch/test_attention.py
+++ b/tests/test_torch/test_attention.py
@@ -14,6 +14,14 @@ from nmn.torch.attention.multi_head import MultiHeadYatAttention
 
 
 class TestAttentionFunctions:
+    def test_negative_scale_cannot_make_masked_key_win_softmax(self):
+        q = torch.ones(1, 1, 1, 4)
+        k = torch.ones(1, 2, 1, 4)
+        weights = yat_attention_weights(
+            q, k, mask=torch.tensor([True, False]), scale=-1.0
+        )
+        assert torch.equal(weights, torch.tensor([[[[1.0, 0.0]]]]))
+
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
     @pytest.mark.parametrize("spherical", [False, True])
     def test_fully_masked_rows_are_zero_with_finite_compiled_gradients(
@@ -120,9 +128,10 @@ class TestAttentionFunctions:
 
 
 class TestMultiHeadYatAttention:
+    @pytest.mark.parametrize("mask_rank", [2, 4])
     @pytest.mark.parametrize("cross_attention", [False, True])
     def test_fully_masked_rows_stay_zero_after_biased_output_projection(
-        self, cross_attention
+        self, cross_attention, mask_rank
     ):
         attn = MultiHeadYatAttention(embed_dim=8, num_heads=2)
         with torch.no_grad():
@@ -130,12 +139,18 @@ class TestMultiHeadYatAttention:
         query = torch.randn(1, 2, 8, requires_grad=True)
         context = torch.randn(1, 3, 8, requires_grad=True)
         kv_length = 3 if cross_attention else 2
-        mask = torch.ones(1, 1, 2, kv_length, dtype=torch.bool)
-        mask[..., 0, :] = False
+        if mask_rank == 2:
+            mask = torch.ones(2, kv_length, dtype=torch.bool)
+            mask[0, :] = False
+        else:
+            mask = torch.ones(1, 1, 2, kv_length, dtype=torch.bool)
+            mask[..., 0, :] = False
         output = (
-            attn(query, key=context, value=context, mask=mask)
+            torch.compile(attn, backend="eager")(
+                query, key=context, value=context, mask=mask
+            )
             if cross_attention
-            else attn(query, mask=mask)
+            else torch.compile(attn, backend="eager")(query, mask=mask)
         )
         assert torch.equal(output[:, 0], torch.zeros_like(output[:, 0]))
         assert torch.isfinite(output).all()

--- a/tests/test_torch/test_attention.py
+++ b/tests/test_torch/test_attention.py
@@ -14,6 +14,29 @@ from nmn.torch.attention.multi_head import MultiHeadYatAttention
 
 
 class TestAttentionFunctions:
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+    @pytest.mark.parametrize("spherical", [False, True])
+    def test_fully_masked_rows_are_zero_with_finite_compiled_gradients(
+        self, spherical, dtype
+    ):
+        q = torch.randn(1, 2, 2, 4, dtype=dtype, requires_grad=True)
+        k = torch.randn(1, 3, 2, 4, dtype=dtype, requires_grad=True)
+        v = torch.randn(1, 3, 2, 5, dtype=dtype, requires_grad=True)
+        mask = torch.tensor([[[[False, False, False], [True, False, True]]]])
+
+        def apply(q, k, v):
+            return yat_attention(q, k, v, mask=mask, spherical=spherical)
+
+        eager = apply(q, k, v)
+        compiled = torch.compile(apply, backend="eager")(q, k, v)
+        weights = yat_attention_weights(q, k, mask=mask, spherical=spherical)
+        grads = torch.autograd.grad(compiled.sum(), (q, k, v))
+
+        assert torch.equal(weights[..., 0, :], torch.zeros_like(weights[..., 0, :]))
+        assert torch.equal(eager[:, 0], torch.zeros_like(eager[:, 0]))
+        torch.testing.assert_close(compiled, eager)
+        assert all(torch.isfinite(grad).all() for grad in grads)
+
     def test_normalize_qk(self):
         q = torch.randn(2, 5, 4, 8)
         k = torch.randn(2, 5, 4, 8)
@@ -97,6 +120,31 @@ class TestAttentionFunctions:
 
 
 class TestMultiHeadYatAttention:
+    @pytest.mark.parametrize("cross_attention", [False, True])
+    def test_fully_masked_rows_stay_zero_after_biased_output_projection(
+        self, cross_attention
+    ):
+        attn = MultiHeadYatAttention(embed_dim=8, num_heads=2)
+        with torch.no_grad():
+            attn.out_proj.bias.fill_(3.0)
+        query = torch.randn(1, 2, 8, requires_grad=True)
+        context = torch.randn(1, 3, 8, requires_grad=True)
+        kv_length = 3 if cross_attention else 2
+        mask = torch.ones(1, 1, 2, kv_length, dtype=torch.bool)
+        mask[..., 0, :] = False
+        output = (
+            attn(query, key=context, value=context, mask=mask)
+            if cross_attention
+            else attn(query, mask=mask)
+        )
+        assert torch.equal(output[:, 0], torch.zeros_like(output[:, 0]))
+        assert torch.isfinite(output).all()
+        grads = torch.autograd.grad(
+            output.square().sum(),
+            (query, context) if cross_attention else (query,),
+        )
+        assert all(torch.isfinite(grad).all() for grad in grads)
+
     def test_self_attention(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4)
         x = torch.randn(2, 10, 32)


### PR DESCRIPTION
Fixes #70.

Defines a cross-backend zero-weight and zero-output policy for fully masked query rows, including finite gradients, self/cross modules, boolean and additive masks, every supported normalization, broadcast masks, biased projections, low precision, and compiled paths.

Independent review completed correction loops for broadcast masks, negative-scale partial rows, performer ABI compatibility, MLX rotary branch locals, and interaction with the merged low-precision core. All locally runnable backend suites pass. The draft remains pending only until the newly inherited macos-15-arm64 MLX/Metal job and full CI matrix pass on this rebased head.