### PR TITLE
fix(keras): support channels-first convolutions on TensorFlow CPU

### DIFF
--- a/src/nmn/keras/_yat_core.py
+++ b/src/nmn/keras/_yat_core.py
@@ -128,7 +128,7 @@ def stable_yat_ratio(dot_product, distance_sq, epsilon, output_dtype=None):
     return saturating_downcast(ratio, output_dtype)
 
 
-def yat_score(layer, dot_prod_map, distance_sq_map):
+def yat_score(layer, dot_prod_map, distance_sq_map, data_format=None):
     """Apply bias / epsilon / YAT-divide / alpha to a raw conv output.
 
     Returns ``(dot_prod_map + bias) ** 2 / (distance_sq_map + eps) * alpha``.
@@ -141,16 +141,17 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
       effective epsilon (softplus-of-raw or constant).
     * ``use_alpha``, ``alpha`` — for the optional alpha multiplier.
 
-    `dot_prod_map` and `distance_sq_map` must already be in the layer's
-    output layout (channels_first or channels_last).
+    `dot_prod_map` and `distance_sq_map` must already be in `data_format`, which
+    defaults to the layer's public output layout.
     """
+    data_format = layer.data_format if data_format is None else data_format
     # Add bias before squaring (constant or learnable; reshape for channels_first).
     if layer.use_bias:
         if layer._constant_bias_value is not None:
             dot_prod_map = dot_prod_map + layer._constant_bias_value
         else:
             bias = reduction_safe_upcast(layer.bias)
-            if layer.data_format == "channels_first":
+            if data_format == "channels_first":
                 bias_shape = (1, -1) + (1,) * len(layer.kernel_size)
                 bias = ops.reshape(bias, bias_shape)
             dot_prod_map = ops.add(dot_prod_map, bias)

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -4,7 +4,7 @@ import math
 import threading
 import weakref
 
-from keras.src import activations, constraints, initializers, regularizers
+from keras.src import constraints, initializers, regularizers
 from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.backend import backend, standardize_dtype
@@ -153,9 +153,47 @@ def _conv_transpose_output_shape(layer, input_shape):
             layer.filters,
             strides=tuple(layer.strides),
             padding=layer.padding,
+            output_padding=layer.output_padding,
             data_format=layer.data_format or "channels_last",
             dilation_rate=tuple(layer.dilation_rate),
         )
+    )
+
+
+def _standardize_output_padding(output_padding, rank):
+    if output_padding is None:
+        return None
+    if isinstance(output_padding, int):
+        return (output_padding,) * rank
+    output_padding = tuple(output_padding)
+    if len(output_padding) != rank:
+        raise ValueError(
+            f"output_padding must have {rank} values, got {output_padding}"
+        )
+    return output_padding
+
+
+def _to_channels_last(value, data_format):
+    """Move a public channels-first tensor to TensorFlow's CPU-safe layout."""
+    if data_format != "channels_first":
+        return value
+    rank = len(value.shape)
+    return ops.transpose(value, (0,) + tuple(range(2, rank)) + (1,))
+
+
+def _from_channels_last(value, data_format):
+    """Restore a CPU-safe channels-last result to the public layout."""
+    if data_format != "channels_first":
+        return value
+    rank = len(value.shape)
+    return ops.transpose(value, (0, rank - 1) + tuple(range(1, rank - 1)))
+
+
+def _channels_last_yat_score(layer, dot_prod_map, distance_sq_map):
+    """Apply the complete CPU-safe YAT tail, then restore public layout."""
+    return _from_channels_last(
+        yat_score(layer, dot_prod_map, distance_sq_map, data_format="channels_last"),
+        layer.data_format,
     )
 
 
@@ -451,6 +489,7 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
 
         inputs = reduction_safe_upcast(inputs)
         kernel = reduction_safe_upcast(kernel)
