### PR TITLE
fix(tests): isolate optional backends and complete framework dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,12 @@ jobs:
     - name: Run PyTorch tests
       run: pytest tests/test_torch/ -v --cov=nmn --cov-report=xml
 
+    - name: Verify Windows optional-backend probe cleanup
+      if: runner.os == 'Windows'
+      run: >-
+        python -m pytest tests/test_cli.py -v
+        -k "optional_backend_probe_windows_job_kills_descendants"
+
     - name: Upload coverage
       uses: codecov/codecov-action@v4
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/tests/_isolated_backend.py
+++ b/tests/_isolated_backend.py
@@ -1,0 +1,56 @@
+"""Safe availability probes for optional native test backends.
+
+This module intentionally contains no imports from a machine-learning runtime.
+Some optional backends can terminate the interpreter from native code during
+initialization, so availability must be decided by a bounded child process.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+
+
+_PROBE_MARKER = "__NMN_TEST_BACKEND_READY__"
+_PROBE_TIMEOUT_SECONDS = 15.0
+_PROBE_SCRIPT = f"""\
+import importlib
+import json
+import sys
+
+request = json.loads(sys.argv[1])
+modules = {{name: importlib.import_module(name) for name in request["modules"]}}
+if request.get("readiness") == "mlx":
+    # Importing mlx.core alone is insufficient: on an installed but unusable
+    # runtime, the first device query may abort in native Metal code.
+    modules["mlx.core"].default_device()
+print({_PROBE_MARKER!r})
+"""
+
+
+def isolated_import_succeeds(
+    modules: Sequence[str], *, readiness: str | None = None
+) -> bool:
+    """Return whether optional modules initialize safely in a child process."""
+
+    request = json.dumps({"modules": list(modules), "readiness": readiness})
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", _PROBE_SCRIPT, request],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+    return completed.returncode == 0 and _PROBE_MARKER in completed.stdout.splitlines()
+
+
+def mlx_is_usable() -> bool:
+    """Return whether MLX imports and can initialize its default device."""
+
+    return isolated_import_succeeds(["mlx.core"], readiness="mlx")

--- a/tests/_isolated_backend.py
+++ b/tests/_isolated_backend.py
@@ -12,6 +12,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import Sequence
 
@@ -23,9 +24,14 @@ _PROBE_REAP_SECONDS = 1.0
 _PROBE_SCRIPT = f"""\
 import importlib
 import json
+import os
 import sys
+import time
 
 request = json.loads(sys.argv[1])
+gate = request.get("gate")
+while gate and not os.path.exists(gate):
+    time.sleep(0.005)
 modules = {{name: importlib.import_module(name) for name in request["modules"]}}
 if request.get("readiness") == "mlx":
     # Importing mlx.core alone is insufficient: on an installed but unusable
@@ -33,6 +39,97 @@ if request.get("readiness") == "mlx":
     modules["mlx.core"].default_device()
 print({_PROBE_MARKER!r})
 """
+
+
+def _assign_windows_kill_job(process: subprocess.Popen) -> None:
+    """Own the probe tree with a Windows kill-on-close Job Object."""
+
+    import ctypes
+    from ctypes import wintypes
+
+    class BasicLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class IoCounters(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class ExtendedLimitInformation(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", BasicLimitInformation),
+            ("IoInfo", IoCounters),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.argtypes = [wintypes.LPVOID, wintypes.LPCWSTR]
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.CreateJobObjectW(None, None)
+    if not handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        information = ExtendedLimitInformation()
+        information.BasicLimitInformation.LimitFlags = 0x00002000
+        if not kernel32.SetInformationJobObject(
+            handle, 9, ctypes.byref(information), ctypes.sizeof(information)
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        if not kernel32.AssignProcessToJobObject(handle, process._handle):
+            raise ctypes.WinError(ctypes.get_last_error())
+    except BaseException:
+        kernel32.CloseHandle(handle)
+        raise
+    process._nmn_job_handle = handle
+    process._nmn_close_job_handle = kernel32.CloseHandle
+
+
+def _close_windows_kill_job(process: subprocess.Popen) -> bool:
+    handle = getattr(process, "_nmn_job_handle", None)
+    if handle is None:
+        return False
+    process._nmn_job_handle = None
+    process._nmn_close_job_handle(handle)
+    return True
+
+
+def _remove_gate(gate: str | None) -> None:
+    if gate is None:
+        return
+    try:
+        os.unlink(gate)
+    except OSError:
+        pass
 
 
 def _process_group_exists(process_group: int) -> bool:
@@ -67,17 +164,10 @@ def _stop_process_tree(process: subprocess.Popen) -> None:
                 except (ProcessLookupError, PermissionError):
                     pass
     else:  # pragma: no cover - exercised on Windows CI
-        # CREATE_NEW_PROCESS_GROUP isolates the probe.  taskkill /T is the
-        # standard Windows mechanism that also follows and kills descendants.
-        try:
-            subprocess.run(
-                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=False,
-                timeout=_PROBE_REAP_SECONDS,
-            )
-        except (OSError, subprocess.SubprocessError):
+        # Job membership survives root-process exit, unlike taskkill's
+        # parent/child discovery. Closing the last handle atomically terminates
+        # every process still owned by the job.
+        if not _close_windows_kill_job(process):
             try:
                 process.kill()
             except OSError:
@@ -113,20 +203,51 @@ def isolated_import_succeeds(
 ) -> bool:
     """Return whether optional modules initialize safely in a child process."""
 
-    request = json.dumps({"modules": list(modules), "readiness": readiness})
+    gate = None
+    request_data = {"modules": list(modules), "readiness": readiness}
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        try:
+            descriptor, gate = tempfile.mkstemp(prefix="nmn-backend-gate-")
+            os.close(descriptor)
+            os.unlink(gate)
+        except OSError:
+            _remove_gate(gate)
+            return False
+        request_data["gate"] = gate
+    request = json.dumps(request_data)
     try:
         process = subprocess.Popen(
             [sys.executable, "-c", _PROBE_SCRIPT, request],
             **_popen_options(),
         )
     except OSError:
+        _remove_gate(gate)
         return False
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        try:
+            _assign_windows_kill_job(process)
+            with open(gate, "wb"):
+                pass
+        except (OSError, AttributeError):
+            _stop_process_tree(process)
+            _remove_gate(gate)
+            return False
 
     try:
         stdout, _stderr = process.communicate(timeout=_PROBE_TIMEOUT_SECONDS)
     except (OSError, subprocess.SubprocessError):
         _stop_process_tree(process)
+        _remove_gate(gate)
         return False
+    finally:
+        _remove_gate(gate)
+
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        # Release durable ownership after the root finishes. This also removes
+        # any background descendants left behind by an otherwise successful
+        # import.
+        _close_windows_kill_job(process)
 
     if stdout is None:
         stdout = b""

--- a/tests/_isolated_backend.py
+++ b/tests/_isolated_backend.py
@@ -8,13 +8,18 @@ initialization, so availability must be decided by a bounded child process.
 from __future__ import annotations
 
 import json
+import os
+import signal
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
 
 
 _PROBE_MARKER = "__NMN_TEST_BACKEND_READY__"
+_PROBE_MARKER_BYTES = _PROBE_MARKER.encode("ascii")
 _PROBE_TIMEOUT_SECONDS = 15.0
+_PROBE_REAP_SECONDS = 1.0
 _PROBE_SCRIPT = f"""\
 import importlib
 import json