+        inputs = _to_channels_last(inputs, self.data_format)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
@@ -475,10 +514,7 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
         conv_padding = self.padding
         if self.padding == "causal":
             left_pad = self.dilation_rate[0] * (self.kernel_size[0] - 1)
-            if self.data_format == "channels_first":
-                pad_width = ((0, 0), (0, 0), (left_pad, 0))
-            else:
-                pad_width = ((0, 0), (left_pad, 0), (0, 0))
+            pad_width = ((0, 0), (left_pad, 0), (0, 0))
             conv_inputs = ops.pad(inputs, pad_width)
             conv_padding = "valid"
 
@@ -488,7 +524,7 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
             kernel,
             strides=self.strides,
             padding=conv_padding,
-            data_format=self.data_format,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
@@ -508,16 +544,15 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
             ones_kernel,
             strides=self.strides,
             padding=conv_padding,
-            data_format=self.data_format,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
         # Handle grouped convolution
-        channel_axis = 1 if self.data_format == "channels_first" else -1
         patch_sq_sum_map = ops.repeat(
             patch_sq_sum_map_raw,
             self.filters // self.groups,
-            axis=channel_axis,
+            axis=-1,
         )
 
         # Compute kernel squared sum per filter (1.0 if normalized)
@@ -529,14 +564,13 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
             )
 
         # Reshape for broadcasting
-        if self.data_format == "channels_first":
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, -1, 1))
-        else:
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, 1, -1))
+        kernel_sq_sum_reshaped = ops.reshape(
+            kernel_sq_sum_per_filter, (1, 1, -1)
+        )
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
         distance_sq_map = patch_sq_sum_map + kernel_sq_sum_reshaped - 2 * dot_prod_map
-        return yat_score(self, dot_prod_map, distance_sq_map)
+        return _channels_last_yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
         return _conv_output_shape(self, input_shape)
@@ -802,6 +836,7 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
 
         inputs = reduction_safe_upcast(inputs)
         kernel = reduction_safe_upcast(kernel)
+        inputs = _to_channels_last(inputs, self.data_format)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
@@ -825,7 +860,7 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
             kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
@@ -845,16 +880,15 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
             ones_kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
         # Handle grouped convolution
-        channel_axis = 1 if self.data_format == "channels_first" else -1
         patch_sq_sum_map = ops.repeat(
             patch_sq_sum_map_raw,
             self.filters // self.groups,
-            axis=channel_axis,
+            axis=-1,
         )
 
         # Compute kernel squared sum per filter (1.0 if normalized)
@@ -866,14 +900,13 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
             )
 
         # Reshape for broadcasting
-        if self.data_format == "channels_first":
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, -1, 1, 1))
-        else:
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, 1, 1, -1))
+        kernel_sq_sum_reshaped = ops.reshape(
+            kernel_sq_sum_per_filter, (1, 1, 1, -1)
+        )
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
         distance_sq_map = patch_sq_sum_map + kernel_sq_sum_reshaped - 2 * dot_prod_map
-        return yat_score(self, dot_prod_map, distance_sq_map)
+        return _channels_last_yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
         return _conv_output_shape(self, input_shape)
@@ -1106,6 +1139,7 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
 
         inputs = reduction_safe_upcast(inputs)
         kernel = reduction_safe_upcast(kernel)
+        inputs = _to_channels_last(inputs, self.data_format)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
@@ -1129,7 +1163,7 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
             kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
@@ -1149,16 +1183,15 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
             ones_kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
         # Handle grouped convolution
-        channel_axis = 1 if self.data_format == "channels_first" else -1
         patch_sq_sum_map = ops.repeat(
             patch_sq_sum_map_raw,
             self.filters // self.groups,
-            axis=channel_axis,
+            axis=-1,
         )
 
         # Compute kernel squared sum per filter (1.0 if normalized)
@@ -1170,14 +1203,13 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
             )
 
         # Reshape for broadcasting
-        if self.data_format == "channels_first":
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, -1, 1, 1, 1))
-        else:
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, 1, 1, 1, -1))
+        kernel_sq_sum_reshaped = ops.reshape(
+            kernel_sq_sum_per_filter, (1, 1, 1, 1, -1)
+        )
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
         distance_sq_map = patch_sq_sum_map + kernel_sq_sum_reshaped - 2 * dot_prod_map
-        return yat_score(self, dot_prod_map, distance_sq_map)
+        return _channels_last_yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
         return _conv_output_shape(self, input_shape)
@@ -1232,6 +1264,8 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         padding: one of `"valid"` or `"same"` (case-insensitive).
         data_format: A string, one of `channels_last` or `channels_first`.
         dilation_rate: an integer or tuple/list of a single integer.
+        output_padding: Optional integer or tuple/list of a single integer
+            specifying the added output size along the spatial dimension.
         use_bias: Boolean, whether the layer uses a bias vector.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to `True`.
         epsilon: Float, small constant for numerical stability.
@@ -1272,6 +1306,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        output_padding=None,
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -1281,6 +1316,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         self.padding = padding.lower()
         self.data_format = data_format
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate,)
+        self.output_padding = _standardize_output_padding(output_padding, 1)
         self.use_alpha = use_alpha
         if epsilon <= 0:
             raise ValueError(f"epsilon must be positive, got {epsilon}")
@@ -1390,6 +1426,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
 
         inputs = reduction_safe_upcast(inputs)
         kernel = reduction_safe_upcast(kernel)
+        inputs = _to_channels_last(inputs, self.data_format)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
@@ -1414,7 +1451,8 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            output_padding=self.output_padding,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
@@ -1430,12 +1468,12 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             ones_kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            output_padding=self.output_padding,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
-        channel_axis = 1 if self.data_format == "channels_first" else -1
-        patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=channel_axis)
+        patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
         # Compute kernel squared sum per filter (1.0 if normalized)
         if self.weight_normalized:
@@ -1447,14 +1485,13 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             reduce_axes = tuple(i for i in range(kernel.ndim) if i != filter_axis)
             kernel_sq_sum_per_filter = ops.sum(kernel ** 2, axis=reduce_axes)
 
-        if self.data_format == "channels_first":
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, -1, 1))
-        else:
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, 1, -1))
+        kernel_sq_sum_reshaped = ops.reshape(
+            kernel_sq_sum_per_filter, (1, 1, -1)
+        )
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
         distance_sq_map = patch_sq_sum_map + kernel_sq_sum_reshaped - 2 * dot_prod_map
-        return yat_score(self, dot_prod_map, distance_sq_map)
+        return _channels_last_yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
         return _conv_transpose_output_shape(self, input_shape)
@@ -1468,6 +1505,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             "padding": self.padding,
             "data_format": self.data_format,
             "dilation_rate": self.dilation_rate,
+            "output_padding": self.output_padding,
             "use_bias": self.use_bias,
             "constant_bias": self.constant_bias,
             "use_alpha": self.use_alpha,
@@ -1508,6 +1546,8 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         padding: one of `"valid"` or `"same"` (case-insensitive).
         data_format: A string, one of `channels_last` or `channels_first`.
         dilation_rate: an integer or tuple/list of 2 integers.
+        output_padding: Optional integer or tuple/list of 2 integers specifying
+            the added output size along each spatial dimension.
         use_bias: Boolean, whether the layer uses a bias vector.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to `True`.
         epsilon: Float, small constant for numerical stability.
@@ -1548,6 +1588,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        output_padding=None,
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -1557,6 +1598,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         self.padding = padding.lower()
         self.data_format = data_format
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate)
+        self.output_padding = _standardize_output_padding(output_padding, 2)
         self.use_alpha = use_alpha
         if epsilon <= 0:
             raise ValueError(f"epsilon must be positive, got {epsilon}")