@@ -30,6 +35,79 @@ print({_PROBE_MARKER!r})
 """
 
 
+def _process_group_exists(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _stop_process_tree(process: subprocess.Popen) -> None:
+    """Terminate the isolated probe and every descendant, with bounded reap."""
+
+    if os.name == "posix":
+        group_signalled = False
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+            group_signalled = True
+        except (ProcessLookupError, PermissionError):
+            pass
+        if group_signalled:
+            deadline = time.monotonic() + _PROBE_REAP_SECONDS
+            while time.monotonic() < deadline:
+                if not _process_group_exists(process.pid):
+                    break
+                time.sleep(0.01)
+            else:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    pass
+    else:  # pragma: no cover - exercised on Windows CI
+        # CREATE_NEW_PROCESS_GROUP isolates the probe.  taskkill /T is the
+        # standard Windows mechanism that also follows and kills descendants.
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=_PROBE_REAP_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError):
+            try:
+                process.kill()
+            except OSError:
+                pass
+
+    try:
+        process.communicate(timeout=_PROBE_REAP_SECONDS)
+    except (OSError, subprocess.SubprocessError):
+        try:
+            process.kill()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=_PROBE_REAP_SECONDS)
+        except (OSError, subprocess.SubprocessError):
+            pass
+
+
+def _popen_options() -> dict:
+    options = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+    }
+    if os.name == "posix":
+        options["start_new_session"] = True
+    else:  # pragma: no cover - exercised on Windows CI
+        options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    return options
+
+
 def isolated_import_succeeds(
     modules: Sequence[str], *, readiness: str | None = None
 ) -> bool:
@@ -37,17 +115,32 @@ def isolated_import_succeeds(
 
     request = json.dumps({"modules": list(modules), "readiness": readiness})
     try:
-        completed = subprocess.run(
+        process = subprocess.Popen(
             [sys.executable, "-c", _PROBE_SCRIPT, request],
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=_PROBE_TIMEOUT_SECONDS,
+            **_popen_options(),
         )
-    except (OSError, subprocess.SubprocessError):
+    except OSError:
         return False
 
-    return completed.returncode == 0 and _PROBE_MARKER in completed.stdout.splitlines()
+    try:
+        stdout, _stderr = process.communicate(timeout=_PROBE_TIMEOUT_SECONDS)
+    except (OSError, subprocess.SubprocessError):
+        _stop_process_tree(process)
+        return False
+
+    if stdout is None:
+        stdout = b""
+    elif not isinstance(stdout, (bytes, bytearray)):
+        _stop_process_tree(process)
+        return False
+    success = (
+        process.returncode == 0
+        and _PROBE_MARKER_BYTES in stdout.splitlines()
+    )
+    if not success:
+        # The direct child may have exited while a grandchild remains alive.
+        _stop_process_tree(process)
+    return success
 
 
 def mlx_is_usable() -> bool:

--- a/tests/integration/test_cross_framework.py
+++ b/tests/integration/test_cross_framework.py
@@ -8,6 +8,8 @@ across all frameworks (PyTorch, TensorFlow, Keras, Linen, NNX).
 import pytest
 import numpy as np
 
+from tests._isolated_backend import mlx_is_usable
+
 
 # ============================================================================
 # Framework Availability Checks
@@ -50,11 +52,8 @@ def get_available_frameworks():
     except ImportError:
         pass
 
-    try:
-        import mlx.core  # noqa: F401
+    if mlx_is_usable():
         frameworks.append('mlx')
-    except ImportError:
-        pass
 
     return frameworks
 
@@ -145,6 +144,7 @@ def get_tf_output(inputs_np, weights_np, bias_np=None, alpha_np=None, epsilon=1e
     layer = YatNMN(
         features=out_features,  # TF YatNMN uses 'features' not 'in_features'
         use_bias=(bias_np is not None),
+        use_alpha=(alpha_np is not None),
         epsilon=epsilon
     )
     
@@ -319,6 +319,12 @@ class TestCrossFrameworkConsistency:
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             outputs['nnx'] = get_nnx_output(inputs, weights, epsilon=epsilon)
 
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            outputs['tensorflow'] = get_tf_output(inputs, weights, epsilon=epsilon)
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            outputs['keras'] = get_keras_output(inputs, weights, epsilon=epsilon)
+
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             outputs['mlx'] = get_mlx_output(inputs, weights, epsilon=epsilon)
 
@@ -350,6 +356,12 @@ class TestCrossFrameworkConsistency:
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             outputs['nnx'] = get_nnx_output(inputs, weights, bias_np=bias, epsilon=epsilon)
 
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            outputs['tensorflow'] = get_tf_output(inputs, weights, bias_np=bias, epsilon=epsilon)
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            outputs['keras'] = get_keras_output(inputs, weights, bias_np=bias, epsilon=epsilon)
+
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             outputs['mlx'] = get_mlx_output(inputs, weights, bias_np=bias, epsilon=epsilon)
 
@@ -380,6 +392,12 @@ class TestCrossFrameworkConsistency:
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             outputs['nnx'] = get_nnx_output(inputs, weights, alpha_np=alpha, epsilon=epsilon)
 
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            outputs['tensorflow'] = get_tf_output(inputs, weights, alpha_np=alpha, epsilon=epsilon)
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            outputs['keras'] = get_keras_output(inputs, weights, alpha_np=alpha, epsilon=epsilon)
+
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             outputs['mlx'] = get_mlx_output(inputs, weights, alpha_np=alpha, epsilon=epsilon)
 
@@ -406,6 +424,14 @@ class TestCrossFrameworkConsistency:
         if 'nnx' in AVAILABLE_FRAMEWORKS:
             output = get_nnx_output(inputs, weights, epsilon=epsilon)
             assert np.all(output >= 0), "NNX produced negative values"
+
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            output = get_tf_output(inputs, weights, epsilon=epsilon)
+            assert np.all(output >= 0), "TensorFlow produced negative values"
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            output = get_keras_output(inputs, weights, epsilon=epsilon)
+            assert np.all(output >= 0), "Keras produced negative values"
 
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             output = get_mlx_output(inputs, weights, epsilon=epsilon)
@@ -502,6 +528,21 @@ class TestNumericalStabilityAllFrameworks:
             assert not np.isnan(output).any(), "Linen NaN with large values"
             assert not np.isinf(output).any(), "Linen Inf with large values"
 
+        if 'nnx' in AVAILABLE_FRAMEWORKS:
+            output = get_nnx_output(inputs, weights)
+            assert not np.isnan(output).any(), "NNX NaN with large values"
+            assert not np.isinf(output).any(), "NNX Inf with large values"
+
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            output = get_tf_output(inputs, weights)
+            assert not np.isnan(output).any(), "TensorFlow NaN with large values"
+            assert not np.isinf(output).any(), "TensorFlow Inf with large values"
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            output = get_keras_output(inputs, weights)
+            assert not np.isnan(output).any(), "Keras NaN with large values"
+            assert not np.isinf(output).any(), "Keras Inf with large values"
+
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             output = get_mlx_output(inputs, weights)
             assert not np.isnan(output).any(), "MLX NaN with large values"
@@ -521,6 +562,18 @@ class TestNumericalStabilityAllFrameworks:
             output = get_linen_output(inputs, weights)
             assert not np.isnan(output).any(), "Linen NaN with small values"
 
+        if 'nnx' in AVAILABLE_FRAMEWORKS:
+            output = get_nnx_output(inputs, weights)
+            assert not np.isnan(output).any(), "NNX NaN with small values"
+
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            output = get_tf_output(inputs, weights)
+            assert not np.isnan(output).any(), "TensorFlow NaN with small values"
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            output = get_keras_output(inputs, weights)
+            assert not np.isnan(output).any(), "Keras NaN with small values"
+
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             output = get_mlx_output(inputs, weights)
             assert not np.isnan(output).any(), "MLX NaN with small values"
@@ -539,6 +592,18 @@ class TestNumericalStabilityAllFrameworks:
         if 'linen' in AVAILABLE_FRAMEWORKS:
             output = get_linen_output(inputs, weights)
             assert not np.isnan(output).any(), "Linen NaN with matching vectors"
+
+        if 'nnx' in AVAILABLE_FRAMEWORKS:
+            output = get_nnx_output(inputs, weights)
+            assert not np.isnan(output).any(), "NNX NaN with matching vectors"
+
+        if 'tensorflow' in AVAILABLE_FRAMEWORKS:
+            output = get_tf_output(inputs, weights)
+            assert not np.isnan(output).any(), "TensorFlow NaN with matching vectors"
+
+        if 'keras' in AVAILABLE_FRAMEWORKS:
+            output = get_keras_output(inputs, weights)
+            assert not np.isnan(output).any(), "Keras NaN with matching vectors"
 
         if 'mlx' in AVAILABLE_FRAMEWORKS:
             output = get_mlx_output(inputs, weights)

--- a/tests/integration/test_cross_framework_consistency.py
+++ b/tests/integration/test_cross_framework_consistency.py
@@ -17,6 +17,8 @@ import numpy as np
 from typing import Dict, List, Tuple, Optional
 from dataclasses import dataclass
 
+from tests._isolated_backend import mlx_is_usable
+
 
 # ============================================================================
 # Framework Availability
@@ -61,11 +63,7 @@ try:
 except ImportError:
     FRAMEWORKS['nnx'] = False
 
-try:
-    import mlx.core as mx
-    FRAMEWORKS['mlx'] = True
-except ImportError:
-    FRAMEWORKS['mlx'] = False
+FRAMEWORKS['mlx'] = mlx_is_usable()
 
 
 def get_available_frameworks() -> List[str]:
@@ -198,6 +196,56 @@ def run_nnx_dense(inputs: np.ndarray, weights: np.ndarray,
     return np.array(output)
 
 
+def run_tensorflow_dense(inputs: np.ndarray, weights: np.ndarray,
+                         bias: Optional[np.ndarray] = None,
+                         alpha: Optional[float] = None,
+                         epsilon: float = 1e-6) -> np.ndarray:
+    """Run YAT dense layer in TensorFlow."""
+    import tensorflow as tf
+    from nmn.tf import YatNMN
+
+    _, out_features = weights.shape
+    layer = YatNMN(
+        features=out_features,
+        use_bias=(bias is not None),
+        use_alpha=(alpha is not None),
+        epsilon=epsilon,
+    )
+    x = tf.constant(inputs, dtype=tf.float32)
+    layer(x)
+    layer.kernel.assign(weights.T)
+    if bias is not None:
+        layer.bias.assign(bias)
+    if alpha is not None:
+        layer.alpha.assign([alpha])
+    return layer(x).numpy()
+
+
+def run_keras_dense(inputs: np.ndarray, weights: np.ndarray,
+                    bias: Optional[np.ndarray] = None,
+                    alpha: Optional[float] = None,
+                    epsilon: float = 1e-6) -> np.ndarray:
+    """Run YAT dense layer in Keras with its TensorFlow backend."""
+    import keras
+    from nmn.keras import YatNMN
+
+    _, out_features = weights.shape
+    layer = YatNMN(
+        units=out_features,
+        use_bias=(bias is not None),
+        use_alpha=(alpha is not None),
+        epsilon=epsilon,
+    )
+    x = keras.ops.convert_to_tensor(inputs)
+    layer(x)
+    layer.kernel.assign(weights)
+    if bias is not None:
+        layer.bias.assign(bias)
+    if alpha is not None:
+        layer.alpha.assign([alpha])
+    return keras.ops.convert_to_numpy(layer(x))
+
+
 def run_mlx_dense(inputs: np.ndarray, weights: np.ndarray,
                   bias: Optional[np.ndarray] = None,
                   alpha: Optional[float] = None,
@@ -263,6 +311,49 @@ def run_numpy_yat(inputs: np.ndarray, weights: np.ndarray,
         y = y * alpha
 
     return y.astype(np.float32)
+
+
+def run_available_frameworks(
+    frameworks: Dict[str, bool],
+    inputs: np.ndarray,
+    weights: np.ndarray,
+    bias: Optional[np.ndarray] = None,
+    alpha: Optional[float] = None,
+    epsilon: float = 1e-6,
+) -> Dict[str, np.ndarray]:
+    """Execute every backend reported available, plus the NumPy reference.
+
+    Keeping detection and dispatch keyed by the same canonical names prevents a
+    backend from being counted for collection-time skip decisions but silently
+    omitted from the comparisons.
+    """
+    runners = {
+        'torch': ('PyTorch', run_torch_dense),
+        'tensorflow': ('TensorFlow', run_tensorflow_dense),
+        'keras': ('Keras', run_keras_dense),
+        'linen': ('Linen', run_linen_dense),
+        'nnx': ('NNX', run_nnx_dense),
+        'mlx': ('MLX', run_mlx_dense),
+    }
+    reported = {name for name, available in frameworks.items() if available}
+    if not reported:
+        raise ValueError("at least one framework must be available for comparison")
+    unsupported = reported.difference(runners)
+    if unsupported:
+        raise AssertionError(
+            "available frameworks have no consistency runner: "
+            + ", ".join(sorted(unsupported))
+        )
+
+    outputs = {
+        'NumPy (ref)': run_numpy_yat(inputs, weights, bias, alpha, epsilon),
+    }
+    for name in frameworks:
+        if name not in reported:
+            continue
+        label, runner = runners[name]
+        outputs[label] = runner(inputs, weights, bias, alpha, epsilon)
+    return outputs
 
 
 # ============================================================================
@@ -345,24 +436,9 @@ class TestCrossFrameworkYATConsistency:
                            alpha: Optional[float] = None,
                            epsilon: float = 1e-6) -> Dict[str, np.ndarray]:
         """Run YAT dense layer on all available frameworks."""
-        outputs = {}
-        
-        # Reference NumPy implementation
-        outputs['NumPy (ref)'] = run_numpy_yat(inputs, weights, bias, alpha, epsilon)
-        
-        if FRAMEWORKS.get('torch'):
-            outputs['PyTorch'] = run_torch_dense(inputs, weights, bias, alpha, epsilon)
-        
-        if FRAMEWORKS.get('linen'):
-            outputs['Linen'] = run_linen_dense(inputs, weights, bias, alpha, epsilon)
-        
-        if FRAMEWORKS.get('nnx'):
-            outputs['NNX'] = run_nnx_dense(inputs, weights, bias, alpha, epsilon)
-
-        if FRAMEWORKS.get('mlx'):
-            outputs['MLX'] = run_mlx_dense(inputs, weights, bias, alpha, epsilon)
-
-        return outputs
+        return run_available_frameworks(
+            FRAMEWORKS, inputs, weights, bias, alpha, epsilon
+        )
     
     def compare_all_pairs(self, outputs: Dict[str, np.ndarray],
                           rtol: float = 1e-4, atol: float = 1e-4) -> List[ComparisonResult]:
@@ -467,6 +543,7 @@ class TestCrossFrameworkYATConsistency:
             all_results.extend(results)
         
         # Summary
+        assert all_results, "no framework comparisons were produced"
         max_error = max(r.max_abs_error for r in all_results)
         mean_error = np.mean([r.mean_abs_error for r in all_results])
         print(f"\n=== Summary ===")
@@ -493,7 +570,7 @@ class TestCrossFrameworkYATConsistency:
         for name, inputs in edge_cases:
             outputs = self.run_all_frameworks(inputs, weights)
             results = self.compare_all_pairs(outputs)
-            
+            assert results, f"no framework comparisons were produced for {name}"
             max_err = max(r.max_abs_error for r in results)
             all_match = all(r.matching for r in results)
             status = "PASS" if all_match else "FAIL"
@@ -522,25 +599,10 @@ class TestYATGeometricProperties:
         print("  Positive Output Test (YAT = squared ratio >= 0)")
         print("="*60)
         
-        if FRAMEWORKS.get('torch'):
-            out = run_torch_dense(inputs, weights)
-            assert np.all(out >= 0), "PyTorch produced negative values"
-            print(f"PyTorch: min={out.min():.6f}, all positive [PASS]")
-        
-        if FRAMEWORKS.get('linen'):
-            out = run_linen_dense(inputs, weights)
-            assert np.all(out >= 0), "Linen produced negative values"
-            print(f"Linen: min={out.min():.6f}, all positive [PASS]")
-        
-        if FRAMEWORKS.get('nnx'):
-            out = run_nnx_dense(inputs, weights)
-            assert np.all(out >= 0), "NNX produced negative values"
-            print(f"NNX: min={out.min():.6f}, all positive [PASS]")
-
-        if FRAMEWORKS.get('mlx'):
-            out = run_mlx_dense(inputs, weights)
-            assert np.all(out >= 0), "MLX produced negative values"
-            print(f"MLX: min={out.min():.6f}, all positive [PASS]")
+        outputs = run_available_frameworks(FRAMEWORKS, inputs, weights)
+        for name, out in outputs.items():
+            assert np.all(out >= 0), f"{name} produced negative values"
+            print(f"{name}: min={out.min():.6f}, all positive [PASS]")
     
     def test_epsilon_effect(self):
         """Epsilon should only affect outputs where distance is near 0."""
@@ -555,15 +617,13 @@ class TestYATGeometricProperties:
         
         epsilons = [1e-3, 1e-5, 1e-7, 1e-9]
         
-        for fw_name, fw_func in [
-            ('PyTorch', run_torch_dense) if FRAMEWORKS.get('torch') else (None, None),
-            ('Linen', run_linen_dense) if FRAMEWORKS.get('linen') else (None, None),
-        ]:
-            if fw_name is None:
-                continue
-                
-            outputs = [fw_func(inputs, weights, epsilon=eps) for eps in epsilons]
-            
+        outputs_by_epsilon = [
+            run_available_frameworks(FRAMEWORKS, inputs, weights, epsilon=eps)
+            for eps in epsilons
+        ]
+        for fw_name in outputs_by_epsilon[0]:
+            outputs = [result[fw_name] for result in outputs_by_epsilon]
+
             print(f"\n{fw_name}:")
             for i in range(len(epsilons) - 1):
                 diff = np.max(np.abs(outputs[i] - outputs[i+1]))
@@ -592,24 +652,11 @@ class TestYATGeometricProperties:
         print("="*60)
         print(f"Expected first output: {expected_first:.6f}")
         
-        if FRAMEWORKS.get('torch'):
-            out = run_torch_dense(inputs, weights, epsilon=epsilon)
-            print(f"PyTorch first output: {out[0, 0]:.6f}")
-            np.testing.assert_allclose(out[0, 0], expected_first, rtol=1e-3)
-        
-        if FRAMEWORKS.get('linen'):
-            out = run_linen_dense(inputs, weights, epsilon=epsilon)
-            print(f"Linen first output: {out[0, 0]:.6f}")
-            np.testing.assert_allclose(out[0, 0], expected_first, rtol=1e-3)
-        
-        if FRAMEWORKS.get('nnx'):
-            out = run_nnx_dense(inputs, weights, epsilon=epsilon)
-            print(f"NNX first output: {out[0, 0]:.6f}")
-            np.testing.assert_allclose(out[0, 0], expected_first, rtol=1e-3)
-
-        if FRAMEWORKS.get('mlx'):
-            out = run_mlx_dense(inputs, weights, epsilon=epsilon)
-            print(f"MLX first output: {out[0, 0]:.6f}")
+        outputs = run_available_frameworks(
+            FRAMEWORKS, inputs, weights, epsilon=epsilon
+        )
+        for name, out in outputs.items():
+            print(f"{name} first output: {out[0, 0]:.6f}")
             np.testing.assert_allclose(out[0, 0], expected_first, rtol=1e-3)
 
 
@@ -633,18 +680,10 @@ def test_generate_consistency_report():
     weights = np.random.randn(32, 64).astype(np.float32)
     epsilon = 1e-6
     
-    # Collect outputs
-    outputs = {}
-    outputs['NumPy (ref)'] = run_numpy_yat(inputs, weights, epsilon=epsilon)
-    
-    if FRAMEWORKS.get('torch'):
-        outputs['PyTorch'] = run_torch_dense(inputs, weights, epsilon=epsilon)
-    if FRAMEWORKS.get('linen'):
-        outputs['Linen'] = run_linen_dense(inputs, weights, epsilon=epsilon)
-    if FRAMEWORKS.get('nnx'):
-        outputs['NNX'] = run_nnx_dense(inputs, weights, epsilon=epsilon)
-    if FRAMEWORKS.get('mlx'):
-        outputs['MLX'] = run_mlx_dense(inputs, weights, epsilon=epsilon)
+    # Collect outputs from exactly the set reported as available.
+    outputs = run_available_frameworks(
+        FRAMEWORKS, inputs, weights, epsilon=epsilon
+    )
 
     # Compare all pairs
     names = list(outputs.keys())
@@ -663,6 +702,7 @@ def test_generate_consistency_report():
             print(f"{names[i]} vs {names[j]:<20} {result.max_abs_error:>15.2e} {result.mean_abs_error:>15.2e}")
     
     # Summary statistics
+    assert all_errors, "no framework comparisons were produced"
     print("\n" + "-"*70)
     print("SUMMARY STATISTICS")
     print("-"*70)
@@ -686,3 +726,77 @@ def test_generate_consistency_report():
     
     # Final assertion
     assert max(all_errors) < 1e-3, f"Cross-framework error too high: {max(all_errors):.2e}"
+
+
+# ============================================================================
+# Harness Regression Tests
+# ============================================================================
+
+@pytest.mark.parametrize(
+    "frameworks, expected_labels",
+    [
+        (
+            {
+                'torch': True,
+                'tensorflow': False,
+                'keras': False,
+                'linen': True,
+                'nnx': True,
+                'mlx': False,
+            },
+            {'PyTorch', 'Linen', 'NNX'},
+        ),
+        (
+            {
+                'torch': False,
+                'tensorflow': True,
+                'keras': True,
+                'linen': False,
+                'nnx': False,
+                'mlx': False,
+            },
+            {'TensorFlow', 'Keras'},
+        ),
+    ],
+    ids=['torch-jax-only', 'tensorflow-keras-enabled'],
+)
+def test_available_framework_matrix_executes_every_reported_backend(
+    monkeypatch, frameworks, expected_labels
+):
+    calls = []
+
+    def fake_runner(name):
+        def run(inputs, weights, bias=None, alpha=None, epsilon=1e-6):
+            calls.append(name)
+            return np.zeros((inputs.shape[0], weights.shape[1]), dtype=np.float32)
+        return run
+
+    for key, function_name in {
+        'torch': 'run_torch_dense',
+        'tensorflow': 'run_tensorflow_dense',
+        'keras': 'run_keras_dense',
+        'linen': 'run_linen_dense',
+        'nnx': 'run_nnx_dense',
+        'mlx': 'run_mlx_dense',
+    }.items():
+        monkeypatch.setitem(globals(), function_name, fake_runner(key))
+
+    outputs = run_available_frameworks(
+        frameworks,
+        np.zeros((2, 3), dtype=np.float32),
+        np.zeros((3, 4), dtype=np.float32),
+    )
+
+    assert set(outputs) == {'NumPy (ref)', *expected_labels}
+    assert set(calls) == {
+        name for name, available in frameworks.items() if available
+    }
+
+
+def test_available_framework_matrix_rejects_empty_comparison():
+    with pytest.raises(ValueError, match="at least one framework"):
+        run_available_frameworks(
+            {name: False for name in FRAMEWORKS},
+            np.zeros((2, 3), dtype=np.float32),
+            np.zeros((3, 4), dtype=np.float32),
+        )

--- a/tests/integration/test_yat_nmn_parity.py
+++ b/tests/integration/test_yat_nmn_parity.py
@@ -24,6 +24,8 @@ import math
 import numpy as np
 import pytest
 
+from tests._isolated_backend import mlx_is_usable
+
 
 # ── Logical inputs / parameters used by every framework ───────────────────
 
@@ -38,6 +40,7 @@ X = RNG.normal(size=(BATCH, IN_FEATURES)).astype(np.float32)
 W_LOGICAL = RNG.normal(size=(IN_FEATURES, OUT_FEATURES)).astype(np.float32)
 B = RNG.normal(size=(OUT_FEATURES,)).astype(np.float32)
 EPSILON = 1e-5
+MLX_USABLE = mlx_is_usable()
 
 
 def reference_yat(
@@ -241,7 +244,11 @@ def _run_tf(spherical, weight_normalized, learnable_epsilon, bias_mode):
 
 
 def _run_mlx(spherical, weight_normalized, learnable_epsilon, bias_mode):
-    mx = pytest.importorskip("mlx.core")
+    if not MLX_USABLE:
+        pytest.skip("MLX runtime is not usable in an isolated probe")
+    # The child probe above is the only conditional MLX import: an installed
+    # runtime that aborts while initializing Metal must never reach this line.
+    import mlx.core as mx
     # Pin to CPU: MLX's Metal matmul accumulates at lower precision than
     # numpy fp32, so the < 1e-4 rtol used here is only meaningful on CPU.
     prev_device = mx.default_device()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ import sys
 import pytest
 
 from nmn import cli
+from tests import _isolated_backend
 
 
 # ---------------------------------------------------------------------------
@@ -206,14 +207,13 @@ def test_torch_guide_snippets_construct(capsys):
     )
 
 
-@pytest.mark.parametrize("fw", ["nnx", "linen", "mlx"])
+@pytest.mark.parametrize("fw", ["nnx", "linen"])
 def test_guide_attention_ctor_constructs_for_importable(fw, capsys):
     """Construct the attention object from each importable backend's guide
     using the exact kwargs the guide emits."""
     backends = {
         "nnx": ["jax", "flax"],
         "linen": ["jax", "flax"],
-        "mlx": ["mlx.core"],
     }
     try:
         for m in backends[fw]:
@@ -236,11 +236,29 @@ def test_guide_attention_ctor_constructs_for_importable(fw, capsys):
         line = _extract_lines(text, "MultiHeadAttention(num_heads=")[0]
         expr = line.split("=", 1)[1].strip()
         eval(expr, {"MultiHeadAttention": MultiHeadAttention})
-    elif fw == "mlx":
-        from nmn.mlx import MultiHeadYatAttention
-        line = _extract_lines(text, "MultiHeadYatAttention(embed_dim=")[0]
-        expr = line.split("=", 1)[1].strip()
-        eval(expr, {"MultiHeadYatAttention": MultiHeadYatAttention})
+
+
+def test_mlx_guide_attention_ctor_constructs_in_isolated_process(capsys):
+    """Never initialize the optional native MLX runtime in the pytest process."""
+    if not _isolated_backend.mlx_is_usable():
+        pytest.skip("MLX runtime is not usable in an isolated probe")
+
+    assert cli.main(["guide", "mlx"]) == 0
+    text = capsys.readouterr().out
+    line = _extract_lines(text, "MultiHeadYatAttention(embed_dim=")[0]
+    expr = line.split("=", 1)[1].strip()
+    script = (
+        "from nmn.mlx import MultiHeadYatAttention\n"
+        f"{expr}\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_features_mentions_may_ray_and_lazy(capsys):
@@ -273,6 +291,93 @@ def _probe_result(*, returncode=0, stdout="", stderr=""):
         returncode=returncode,
         stdout=stdout,
         stderr=stderr,
+    )
+
+
+def test_optional_backend_probe_success(monkeypatch):
+    completed = _probe_result(stdout=_isolated_backend._PROBE_MARKER + "\n")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return completed
+
+    monkeypatch.setattr(_isolated_backend.subprocess, "run", fake_run)
+
+    assert _isolated_backend.isolated_import_succeeds(
+        ["mlx.core"], readiness="mlx"
+    )
+    command, kwargs = calls[0]
+    assert command[:3] == [sys.executable, "-c", _isolated_backend._PROBE_SCRIPT]
+    assert json.loads(command[3]) == {
+        "modules": ["mlx.core"],
+        "readiness": "mlx",
+    }
+    assert kwargs["check"] is False
+    assert kwargs["timeout"] == _isolated_backend._PROBE_TIMEOUT_SECONDS
+
+
+def test_optional_backend_probe_python_failure_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        _isolated_backend.subprocess,
+        "run",
+        lambda *args, **kwargs: _probe_result(
+            returncode=1, stderr="RuntimeError: backend initialization failed"
+        ),
+    )
+    assert not _isolated_backend.mlx_is_usable()
+
+
+@pytest.mark.parametrize("returncode", [-signal.SIGABRT, 128 + signal.SIGABRT])
+def test_optional_backend_probe_native_failure_is_unavailable(
+    monkeypatch, returncode
+):
+    monkeypatch.setattr(
+        _isolated_backend.subprocess,
+        "run",
+        lambda *args, **kwargs: _probe_result(returncode=returncode),
+    )
+    assert not _isolated_backend.mlx_is_usable()
+
+
+def _prepend_pythonpath(monkeypatch, directory):
+    existing = os.environ.get("PYTHONPATH")
+    value = str(directory)
+    if existing:
+        value += os.pathsep + existing
+    monkeypatch.setenv("PYTHONPATH", value)
+
+
+def test_optional_backend_probe_really_imports_in_child(tmp_path, monkeypatch):
+    (tmp_path / "healthy_backend.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _prepend_pythonpath(monkeypatch, tmp_path)
+
+    assert _isolated_backend.isolated_import_succeeds(["healthy_backend"])
+
+
+def test_optional_backend_probe_really_contains_python_failure(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "python_failure_backend.py").write_text(
+        "raise RuntimeError('initialization failed')\n", encoding="utf-8"
+    )
+    _prepend_pythonpath(monkeypatch, tmp_path)
+
+    assert not _isolated_backend.isolated_import_succeeds(
+        ["python_failure_backend"]
+    )
+
+
+def test_optional_backend_probe_really_contains_native_abort(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "native_abort_backend.py").write_text(
+        "import os\nos.abort()\n", encoding="utf-8"
+    )
+    _prepend_pythonpath(monkeypatch, tmp_path)
+
+    assert not _isolated_backend.isolated_import_succeeds(
+        ["native_abort_backend"]
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -294,15 +295,29 @@ def _probe_result(*, returncode=0, stdout="", stderr=""):
     )
 
 
+class _FakeProbeProcess:
+    def __init__(self, *, returncode=0, stdout=b"", stderr=b""):
+        self.pid = 999_999_999
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    def communicate(self, timeout=None):
+        del timeout
+        return self._stdout, self._stderr
+
+
 def test_optional_backend_probe_success(monkeypatch):
-    completed = _probe_result(stdout=_isolated_backend._PROBE_MARKER + "\n")
+    process = _FakeProbeProcess(
+        stdout=_isolated_backend._PROBE_MARKER_BYTES + b"\n"
+    )
     calls = []
 
-    def fake_run(command, **kwargs):
+    def fake_popen(command, **kwargs):
         calls.append((command, kwargs))
-        return completed
+        return process
 
-    monkeypatch.setattr(_isolated_backend.subprocess, "run", fake_run)
+    monkeypatch.setattr(_isolated_backend.subprocess, "Popen", fake_popen)
 
     assert _isolated_backend.isolated_import_succeeds(
         ["mlx.core"], readiness="mlx"
@@ -313,18 +328,42 @@ def test_optional_backend_probe_success(monkeypatch):
         "modules": ["mlx.core"],
         "readiness": "mlx",
     }
-    assert kwargs["check"] is False
-    assert kwargs["timeout"] == _isolated_backend._PROBE_TIMEOUT_SECONDS
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["stderr"] is subprocess.PIPE
+    if os.name == "posix":
+        assert kwargs["start_new_session"] is True
+    else:
+        assert kwargs["creationflags"] == subprocess.CREATE_NEW_PROCESS_GROUP
+
+
+def test_optional_backend_probe_handles_none_and_malformed_output(monkeypatch):
+    processes = iter([
+        _FakeProbeProcess(stdout=None, stderr=None),
+        _FakeProbeProcess(stdout=_isolated_backend._PROBE_MARKER),
+        _FakeProbeProcess(
+            stdout=b"\xff\xfe\n" + _isolated_backend._PROBE_MARKER_BYTES + b"\n",
+            stderr=b"\x80",
+        ),
+    ])
+    monkeypatch.setattr(
+        _isolated_backend.subprocess, "Popen", lambda *args, **kwargs: next(processes)
+    )
+    monkeypatch.setattr(_isolated_backend, "_stop_process_tree", lambda process: None)
+
+    assert not _isolated_backend.isolated_import_succeeds(["unused"])
+    assert not _isolated_backend.isolated_import_succeeds(["unused"])
+    assert _isolated_backend.isolated_import_succeeds(["unused"])
 
 
 def test_optional_backend_probe_python_failure_is_unavailable(monkeypatch):
     monkeypatch.setattr(
         _isolated_backend.subprocess,
-        "run",
-        lambda *args, **kwargs: _probe_result(
-            returncode=1, stderr="RuntimeError: backend initialization failed"
+        "Popen",
+        lambda *args, **kwargs: _FakeProbeProcess(
+            returncode=1, stderr=b"RuntimeError: backend initialization failed"
         ),
     )
+    monkeypatch.setattr(_isolated_backend, "_stop_process_tree", lambda process: None)
     assert not _isolated_backend.mlx_is_usable()
 
 
@@ -334,9 +373,10 @@ def test_optional_backend_probe_native_failure_is_unavailable(
 ):
     monkeypatch.setattr(
         _isolated_backend.subprocess,
-        "run",
-        lambda *args, **kwargs: _probe_result(returncode=returncode),
+        "Popen",
+        lambda *args, **kwargs: _FakeProbeProcess(returncode=returncode),
     )
+    monkeypatch.setattr(_isolated_backend, "_stop_process_tree", lambda process: None)
     assert not _isolated_backend.mlx_is_usable()
 
 
@@ -379,6 +419,58 @@ def test_optional_backend_probe_really_contains_native_abort(
     assert not _isolated_backend.isolated_import_succeeds(
         ["native_abort_backend"]
     )
+
+
+def test_optional_backend_probe_really_handles_invalid_bytes(
+    tmp_path, monkeypatch
+):
+    (tmp_path / "invalid_bytes_backend.py").write_text(
+        "import os\nos.write(1, b'\\xff\\xfe\\n')\n"
+        "os.write(2, b'\\x80\\n')\n",
+        encoding="utf-8",
+    )
+    _prepend_pythonpath(monkeypatch, tmp_path)
+
+    assert _isolated_backend.isolated_import_succeeds(
+        ["invalid_bytes_backend"]
+    )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX process-group assertion")
+def test_optional_backend_probe_timeout_kills_descendant_group(
+    tmp_path, monkeypatch
+):
+    pid_file = tmp_path / "descendant.pid"
+    (tmp_path / "descendant_backend.py").write_text(
+        "import pathlib, signal, subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(60)'])\n"
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(child.pid))\n"
+        "def stop(signum, frame):\n"
+        "    child.wait(timeout=2)\n"
+        "    raise SystemExit(128 + signum)\n"
+        "signal.signal(signal.SIGTERM, stop)\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    _prepend_pythonpath(monkeypatch, tmp_path)
+    monkeypatch.setattr(_isolated_backend, "_PROBE_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(_isolated_backend, "_PROBE_REAP_SECONDS", 0.5)
+
+    assert not _isolated_backend.isolated_import_succeeds(
+        ["descendant_backend"]
+    )
+    descendant_pid = int(pid_file.read_text(encoding="utf-8"))
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        try:
+            os.kill(descendant_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"probe descendant {descendant_pid} remained alive")
 
 
 def test_doctor_probe_success_ignores_backend_output(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -307,7 +307,18 @@ class _FakeProbeProcess:
         return self._stdout, self._stderr
 
 
+def _patch_fake_windows_job(monkeypatch):
+    if os.name == "nt":
+        monkeypatch.setattr(
+            _isolated_backend, "_assign_windows_kill_job", lambda process: None
+        )
+        monkeypatch.setattr(
+            _isolated_backend, "_close_windows_kill_job", lambda process: True
+        )
+
+
 def test_optional_backend_probe_success(monkeypatch):
+    _patch_fake_windows_job(monkeypatch)
     process = _FakeProbeProcess(
         stdout=_isolated_backend._PROBE_MARKER_BYTES + b"\n"
     )
@@ -324,10 +335,10 @@ def test_optional_backend_probe_success(monkeypatch):
     )
     command, kwargs = calls[0]
     assert command[:3] == [sys.executable, "-c", _isolated_backend._PROBE_SCRIPT]
-    assert json.loads(command[3]) == {
-        "modules": ["mlx.core"],
-        "readiness": "mlx",
-    }
+    request = json.loads(command[3])
+    assert request["modules"] == ["mlx.core"]
+    assert request["readiness"] == "mlx"
+    assert ("gate" in request) == (os.name == "nt")
     assert kwargs["stdout"] is subprocess.PIPE
     assert kwargs["stderr"] is subprocess.PIPE
     if os.name == "posix":
@@ -337,6 +348,7 @@ def test_optional_backend_probe_success(monkeypatch):
 
 
 def test_optional_backend_probe_handles_none_and_malformed_output(monkeypatch):
+    _patch_fake_windows_job(monkeypatch)
     processes = iter([
         _FakeProbeProcess(stdout=None, stderr=None),
         _FakeProbeProcess(stdout=_isolated_backend._PROBE_MARKER),
@@ -356,6 +368,7 @@ def test_optional_backend_probe_handles_none_and_malformed_output(monkeypatch):
 
 
 def test_optional_backend_probe_python_failure_is_unavailable(monkeypatch):
+    _patch_fake_windows_job(monkeypatch)
     monkeypatch.setattr(
         _isolated_backend.subprocess,
         "Popen",
@@ -371,6 +384,7 @@ def test_optional_backend_probe_python_failure_is_unavailable(monkeypatch):
 def test_optional_backend_probe_native_failure_is_unavailable(
     monkeypatch, returncode
 ):
+    _patch_fake_windows_job(monkeypatch)
     monkeypatch.setattr(
         _isolated_backend.subprocess,
         "Popen",
@@ -471,6 +485,66 @@ def test_optional_backend_probe_timeout_kills_descendant_group(
         time.sleep(0.05)
     else:
         pytest.fail(f"probe descendant {descendant_pid} remained alive")
+
+
+def _windows_pid_is_running(pid):
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, wintypes.LPDWORD]
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    handle = kernel32.OpenProcess(0x1000, False, pid)
+    if not handle:
+        return False
+    try:
+        exit_code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == 259
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows Job Object assertion")
+@pytest.mark.parametrize("termination", ["timeout", "nonzero", "abort"])
+def test_optional_backend_probe_windows_job_kills_descendants(
+    tmp_path, monkeypatch, termination
+):
+    pid_file = tmp_path / f"windows-{termination}.pid"
+    ending = {
+        "timeout": "time.sleep(60)",
+        "nonzero": "raise SystemExit(23)",
+        "abort": "os.abort()",
+    }[termination]
+    (tmp_path / "windows_descendant_backend.py").write_text(
+        "import os, pathlib, subprocess, sys, time\n"
+        "child = subprocess.Popen([sys.executable, '-c', "
+        "'import time; time.sleep(60)'], stdout=subprocess.DEVNULL, "
+        "stderr=subprocess.DEVNULL)\n"
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(child.pid))\n"
+        f"{ending}\n",
+        encoding="utf-8",
+    )
+    _prepend_pythonpath(monkeypatch, tmp_path)
+    monkeypatch.setattr(_isolated_backend, "_PROBE_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(_isolated_backend, "_PROBE_REAP_SECONDS", 0.5)
+
+    assert not _isolated_backend.isolated_import_succeeds(
+        ["windows_descendant_backend"]
+    )
+    descendant_pid = int(pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if not _windows_pid_is_running(descendant_pid):
+            break
+        time.sleep(0.05)
+    else:
+        pytest.fail(f"job descendant {descendant_pid} remained alive")
 
 
 def test_doctor_probe_success_ignores_backend_output(monkeypatch):

--- a/tests/test_mlx/conftest.py
+++ b/tests/test_mlx/conftest.py
@@ -10,12 +10,25 @@ from __future__ import annotations
 
 import pytest
 
-mlx_core = pytest.importorskip("mlx.core")
+from tests._isolated_backend import mlx_is_usable
+
+
+# A plain ``pytest.importorskip`` cannot catch a native abort.  Ignore the MLX
+# modules before collection unless a child process can both import MLX and
+# initialize its device runtime successfully.
+_MLX_USABLE = mlx_is_usable()
+collect_ignore_glob = [] if _MLX_USABLE else ["test_*.py"]
+
+if _MLX_USABLE:
+    import mlx.core as mlx_core
+else:
+    mlx_core = None
 
 
 @pytest.fixture(autouse=True)
 def _force_cpu():
     """Pin every MLX test to the CPU device for deterministic parity."""
+    assert mlx_core is not None
     prev = mlx_core.default_device()
     mlx_core.set_default_device(mlx_core.cpu)
     yield


### PR DESCRIPTION
Fixes #91 and fixes #93. Adds subprocess-isolated MLX readiness checks that survive native aborts, malformed bytes, timeouts, and descendant processes; uses POSIX process groups and Windows kill-on-close Job Objects. Repairs TensorFlow/Keras cross-framework dispatch and empty-set handling. Adds real timeout/nonzero/abort cleanup regressions and a scoped windows-latest CI step that executes all three Job Object cases. Independently source-reviewed; merge requires the new Windows runtime step to pass.