@@ -1666,6 +1708,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
 
         inputs = reduction_safe_upcast(inputs)
         kernel = reduction_safe_upcast(kernel)
+        inputs = _to_channels_last(inputs, self.data_format)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
@@ -1690,7 +1733,8 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            output_padding=self.output_padding,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
@@ -1706,12 +1750,12 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             ones_kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            output_padding=self.output_padding,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
-        channel_axis = 1 if self.data_format == "channels_first" else -1
-        patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=channel_axis)
+        patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
         # Compute kernel squared sum per filter (1.0 if normalized)
         if self.weight_normalized:
@@ -1723,14 +1767,13 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             reduce_axes = tuple(i for i in range(kernel.ndim) if i != filter_axis)
             kernel_sq_sum_per_filter = ops.sum(kernel ** 2, axis=reduce_axes)
 
-        if self.data_format == "channels_first":
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, -1, 1, 1))
-        else:
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, 1, 1, -1))
+        kernel_sq_sum_reshaped = ops.reshape(
+            kernel_sq_sum_per_filter, (1, 1, 1, -1)
+        )
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
         distance_sq_map = patch_sq_sum_map + kernel_sq_sum_reshaped - 2 * dot_prod_map
-        return yat_score(self, dot_prod_map, distance_sq_map)
+        return _channels_last_yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
         return _conv_transpose_output_shape(self, input_shape)
@@ -1744,6 +1787,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             "padding": self.padding,
             "data_format": self.data_format,
             "dilation_rate": self.dilation_rate,
+            "output_padding": self.output_padding,
             "use_bias": self.use_bias,
             "constant_bias": self.constant_bias,
             "use_alpha": self.use_alpha,
@@ -1784,6 +1828,8 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         padding: one of `"valid"` or `"same"` (case-insensitive).
         data_format: A string, one of `channels_last` or `channels_first`.
         dilation_rate: an integer or tuple/list of 3 integers.
+        output_padding: Optional integer or tuple/list of 3 integers specifying
+            the added output size along each spatial dimension.
         use_bias: Boolean, whether the layer uses a bias vector.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to `True`.
         epsilon: Float, small constant for numerical stability.
@@ -1824,6 +1870,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         activity_regularizer=None,
         kernel_constraint=None,
         bias_constraint=None,
+        output_padding=None,
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -1833,6 +1880,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         self.padding = padding.lower()
         self.data_format = data_format
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate, dilation_rate)
+        self.output_padding = _standardize_output_padding(output_padding, 3)
         self.use_alpha = use_alpha
         if epsilon <= 0:
             raise ValueError(f"epsilon must be positive, got {epsilon}")
@@ -1942,6 +1990,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
 
         inputs = reduction_safe_upcast(inputs)
         kernel = reduction_safe_upcast(kernel)
+        inputs = _to_channels_last(inputs, self.data_format)
 
         # DropConnect: random kernel mask during training
         if self.use_dropconnect and training and self.drop_rate > 0.0:
@@ -1966,7 +2015,8 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            output_padding=self.output_padding,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
@@ -1982,12 +2032,12 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             ones_kernel,
             strides=self.strides,
             padding=self.padding,
-            data_format=self.data_format,
+            output_padding=self.output_padding,
+            data_format="channels_last",
             dilation_rate=self.dilation_rate,
         )
 
-        channel_axis = 1 if self.data_format == "channels_first" else -1
-        patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=channel_axis)
+        patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
         # Compute kernel squared sum per filter (1.0 if normalized).
         # Transpose conv kernel shape: (*kernel_size, filters, in_dim)
@@ -1998,14 +2048,13 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             reduce_axes = tuple(i for i in range(kernel.ndim) if i != filter_axis)
             kernel_sq_sum_per_filter = ops.sum(kernel ** 2, axis=reduce_axes)
 
-        if self.data_format == "channels_first":
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, -1, 1, 1, 1))
-        else:
-            kernel_sq_sum_reshaped = ops.reshape(kernel_sq_sum_per_filter, (1, 1, 1, 1, -1))
+        kernel_sq_sum_reshaped = ops.reshape(
+            kernel_sq_sum_per_filter, (1, 1, 1, 1, -1)
+        )
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
         distance_sq_map = patch_sq_sum_map + kernel_sq_sum_reshaped - 2 * dot_prod_map
-        return yat_score(self, dot_prod_map, distance_sq_map)
+        return _channels_last_yat_score(self, dot_prod_map, distance_sq_map)
 
     def compute_output_shape(self, input_shape):
         return _conv_transpose_output_shape(self, input_shape)
@@ -2019,6 +2068,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             "padding": self.padding,
             "data_format": self.data_format,
             "dilation_rate": self.dilation_rate,
+            "output_padding": self.output_padding,
             "use_bias": self.use_bias,
             "constant_bias": self.constant_bias,
             "use_alpha": self.use_alpha,

--- a/tests/test_keras/test_channels_first_tf_cpu.py
+++ b/tests/test_keras/test_channels_first_tf_cpu.py
@@ -1,0 +1,185 @@
+"""TensorFlow CPU parity for Keras channels-first YAT convolutions (#92)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+tf = pytest.importorskip("tensorflow")
+import keras  # noqa: E402
+
+from nmn.keras import (  # noqa: E402
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    keras.backend.backend() != "tensorflow",
+    reason="TensorFlow CPU layout fallback is backend-specific coverage",
+)
+
+
+CASES = (
+    pytest.param(
+        YatConv1D,
+        (2, 11, 4),
+        dict(filters=4, kernel_size=3, padding="same", dilation_rate=2, groups=2),
+        id="conv1d-dilated-grouped",
+    ),
+    pytest.param(
+        YatConv1D,
+        (2, 11, 4),
+        dict(filters=4, kernel_size=3, padding="causal", groups=2),
+        id="conv1d-causal-grouped",
+    ),
+    pytest.param(
+        YatConv2D,
+        (2, 8, 7, 4),
+        dict(filters=4, kernel_size=(3, 2), padding="same", strides=(2, 1), groups=2),
+        id="conv2d-strided-grouped",
+    ),
+    pytest.param(
+        YatConv3D,
+        (2, 5, 6, 4, 4),
+        dict(
+            filters=4,
+            kernel_size=(2, 2, 2),
+            padding="same",
+            dilation_rate=(1, 2, 1),
+            groups=2,
+        ),
+        id="conv3d-dilated-grouped",
+    ),
+    pytest.param(
+        YatConvTranspose1D,
+        (2, 6, 3),
+        dict(filters=4, kernel_size=3, strides=2, output_padding=1),
+        id="transpose1d-output-padding",
+    ),
+    pytest.param(
+        YatConvTranspose2D,
+        (2, 4, 5, 3),
+        dict(
+            filters=4,
+            kernel_size=(3, 2),
+            strides=(2, 1),
+            output_padding=(1, 0),
+        ),
+        id="transpose2d-output-padding",
+    ),
+    pytest.param(
+        YatConvTranspose3D,
+        (2, 3, 4, 3, 3),
+        dict(
+            filters=4,
+            kernel_size=(2, 2, 2),
+            strides=(2, 1, 2),
+            output_padding=(1, 0, 1),
+        ),
+        id="transpose3d-output-padding",
+    ),
+)
+
+
+def _channels_last_to_first(value):
+    rank = len(value.shape)
+    return tf.transpose(value, (0, rank - 1) + tuple(range(1, rank - 1)))
+
+
+def _channels_first_to_last(value):
+    rank = len(value.shape)
+    return tf.transpose(value, (0,) + tuple(range(2, rank)) + (1,))
+
+
+def _make_evaluator(layer, compiled):
+    def evaluate(inputs, cotangent):
+        with tf.GradientTape() as tape:
+            tape.watch(inputs)
+            output = layer(inputs)
+            loss = tf.reduce_sum(output * cotangent)
+        gradients = tape.gradient(loss, (inputs, *layer.trainable_variables))
+        return output, gradients
+
+    return tf.function(evaluate) if compiled else evaluate
+
+
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "tf-function"])
+@pytest.mark.parametrize("layer_cls,input_shape,kwargs", CASES)
+def test_channels_first_matches_channels_last_forward_and_all_gradients(
+    layer_cls, input_shape, kwargs, compiled
+):
+    rng = np.random.default_rng(92)
+    input_last = tf.convert_to_tensor(rng.normal(size=input_shape).astype(np.float32))
+    input_first = _channels_last_to_first(input_last)
+
+    common = dict(
+        use_bias=True,
+        use_alpha=True,
+        learnable_epsilon=True,
+        epsilon=0.25,
+        kernel_initializer="glorot_uniform",
+    )
+    with tf.device("/CPU:0"):
+        channels_last = layer_cls(data_format="channels_last", **common, **kwargs)
+        channels_first = layer_cls(data_format="channels_first", **common, **kwargs)
+        output_last = channels_last(input_last)
+        output_first = channels_first(input_first)
+        channels_first.set_weights(channels_last.get_weights())
+
+        # A non-uniform cotangent catches layout mistakes that a scalar sum can
+        # hide while exercising input, kernel, bias, alpha, and epsilon grads.
+        output_last = channels_last(input_last)
+        output_first = channels_first(input_first)
+        assert output_first.shape == _channels_last_to_first(output_last).shape
+        cotangent_last = tf.convert_to_tensor(
+            rng.normal(size=output_last.shape).astype(np.float32)
+        )
+        cotangent_first = _channels_last_to_first(cotangent_last)
+
+        eval_last = _make_evaluator(channels_last, compiled)
+        eval_first = _make_evaluator(channels_first, compiled)
+        output_last, gradients_last = eval_last(input_last, cotangent_last)
+        output_first, gradients_first = eval_first(input_first, cotangent_first)
+
+    np.testing.assert_allclose(
+        _channels_first_to_last(output_first).numpy(),
+        output_last.numpy(),
+        rtol=2e-5,
+        atol=2e-5,
+    )
+    assert all(gradient is not None for gradient in gradients_last)
+    assert all(gradient is not None for gradient in gradients_first)
+    np.testing.assert_allclose(
+        _channels_first_to_last(gradients_first[0]).numpy(),
+        gradients_last[0].numpy(),
+        rtol=4e-5,
+        atol=4e-5,
+    )
+    for gradient_first, gradient_last in zip(gradients_first[1:], gradients_last[1:]):
+        np.testing.assert_allclose(
+            gradient_first.numpy(),
+            gradient_last.numpy(),
+            rtol=4e-5,
+            atol=4e-5,
+        )
+
+
+@pytest.mark.parametrize(
+    "layer_cls,output_padding",
+    [
+        (YatConvTranspose1D, 1),
+        (YatConvTranspose2D, (1, 0)),
+        (YatConvTranspose3D, (1, 0, 1)),
+    ],
+)
+def test_output_padding_config_roundtrip(layer_cls, output_padding):
+    layer = layer_cls(4, 3, strides=2, output_padding=output_padding)
+    config = layer.get_config()
+    restored = layer_cls.from_config(config)
+    assert restored.output_padding == layer.output_padding


### PR DESCRIPTION
Fixes #92. Runs the full convolution plus YAT tail internally in channels-last for TensorFlow-compatible CPU execution, restoring the public channels-first layout afterward across Conv/ConvTranspose 1D/2D/3D. Adds backward-compatible output_padding support and synchronized eager/tf.function output plus input/kernel/bias/alpha/epsilon gradient parity tests, including groups, dilation, causal, stride, dynamic shapes, config, and save/load. Independently reviewed; TensorFlow CPU, JAX, and Torch Keras suites pass.