### PR TITLE
fix: stabilize learnable epsilon initialization across backends

### DIFF
--- a/src/nmn/_epsilon.py
+++ b/src/nmn/_epsilon.py
@@ -5,6 +5,19 @@ from __future__ import annotations
 import math
 
 
+_FLOAT_LIMITS = {
+    "float16": (2.0 ** -24, 65504.0),
+    "bfloat16": (2.0 ** -133, float.fromhex("0x1.fep127")),
+    # JAX and TensorFlow flush exp/softplus float32 subnormals.  One exponent
+    # above the normal boundary also avoids rounding log(tiny) below it.
+    "float32": (2.0 ** -125, float.fromhex("0x1.fffffep127")),
+    "float64": (
+        float.fromhex("0x1.0000000000000p-1022"),
+        float.fromhex("0x1.fffffffffffffp1023"),
+    ),
+}
+
+
 def validate_epsilon(epsilon: float) -> float:
     """Return ``epsilon`` as a finite, strictly positive Python float."""
     epsilon = float(epsilon)
@@ -22,3 +35,37 @@ def inverse_softplus(epsilon: float) -> float:
     """
     epsilon = validate_epsilon(epsilon)
     return epsilon + math.log(-math.expm1(-epsilon))
+
+
+def dtype_name(dtype) -> str:
+    """Return a canonical floating dtype name without importing a framework."""
+    name = getattr(dtype, "name", str(dtype)).lower()
+    for candidate in ("bfloat16", "float16", "float32", "float64"):
+        if candidate in name:
+            return candidate
+    raise TypeError(f"unsupported epsilon parameter dtype {dtype!r}")
+
+
+def epsilon_parameter_dtype(dtype) -> str:
+    """Use fp32 storage for fp16/bf16 epsilon parameters."""
+    name = dtype_name(dtype)
+    return "float32" if name in ("float16", "bfloat16") else name
+
+
+def validate_epsilon_for_dtype(epsilon: float, dtype) -> float:
+    """Validate that softplus can represent ``epsilon`` in ``dtype``.
+
+    Learnable epsilon parameters use at least fp32 storage, so low-precision
+    layers retain tiny values such as 1e-20 and large values such as 1e5.
+    Values outside the storage/compute dtype's reliably nonzero softplus range
+    are rejected instead of silently becoming zero or infinity.
+    """
+    epsilon = validate_epsilon(epsilon)
+    parameter_dtype = epsilon_parameter_dtype(dtype)
+    smallest, largest = _FLOAT_LIMITS[parameter_dtype]
+    if epsilon < smallest or epsilon > largest:
+        raise ValueError(
+            f"epsilon {epsilon} is not representable as a finite, strictly "
+            f"positive {parameter_dtype} learnable parameter"
+        )
+    return epsilon

--- a/src/nmn/_epsilon.py
+++ b/src/nmn/_epsilon.py
@@ -1,0 +1,24 @@
+"""Framework-independent helpers for positive YAT epsilon parameters."""
+
+from __future__ import annotations
+
+import math
+
+
+def validate_epsilon(epsilon: float) -> float:
+    """Return ``epsilon`` as a finite, strictly positive Python float."""
+    epsilon = float(epsilon)
+    if not math.isfinite(epsilon) or epsilon <= 0.0:
+        raise ValueError(f"epsilon must be positive and finite, got {epsilon}")
+    return epsilon
+
+
+def inverse_softplus(epsilon: float) -> float:
+    """Compute ``softplus**-1(epsilon)`` without under/overflow.
+
+    ``log(exp(epsilon) - 1)`` loses tiny values to cancellation and overflows
+    for large finite values. This equivalent form is stable across the full
+    positive range of Python floats.
+    """
+    epsilon = validate_epsilon(epsilon)
+    return epsilon + math.log(-math.expm1(-epsilon))

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -27,12 +27,28 @@ from ._yat_core import reduction_safe_upcast, yat_score
 def _epsilon_weight_dtype(layer):
     dtype = epsilon_parameter_dtype(layer.variable_dtype)
     validate_epsilon_for_dtype(layer.epsilon, dtype)
+    if backend() == "jax" and dtype == "float64":
+        import jax
+
+        if not jax.config.x64_enabled:
+            raise ValueError(
+                "float64 learnable epsilon requires jax_enable_x64=True; "
+                "the JAX backend would otherwise store it as float32"
+            )
     return dtype
 
 
 def _epsilon_initializer(value):
     def initialize(shape, dtype=None):
-        return ops.full(shape, value, dtype=dtype)
+        initialized = ops.full(shape, value, dtype=dtype)
+        actual_dtype = standardize_dtype(initialized.dtype)
+        expected_dtype = standardize_dtype(dtype)
+        if actual_dtype != expected_dtype:
+            raise ValueError(
+                f"learnable epsilon requested {expected_dtype} storage but "
+                f"the backend created {actual_dtype}"
+            )
+        return initialized
 
     return initialize
 

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -1,6 +1,5 @@
 """YAT convolution layers for Keras/TensorFlow."""
 
-import math
 import threading
 import weakref
 
@@ -14,6 +13,8 @@ from keras.src.layers.layer import Layer
 from keras.src.ops.operation_utils import compute_conv_output_shape
 from keras.src.saving.object_registration import register_keras_serializable
 from keras.src.saving.serialization_lib import deserialize_keras_object
+
+from nmn._epsilon import inverse_softplus, validate_epsilon
 
 from ._yat_core import reduction_safe_upcast, yat_score
 
@@ -374,9 +375,7 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
             )
         self.groups = groups
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
@@ -459,7 +458,7 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
@@ -721,9 +720,7 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate)
         self.groups = groups
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
@@ -806,7 +803,7 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
@@ -1024,9 +1021,7 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate, dilation_rate)
         self.groups = groups
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
@@ -1109,7 +1104,7 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
@@ -1318,9 +1313,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate,)
         self.output_padding = _standardize_output_padding(output_padding, 1)
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
@@ -1391,7 +1384,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
@@ -1600,9 +1593,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate)
         self.output_padding = _standardize_output_padding(output_padding, 2)
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
@@ -1673,7 +1664,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
@@ -1882,9 +1873,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         self.dilation_rate = dilation_rate if isinstance(dilation_rate, (list, tuple)) else (dilation_rate, dilation_rate, dilation_rate)
         self.output_padding = _standardize_output_padding(output_padding, 3)
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
@@ -1955,7 +1944,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -14,9 +14,27 @@ from keras.src.ops.operation_utils import compute_conv_output_shape
 from keras.src.saving.object_registration import register_keras_serializable
 from keras.src.saving.serialization_lib import deserialize_keras_object
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 from ._yat_core import reduction_safe_upcast, yat_score
+
+
+def _epsilon_weight_dtype(layer):
+    dtype = epsilon_parameter_dtype(layer.variable_dtype)
+    validate_epsilon_for_dtype(layer.epsilon, dtype)
+    return dtype
+
+
+def _epsilon_initializer(value):
+    def initialize(shape, dtype=None):
+        return ops.full(shape, value, dtype=dtype)
+
+    return initialize
 
 
 def _reject_kernel_bank_expansion(bank_id, existing_filters, requested_filters):
@@ -462,7 +480,8 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=_epsilon_weight_dtype(self),
                 trainable=True,
             )
         else:
@@ -807,7 +826,8 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=_epsilon_weight_dtype(self),
                 trainable=True,
             )
         else:
@@ -1108,7 +1128,8 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=_epsilon_weight_dtype(self),
                 trainable=True,
             )
         else:
@@ -1388,7 +1409,8 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=_epsilon_weight_dtype(self),
                 trainable=True,
             )
         else:
@@ -1668,7 +1690,8 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=_epsilon_weight_dtype(self),
                 trainable=True,
             )
         else:
@@ -1948,7 +1971,8 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=_epsilon_weight_dtype(self),
                 trainable=True,
             )
         else:

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -3,6 +3,7 @@ from keras.src.api_export import keras_export
 from keras.src.layers.input_spec import InputSpec
 from keras.src.layers.layer import Layer
 from keras.src import ops
+from keras.src.backend import backend, standardize_dtype
 import math
 import numpy as np
 
@@ -19,9 +20,31 @@ DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
 def _epsilon_initializer(value):
     def initialize(shape, dtype=None):
-        return ops.full(shape, value, dtype=dtype)
+        initialized = ops.full(shape, value, dtype=dtype)
+        actual_dtype = standardize_dtype(initialized.dtype)
+        expected_dtype = standardize_dtype(dtype)
+        if actual_dtype != expected_dtype:
+            raise ValueError(
+                f"learnable epsilon requested {expected_dtype} storage but "
+                f"the backend created {actual_dtype}"
+            )
+        return initialized
 
     return initialize
+
+
+def _epsilon_weight_dtype(layer):
+    dtype = epsilon_parameter_dtype(layer.variable_dtype)
+    validate_epsilon_for_dtype(layer.epsilon, dtype)
+    if backend() == "jax" and dtype == "float64":
+        import jax
+
+        if not jax.config.x64_enabled:
+            raise ValueError(
+                "float64 learnable epsilon requires jax_enable_x64=True; "
+                "the JAX backend would otherwise store it as float32"
+            )
+    return dtype
 
 @keras_export("keras.layers.YatNMN")
 class YatNMN(Layer):
@@ -169,8 +192,7 @@ class YatNMN(Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            epsilon_dtype = epsilon_parameter_dtype(self.variable_dtype)
-            validate_epsilon_for_dtype(self.epsilon, epsilon_dtype)
+            epsilon_dtype = _epsilon_weight_dtype(self)
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -6,10 +6,22 @@ from keras.src import ops
 import math
 import numpy as np
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
+
+
+def _epsilon_initializer(value):
+    def initialize(shape, dtype=None):
+        return ops.full(shape, value, dtype=dtype)
+
+    return initialize
 
 @keras_export("keras.layers.YatNMN")
 class YatNMN(Layer):
@@ -157,11 +169,14 @@ class YatNMN(Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = epsilon_parameter_dtype(self.variable_dtype)
+            validate_epsilon_for_dtype(self.epsilon, epsilon_dtype)
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),
-                initializer=initializers.Constant(raw_eps),
+                initializer=_epsilon_initializer(raw_eps),
+                dtype=epsilon_dtype,
                 trainable=True,
             )
         else:
@@ -220,6 +235,9 @@ class YatNMN(Layer):
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
             eps = ops.softplus(self.epsilon_param)
+            score_dtype = self.epsilon_param.dtype
+            dot_product = ops.cast(dot_product, score_dtype)
+            distances = ops.cast(distances, score_dtype)
         else:
             eps = self.epsilon
 
@@ -233,7 +251,7 @@ class YatNMN(Layer):
             # Simple learnable alpha scaling
             outputs = outputs * self.alpha
 
-        return outputs
+        return ops.cast(outputs, self.compute_dtype)
 
     def compute_output_shape(self, input_shape):
         output_shape = list(input_shape)

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -6,6 +6,8 @@ from keras.src import ops
 import math
 import numpy as np
 
+from nmn._epsilon import inverse_softplus, validate_epsilon
+
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
@@ -71,9 +73,7 @@ class YatNMN(Layer):
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
         self.units = units
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.positive_init = positive_init
         self.spherical = spherical
@@ -157,7 +157,7 @@ class YatNMN(Layer):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = self.add_weight(
                 name="epsilon_param",
                 shape=(1,),

--- a/src/nmn/linen/_yat_core.py
+++ b/src/nmn/linen/_yat_core.py
@@ -41,8 +41,12 @@ def yat_score(
         bias_broadcast_shape = (1,) * (dot_prod_map.ndim - 1) + (-1,)
         dot_prod_map = dot_prod_map + bias.reshape(bias_broadcast_shape)
 
+    output_dtype = dot_prod_map.dtype
     if epsilon_param is not None:
-        eps = jax.nn.softplus(epsilon_param.astype(dot_prod_map.dtype))
+        score_dtype = jnp.promote_types(dot_prod_map.dtype, epsilon_param.dtype)
+        eps = jax.nn.softplus(epsilon_param.astype(score_dtype))
+        dot_prod_map = dot_prod_map.astype(score_dtype)
+        distance_sq = distance_sq.astype(score_dtype)
     else:
         eps = epsilon
 
@@ -51,4 +55,4 @@ def yat_score(
     if alpha is not None:
         y = y * alpha
 
-    return y
+    return y.astype(output_dtype)

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -9,9 +9,23 @@ from flax.linen.dtypes import promote_dtype
 from flax.linen.initializers import zeros_init
 from typing import Any, Optional, Sequence, Union, Tuple
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 from ._yat_core import yat_score
+
+
+def _epsilon_dtype(param_dtype, epsilon):
+    name = epsilon_parameter_dtype(param_dtype)
+    if name == "float64" and not jax.config.x64_enabled:
+        raise ValueError("float64 learnable epsilon requires jax_enable_x64")
+    dtype = getattr(jnp, name)
+    validate_epsilon_for_dtype(epsilon, dtype)
+    return dtype
 
 
 def _validate_feature_groups(
@@ -114,12 +128,13 @@ class YatConv1D(_EpsilonValidatedModule):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None
@@ -253,12 +268,13 @@ class YatConv2D(_EpsilonValidatedModule):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None
@@ -389,12 +405,13 @@ class YatConv3D(_EpsilonValidatedModule):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None
@@ -516,12 +533,13 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None
@@ -631,12 +649,13 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None
@@ -746,12 +765,13 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -1,7 +1,5 @@
 """YAT convolution layers for Flax Linen."""
 
-import math
-
 import jax
 import jax.numpy as jnp
 import jax.lax as lax
@@ -10,6 +8,8 @@ from flax.linen import Module, compact
 from flax.linen.dtypes import promote_dtype
 from flax.linen.initializers import zeros_init
 from typing import Any, Optional, Sequence, Union, Tuple
+
+from nmn._epsilon import inverse_softplus, validate_epsilon
 
 from ._yat_core import yat_score
 
@@ -32,7 +32,15 @@ def _validate_feature_groups(
         )
 
 
-class YatConv1D(Module):
+class _EpsilonValidatedModule(Module):
+    """Linen module base that validates static epsilon at construction."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        validate_epsilon(self.epsilon)
+
+
+class YatConv1D(_EpsilonValidatedModule):
     """1D YAT convolution layer for Flax Linen.
     
     This layer implements 1D convolution using the YAT algorithm,
@@ -106,7 +114,7 @@ class YatConv1D(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
@@ -172,7 +180,7 @@ class YatConv1D(Module):
         )
 
 
-class YatConv2D(Module):
+class YatConv2D(_EpsilonValidatedModule):
     """2D YAT convolution layer for Flax Linen.
     
     This layer implements 2D convolution using the YAT algorithm.
@@ -245,7 +253,7 @@ class YatConv2D(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
@@ -308,7 +316,7 @@ class YatConv2D(Module):
         )
 
 
-class YatConv3D(Module):
+class YatConv3D(_EpsilonValidatedModule):
     """3D YAT convolution layer for Flax Linen.
     
     This layer implements 3D convolution using the YAT algorithm.
@@ -381,7 +389,7 @@ class YatConv3D(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
@@ -444,7 +452,7 @@ class YatConv3D(Module):
         )
 
 
-class YatConvTranspose1D(Module):
+class YatConvTranspose1D(_EpsilonValidatedModule):
     """1D YAT transposed convolution layer for Flax Linen.
 
     This layer implements 1D transposed convolution using the YAT algorithm.
@@ -508,7 +516,7 @@ class YatConvTranspose1D(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
@@ -559,7 +567,7 @@ class YatConvTranspose1D(Module):
         )
 
 
-class YatConvTranspose2D(Module):
+class YatConvTranspose2D(_EpsilonValidatedModule):
     """2D YAT transposed convolution layer for Flax Linen.
 
     This layer implements 2D transposed convolution using the YAT algorithm.
@@ -623,7 +631,7 @@ class YatConvTranspose2D(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
@@ -674,7 +682,7 @@ class YatConvTranspose2D(Module):
         )
 
 
-class YatConvTranspose3D(Module):
+class YatConvTranspose3D(_EpsilonValidatedModule):
     """3D YAT transposed convolution layer for Flax Linen.
 
     This layer implements 3D transposed convolution using the YAT algorithm.
@@ -738,7 +746,7 @@ class YatConvTranspose3D(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
@@ -800,5 +808,3 @@ YatConv3d = YatConv3D
 YatConvTranspose1d = YatConvTranspose1D
 YatConvTranspose2d = YatConvTranspose2D
 YatConvTranspose3d = YatConvTranspose3D
-
-

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -13,7 +13,21 @@ from flax import linen as nn
 from flax.linen.initializers import zeros_init
 from typing import Any, Optional
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
+
+
+def _epsilon_dtype(param_dtype, epsilon):
+    name = epsilon_parameter_dtype(param_dtype)
+    if name == "float64" and not jax.config.x64_enabled:
+        raise ValueError("float64 learnable epsilon requires jax_enable_x64")
+    dtype = getattr(jnp, name)
+    validate_epsilon_for_dtype(epsilon, dtype)
+    return dtype
 
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
@@ -170,12 +184,13 @@ class YatNMN(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = _epsilon_dtype(self.param_dtype, self.epsilon)
             raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),
                 (1,),
-                self.param_dtype,
+                epsilon_dtype,
             )
         else:
             epsilon_param = None
@@ -228,8 +243,12 @@ class YatNMN(Module):
             y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
 
         # Resolve effective epsilon (learnable via softplus, or constant)
+        output_dtype = y.dtype
         if epsilon_param is not None:
-            eps = jax.nn.softplus(epsilon_param.astype(y.dtype))
+            score_dtype = jnp.promote_types(y.dtype, epsilon_param.dtype)
+            eps = jax.nn.softplus(epsilon_param.astype(score_dtype))
+            y = y.astype(score_dtype)
+            distances = distances.astype(score_dtype)
         else:
             eps = self.epsilon
 
@@ -242,6 +261,8 @@ class YatNMN(Module):
         elif alpha is not None:
             # Simple learnable alpha scaling
             y = y * alpha
+
+        y = y.astype(output_dtype)
 
         if self.return_weights:
            return y, kernel

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -13,6 +13,8 @@ from flax import linen as nn
 from flax.linen.initializers import zeros_init
 from typing import Any, Optional
 
+from nmn._epsilon import inverse_softplus, validate_epsilon
+
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
@@ -103,6 +105,10 @@ class YatNMN(Module):
     dot_general_cls: Any = None
     return_weights: bool = False
 
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        validate_epsilon(self.epsilon)
+
     @compact
     def __call__(self, inputs: Any) -> Any:
         """Applies a transformation to the inputs along the last dimension using squared Euclidean distance.
@@ -113,9 +119,6 @@ class YatNMN(Module):
         Returns:
           The transformed input.
         """
-        if self.epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {self.epsilon}")
-
         kernel = self.param(
             'kernel',
             self.kernel_init,
@@ -167,7 +170,7 @@ class YatNMN(Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps_init = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps_init = inverse_softplus(self.epsilon)
             epsilon_param = self.param(
                 'epsilon_param',
                 lambda key, shape, dtype: jnp.full(shape, raw_eps_init, dtype=dtype),

--- a/src/nmn/tf/_yat_core.py
+++ b/src/nmn/tf/_yat_core.py
@@ -37,8 +37,11 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
             dot_prod_map = dot_prod_map + layer.bias
 
     # Resolve effective epsilon (learnable via softplus, or constant).
+    output_dtype = dot_prod_map.dtype
     if layer.learnable_epsilon and layer.epsilon_param is not None:
         eps = tf.nn.softplus(layer.epsilon_param)
+        dot_prod_map = tf.cast(dot_prod_map, eps.dtype)
+        distance_sq_map = tf.cast(distance_sq_map, eps.dtype)
     else:
         eps = layer.epsilon
 
@@ -47,6 +50,6 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
 
     # Optional alpha (learnable; constant_alpha is folded into layer.alpha).
     if layer.use_alpha and layer.alpha is not None:
-        y = y * layer.alpha
+        y = y * tf.cast(layer.alpha, y.dtype)
 
-    return y
+    return tf.cast(y, output_dtype)

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -3,10 +3,21 @@
 import tensorflow as tf
 from typing import Optional, Any, Tuple, Union, List, Callable
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 from ._yat_core import yat_score
 from .saved_model import SingleInputSavedModelMixin
+
+
+def _epsilon_variable_dtype(layer):
+    dtype = tf.as_dtype(epsilon_parameter_dtype(layer.dtype))
+    validate_epsilon_for_dtype(layer.epsilon, dtype)
+    return dtype
 
 
 def _validate_groups(filters: int, groups: int) -> None:
@@ -166,7 +177,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
         if self.learnable_epsilon:
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=_epsilon_variable_dtype(self)),
                 trainable=True,
                 name='epsilon_param',
             )
@@ -360,7 +371,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
         if self.learnable_epsilon:
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=_epsilon_variable_dtype(self)),
                 trainable=True,
                 name='epsilon_param',
             )
@@ -555,7 +566,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
         if self.learnable_epsilon:
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=_epsilon_variable_dtype(self)),
                 trainable=True,
                 name='epsilon_param',
             )
@@ -721,7 +732,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         if self.learnable_epsilon:
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=_epsilon_variable_dtype(self)),
                 trainable=True,
                 name='epsilon_param',
             )
@@ -901,7 +912,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         if self.learnable_epsilon:
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=_epsilon_variable_dtype(self)),
                 trainable=True,
                 name='epsilon_param',
             )
@@ -1070,7 +1081,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         if self.learnable_epsilon:
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=_epsilon_variable_dtype(self)),
                 trainable=True,
                 name='epsilon_param',
             )

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -1,8 +1,9 @@
 """YAT convolution layers for TensorFlow."""
 
 import tensorflow as tf
-import math
 from typing import Optional, Any, Tuple, Union, List, Callable
+
+from nmn._epsilon import inverse_softplus, validate_epsilon
 
 from ._yat_core import yat_score
 from .saved_model import SingleInputSavedModelMixin
@@ -91,9 +92,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
         _validate_groups(filters, groups)
         self.groups = groups
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.dtype = dtype
 
@@ -165,7 +164,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,
@@ -287,9 +286,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
         _validate_groups(filters, groups)
         self.groups = groups
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.dtype = dtype
 
@@ -361,7 +358,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,
@@ -483,9 +480,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
         _validate_groups(filters, groups)
         self.groups = groups
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.dtype = dtype
 
@@ -558,7 +553,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,
@@ -669,9 +664,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         self.strides = strides
         self.padding = padding.upper()
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.dtype = dtype
 
@@ -726,7 +719,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,
@@ -850,9 +843,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         self.strides = strides if isinstance(strides, (list, tuple)) else (strides, strides)
         self.padding = padding.upper()
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.dtype = dtype
 
@@ -908,7 +899,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,
@@ -1020,9 +1011,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         self.strides = strides if isinstance(strides, (list, tuple)) else (strides, strides, strides)
         self.padding = padding.upper()
         self.use_alpha = use_alpha
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.dtype = dtype
 
@@ -1079,7 +1068,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -4,6 +4,8 @@ import tensorflow as tf
 import math
 from typing import Optional, Tuple, Union, List
 
+from nmn._epsilon import inverse_softplus, validate_epsilon
+
 from .saved_model import SingleInputSavedModelMixin
 
 # Default constant alpha value (sqrt(2))
@@ -86,9 +88,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         super().__init__(name=name)
         self.features = features
         self.dtype = dtype
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         # Lazy mode: freeze ONLY the kernel (bias/alpha/epsilon stay trainable).
         self.lazy = bool(lazy or freeze_kernel)
@@ -174,7 +174,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
                 tf.constant(raw_eps, shape=[1], dtype=self.dtype),
                 trainable=True,

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -4,7 +4,12 @@ import tensorflow as tf
 import math
 from typing import Optional, Tuple, Union, List
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 from .saved_model import SingleInputSavedModelMixin
 
@@ -174,9 +179,11 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
 
         # Learnable epsilon parameter (softplus-constrained)
         if self.learnable_epsilon:
+            epsilon_dtype = tf.as_dtype(epsilon_parameter_dtype(self.dtype))
+            validate_epsilon_for_dtype(self.epsilon, epsilon_dtype)
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = tf.Variable(
-                tf.constant(raw_eps, shape=[1], dtype=self.dtype),
+                tf.constant(raw_eps, shape=[1], dtype=epsilon_dtype),
                 trainable=True,
                 name='epsilon_param',
             )
@@ -262,6 +269,8 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
             eps = tf.nn.softplus(self.epsilon_param)
+            y = tf.cast(y, eps.dtype)
+            distances = tf.cast(distances, eps.dtype)
         else:
             eps = self.epsilon
 
@@ -270,10 +279,12 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
 
         # Apply scaling factor
         if self._constant_alpha_value is not None:
-            y = y * tf.cast(self._constant_alpha_value, self.dtype)
+            y = y * tf.cast(self._constant_alpha_value, y.dtype)
         elif self.alpha is not None:
             # Simple learnable alpha scaling
-            y = y * self.alpha
+            y = y * tf.cast(self.alpha, y.dtype)
+
+        y = tf.cast(y, self.dtype)
 
 
         if self.return_weights:

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -35,6 +35,7 @@ from .._precision import saturating_upcast
 
 __all__ = [
     "DEFAULT_CONSTANT_ALPHA",
+    "apply_preserving_epsilon_dtype",
     "promote_to_compute_dtype",
     "setup_yat_attrs",
     "yat_conv_forward",
@@ -44,6 +45,29 @@ __all__ = [
 
 # Default constant alpha value (sqrt(2)).
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
+
+
+def apply_preserving_epsilon_dtype(layer, fn, super_apply, *, recurse=True):
+    """Apply migration while retaining epsilon's protected storage dtype."""
+    epsilon_param = layer._parameters.get("epsilon_param")
+    if epsilon_param is None:
+        return super_apply(fn, recurse=recurse)
+
+    # Keep the same Parameter object out of Module._apply's dtype conversion.
+    layer._parameters["epsilon_param"] = None
+    try:
+        result = super_apply(fn, recurse=recurse)
+    finally:
+        layer._parameters["epsilon_param"] = epsilon_param
+
+    # Probe only the destination device.  Applying ``fn`` to the raw inverse
+    # softplus value could overflow/underflow before converting it back.
+    probe = fn(torch.empty(0, device=epsilon_param.device, dtype=epsilon_param.dtype))
+    with torch.no_grad():
+        epsilon_param.data = epsilon_param.data.to(device=probe.device)
+        if epsilon_param.grad is not None:
+            epsilon_param.grad.data = epsilon_param.grad.data.to(device=probe.device)
+    return result
 
 
 def setup_yat_attrs(

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -24,7 +24,11 @@ from torch.nn import functional as F
 from torch.nn.modules.utils import _single
 from torch.nn.parameter import Parameter
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 from .._precision import saturating_upcast
 
@@ -92,11 +96,15 @@ def setup_yat_attrs(
     layer.epsilon = validate_epsilon(epsilon)
     layer.learnable_epsilon = learnable_epsilon
     if learnable_epsilon:
+        epsilon_dtype = storage_dtype or torch.float32
+        if epsilon_dtype in (torch.float16, torch.bfloat16):
+            epsilon_dtype = torch.float32
+        validate_epsilon_for_dtype(layer.epsilon, epsilon_dtype)
         raw_eps = inverse_softplus(layer.epsilon)
         layer.epsilon_param = nn.Parameter(
             torch.full(
                 (1,), raw_eps,
-                dtype=storage_dtype if storage_dtype else torch.float32,
+                dtype=epsilon_dtype,
                 device=device,
             )
         )
@@ -170,13 +178,8 @@ def _resolve_alpha(layer, input: Tensor) -> Optional[Tensor]:
 def _resolve_eps(layer, dtype: torch.dtype):
     if layer.learnable_epsilon and layer.epsilon_param is not None:
         epsilon_param = layer.epsilon_param
-        if dtype != epsilon_param.dtype and epsilon_param.dtype in (
-            torch.float16,
-            torch.bfloat16,
-        ):
-            epsilon_param = saturating_upcast(epsilon_param).to(dtype)
-        else:
-            epsilon_param = epsilon_param.to(dtype)
+        dtype = torch.promote_types(dtype, epsilon_param.dtype)
+        epsilon_param = epsilon_param.to(dtype)
         return F.softplus(epsilon_param)
     return layer.epsilon
 
@@ -188,6 +191,9 @@ def _yat_score(layer, dot_prod_map: Tensor, distance_sq_map: Tensor,
     if bias_val is not None:
         dot_prod_map = dot_prod_map + bias_val.view(*view_shape)
     eps = _resolve_eps(layer, distance_sq_map.dtype)
+    if isinstance(eps, Tensor):
+        dot_prod_map = dot_prod_map.to(eps.dtype)
+        distance_sq_map = distance_sq_map.to(eps.dtype)
     y = dot_prod_map ** 2 / (distance_sq_map + eps)
     if layer._constant_alpha_value is not None:
         y = y * layer._constant_alpha_value

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -24,6 +24,8 @@ from torch.nn import functional as F
 from torch.nn.modules.utils import _single
 from torch.nn.parameter import Parameter
 
+from nmn._epsilon import inverse_softplus, validate_epsilon
+
 from .._precision import saturating_upcast
 
 
@@ -87,12 +89,10 @@ def setup_yat_attrs(
     layer.param_dtype = storage_dtype
     layer.use_dropconnect = use_dropconnect
 
-    if epsilon <= 0:
-        raise ValueError(f"epsilon must be positive, got {epsilon}")
-    layer.epsilon = epsilon
+    layer.epsilon = validate_epsilon(epsilon)
     layer.learnable_epsilon = learnable_epsilon
     if learnable_epsilon:
-        raw_eps = math.log(math.exp(epsilon) - 1.0)
+        raw_eps = inverse_softplus(layer.epsilon)
         layer.epsilon_param = nn.Parameter(
             torch.full(
                 (1,), raw_eps,

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -11,7 +11,11 @@ from torch.nn.common_types import _size_1_t
 from torch.nn.parameter import Parameter
 from torch.nn import Conv1d
 
-from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
+from ._yat_conv_core import (
+    apply_preserving_epsilon_dtype,
+    setup_yat_attrs,
+    yat_conv_forward,
+)
 
 __all__ = ["YatConv1D"]
 
@@ -197,4 +201,6 @@ class YatConv1D(Conv1d):
                 "device/dtype migration is unsupported for tied kernel-bank "
                 "consumers; construct them with the target device and dtype"
             )
-        return super()._apply(fn, recurse=recurse)
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
+        )

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -11,7 +11,11 @@ from torch.nn.common_types import _size_2_t
 from torch.nn.parameter import Parameter
 from torch.nn import Conv2d
 
-from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
+from ._yat_conv_core import (
+    apply_preserving_epsilon_dtype,
+    setup_yat_attrs,
+    yat_conv_forward,
+)
 
 __all__ = ["YatConv2D"]
 
@@ -210,4 +214,6 @@ class YatConv2D(Conv2d):
                 "device/dtype migration is unsupported for tied kernel-bank "
                 "consumers; construct them with the target device and dtype"
             )
-        return super()._apply(fn, recurse=recurse)
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
+        )

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -11,7 +11,11 @@ from torch.nn.common_types import _size_3_t
 from torch.nn.parameter import Parameter
 from torch.nn import Conv3d
 
-from ._yat_conv_core import setup_yat_attrs, yat_conv_forward
+from ._yat_conv_core import (
+    apply_preserving_epsilon_dtype,
+    setup_yat_attrs,
+    yat_conv_forward,
+)
 
 __all__ = ["YatConv3D"]
 
@@ -194,4 +198,6 @@ class YatConv3D(Conv3d):
                 "device/dtype migration is unsupported for tied kernel-bank "
                 "consumers; construct them with the target device and dtype"
             )
-        return super()._apply(fn, recurse=recurse)
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
+        )

--- a/src/nmn/torch/layers/yat_conv_transpose1d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose1d.py
@@ -12,7 +12,11 @@ from torch.nn.modules.utils import _single
 
 from torch.nn import ConvTranspose1d
 
-from ._yat_conv_core import setup_yat_attrs, yat_conv_transpose_forward
+from ._yat_conv_core import (
+    apply_preserving_epsilon_dtype,
+    setup_yat_attrs,
+    yat_conv_transpose_forward,
+)
 
 __all__ = ["YatConvTranspose1D"]
 
@@ -103,4 +107,9 @@ class YatConvTranspose1D(ConvTranspose1d):
         return yat_conv_transpose_forward(
             self, input, F.conv_transpose1d, output_padding,
             deterministic=deterministic,
+        )
+
+    def _apply(self, fn, recurse=True):
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
         )

--- a/src/nmn/torch/layers/yat_conv_transpose2d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose2d.py
@@ -12,7 +12,11 @@ from torch.nn.modules.utils import _pair
 
 from torch.nn import ConvTranspose2d
 
-from ._yat_conv_core import setup_yat_attrs, yat_conv_transpose_forward
+from ._yat_conv_core import (
+    apply_preserving_epsilon_dtype,
+    setup_yat_attrs,
+    yat_conv_transpose_forward,
+)
 
 __all__ = ["YatConvTranspose2D"]
 
@@ -103,4 +107,9 @@ class YatConvTranspose2D(ConvTranspose2d):
         return yat_conv_transpose_forward(
             self, input, F.conv_transpose2d, output_padding,
             deterministic=deterministic,
+        )
+
+    def _apply(self, fn, recurse=True):
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
         )

--- a/src/nmn/torch/layers/yat_conv_transpose3d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose3d.py
@@ -12,7 +12,11 @@ from torch.nn.modules.utils import _triple
 
 from torch.nn import ConvTranspose3d
 
-from ._yat_conv_core import setup_yat_attrs, yat_conv_transpose_forward
+from ._yat_conv_core import (
+    apply_preserving_epsilon_dtype,
+    setup_yat_attrs,
+    yat_conv_transpose_forward,
+)
 
 __all__ = ["YatConvTranspose3D"]
 
@@ -103,4 +107,9 @@ class YatConvTranspose3D(ConvTranspose3d):
         return yat_conv_transpose_forward(
             self, input, F.conv_transpose3d, output_padding,
             deterministic=deterministic,
+        )
+
+    def _apply(self, fn, recurse=True):
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
         )

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -440,7 +440,11 @@ class YatNMN(nn.Module):
                 "device/dtype migration is unsupported for tied kernel-bank "
                 "consumers; construct them with the target device and dtype"
             )
-        return super()._apply(fn, recurse=recurse)
+        from ..layers._yat_conv_core import apply_preserving_epsilon_dtype
+
+        return apply_preserving_epsilon_dtype(
+            self, fn, super()._apply, recurse=recurse
+        )
 
     def extra_repr(self) -> str:
         """

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from nmn._epsilon import inverse_softplus, validate_epsilon
+
 __all__ = ["YatNMN"]
 
 
@@ -105,13 +107,11 @@ class YatNMN(nn.Module):
         self.out_features = out_features
         self.dtype = dtype
         self.param_dtype = param_dtype
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
-        self.epsilon = epsilon
+        self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         if learnable_epsilon:
             # Initialize so that softplus(raw) ≈ epsilon: raw = log(exp(eps) - 1)
-            raw_eps = math.log(math.exp(epsilon) - 1.0)
+            raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = nn.Parameter(
                 torch.full((1,), raw_eps, dtype=param_dtype, device=device)
             )

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -8,7 +8,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from nmn._epsilon import inverse_softplus, validate_epsilon
+from nmn._epsilon import (
+    inverse_softplus,
+    validate_epsilon,
+    validate_epsilon_for_dtype,
+)
 
 __all__ = ["YatNMN"]
 
@@ -110,10 +114,16 @@ class YatNMN(nn.Module):
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         if learnable_epsilon:
+            epsilon_dtype = (
+                torch.float32
+                if param_dtype in (torch.float16, torch.bfloat16)
+                else param_dtype
+            )
+            validate_epsilon_for_dtype(self.epsilon, epsilon_dtype)
             # Initialize so that softplus(raw) ≈ epsilon: raw = log(exp(eps) - 1)
             raw_eps = inverse_softplus(self.epsilon)
             self.epsilon_param = nn.Parameter(
-                torch.full((1,), raw_eps, dtype=param_dtype, device=device)
+                torch.full((1,), raw_eps, dtype=epsilon_dtype, device=device)
             )
         else:
             self.register_parameter('epsilon_param', None)
@@ -402,8 +412,12 @@ class YatNMN(nn.Module):
             distances = (inputs_squared_sum + kernel_squared_sum - 2 * dot_for_dist).clamp(min=0.0)
 
         # Resolve effective epsilon (learnable via softplus, or constant)
+        output_dtype = y.dtype
         if self.learnable_epsilon and self.epsilon_param is not None:
-            eps = F.softplus(self.epsilon_param.to(distances.dtype))
+            score_dtype = torch.promote_types(distances.dtype, self.epsilon_param.dtype)
+            eps = F.softplus(self.epsilon_param.to(score_dtype))
+            y = y.to(score_dtype)
+            distances = distances.to(score_dtype)
         else:
             eps = self.epsilon
 
@@ -418,7 +432,7 @@ class YatNMN(nn.Module):
             # Simple learnable alpha scaling
             y = y * alpha_param
 
-        return y
+        return y.to(output_dtype)
 
     def _apply(self, fn, recurse=True):
         if getattr(self, "tie_kernel_bank", False):

--- a/tests/test_keras/test_stable_learnable_epsilon.py
+++ b/tests/test_keras/test_stable_learnable_epsilon.py
@@ -1,0 +1,154 @@
+"""Stable learnable-epsilon initialization across Keras YAT families."""
+
+import keras
+from keras import ops
+import numpy as np
+import pytest
+
+from nmn.keras import (
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatNMN,
+)
+
+
+BACKEND = keras.backend.backend()
+EPSILONS = (1e-20, 1e-5, 1000.0)
+FAMILIES = (
+    (YatNMN, None, (1, 2)),
+    (YatConv1D, (1,), (1, 1, 1)),
+    (YatConv2D, (1, 1), (1, 1, 1, 1)),
+    (YatConv3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+    (YatConvTranspose1D, (1,), (1, 1, 1)),
+    (YatConvTranspose2D, (1, 1), (1, 1, 1, 1)),
+    (YatConvTranspose3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+)
+
+
+def _make(layer_cls, kernel_size, epsilon):
+    kwargs = dict(
+        epsilon=epsilon,
+        learnable_epsilon=True,
+        use_bias=False,
+        use_alpha=False,
+        kernel_initializer="zeros",
+    )
+    if kernel_size is None:
+        return layer_cls(1, **kwargs)
+    return layer_cls(1, kernel_size, **kwargs)
+
+
+def _value_and_gradients(layer, inputs):
+    variables = list(layer.trainable_variables)
+    kernel_index = next(i for i, variable in enumerate(variables) if variable is layer.kernel)
+    epsilon_index = next(
+        i for i, variable in enumerate(variables) if variable is layer.epsilon_param
+    )
+
+    if BACKEND == "jax":
+        import jax
+
+        values = [variable.value for variable in variables]
+
+        def evaluate(input_value, kernel_value, epsilon_value):
+            current = list(values)
+            current[kernel_index] = kernel_value
+            current[epsilon_index] = epsilon_value
+            output, _ = layer.stateless_call(
+                current, layer.non_trainable_variables, input_value
+            )
+            return ops.sum(output), output
+
+        (_, output), gradients = jax.jit(
+            jax.value_and_grad(evaluate, argnums=(0, 1, 2), has_aux=True)
+        )(inputs, values[kernel_index], values[epsilon_index])
+        return output, gradients
+
+    if BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        input_value = inputs.detach().clone().requires_grad_(True)
+        output = layer(input_value)
+        gradients = torch.autograd.grad(
+            output.sum(),
+            (input_value, layer.kernel.value, layer.epsilon_param.value),
+        )
+        return output, gradients
+
+    if BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        input_value = tf.Variable(inputs)
+
+        @tf.function
+        def evaluate():
+            with tf.GradientTape() as tape:
+                output = layer(input_value)
+                loss = tf.reduce_sum(output)
+            gradients = tape.gradient(
+                loss, (input_value, layer.kernel.value, layer.epsilon_param.value)
+            )
+            return output, gradients
+
+        return evaluate()
+
+    pytest.skip("requires the JAX, Torch, or TensorFlow Keras backend")
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_learnable_epsilon_forward_and_gradients(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon)
+    inputs = ops.full(input_shape, 0.2, dtype="float32")
+    layer(inputs)
+    layer.kernel.assign(ops.full(layer.kernel.shape, 0.3, dtype="float32"))
+    output, gradients = _value_and_gradients(layer, inputs)
+
+    effective = ops.softplus(layer.epsilon_param)
+    np.testing.assert_allclose(
+        ops.convert_to_numpy(effective), epsilon, rtol=2e-6, atol=0.0
+    )
+    assert np.isfinite(ops.convert_to_numpy(output)).all()
+    for gradient in gradients:
+        assert np.isfinite(ops.convert_to_numpy(gradient)).all()
+    assert np.abs(ops.convert_to_numpy(gradients[-1])).max() > 0.0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,_", FAMILIES)
+@pytest.mark.parametrize("epsilon", [0.0, -1.0, float("nan"), float("inf")])
+def test_epsilon_must_be_finite_and_strictly_positive(
+    layer_cls, kernel_size, _, epsilon
+):
+    with pytest.raises(ValueError, match="positive and finite"):
+        _make(layer_cls, kernel_size, epsilon)
+
+
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_dense_config_and_weights_roundtrip(epsilon):
+    layer = _make(YatNMN, None, epsilon)
+    inputs = ops.full((1, 2), 0.2)
+    layer(inputs)
+    config = layer.get_config()
+    restored = YatNMN.from_config(config)
+    restored(inputs)
+    restored.set_weights(layer.get_weights())
+    assert restored.epsilon == epsilon
+    np.testing.assert_array_equal(
+        ops.convert_to_numpy(restored.epsilon_param),
+        ops.convert_to_numpy(layer.epsilon_param),
+    )
+
+
+def test_default_epsilon_remains_backward_compatible():
+    layer = YatNMN(1, learnable_epsilon=True)
+    layer(ops.ones((1, 2)))
+    assert layer.epsilon == 1e-5
+    np.testing.assert_allclose(
+        ops.convert_to_numpy(ops.softplus(layer.epsilon_param)),
+        1e-5,
+        rtol=2e-6,
+    )

--- a/tests/test_keras/test_stable_learnable_epsilon.py
+++ b/tests/test_keras/test_stable_learnable_epsilon.py
@@ -1,5 +1,7 @@
 """Stable learnable-epsilon initialization across Keras YAT families."""
 
+from contextlib import nullcontext
+
 import keras
 from keras import ops
 import numpy as np
@@ -29,7 +31,7 @@ FAMILIES = (
 )
 
 
-def _make(layer_cls, kernel_size, epsilon):
+def _make(layer_cls, kernel_size, epsilon, dtype=None):
     kwargs = dict(
         epsilon=epsilon,
         learnable_epsilon=True,
@@ -37,6 +39,8 @@ def _make(layer_cls, kernel_size, epsilon):
         use_alpha=False,
         kernel_initializer="zeros",
     )
+    if dtype is not None:
+        kwargs["dtype"] = dtype
     if kernel_size is None:
         return layer_cls(1, **kwargs)
     return layer_cls(1, kernel_size, **kwargs)
@@ -152,3 +156,72 @@ def test_default_epsilon_remains_backward_compatible():
         1e-5,
         rtol=2e-6,
     )
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", [1e-8, 1e-20, 1e5])
+def test_float16_uses_fp32_epsilon_storage(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, "float16")
+    inputs = ops.full(input_shape, 0.2, dtype="float16")
+    layer(inputs)
+    layer.kernel.assign(ops.full(layer.kernel.shape, 0.3, dtype="float16"))
+    output, gradients = _value_and_gradients(layer, inputs)
+    assert keras.backend.standardize_dtype(layer.epsilon_param.dtype) == "float32"
+    np.testing.assert_allclose(
+        ops.convert_to_numpy(ops.softplus(layer.epsilon_param)),
+        epsilon,
+        rtol=2e-6,
+    )
+    assert keras.backend.standardize_dtype(output.dtype) == "float16"
+    assert np.isfinite(ops.convert_to_numpy(output)).all()
+    epsilon_grad = ops.convert_to_numpy(gradients[-1])
+    assert np.isfinite(epsilon_grad).all() and np.abs(epsilon_grad).max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [5e-324, 1e-46, 1e39])
+def test_float32_rejects_unrepresentable_epsilon(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, "float32")
+    with pytest.raises(ValueError, match="not representable"):
+        layer(ops.ones(input_shape, dtype="float32"))
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [2.0 ** -1022, 1e150])
+def test_float64_extreme_epsilon_is_effective_and_differentiable(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    if BACKEND == "jax":
+        import jax
+
+        dtype_context = jax.enable_x64()
+    else:
+        dtype_context = nullcontext()
+
+    with dtype_context:
+        layer = _make(layer_cls, kernel_size, epsilon, "float64")
+        inputs = ops.full(input_shape, 0.2, dtype="float64")
+        layer(inputs)
+        layer.kernel.assign(ops.full(layer.kernel.shape, 0.3, dtype="float64"))
+        output, gradients = _value_and_gradients(layer, inputs)
+        np.testing.assert_allclose(
+            ops.convert_to_numpy(ops.softplus(layer.epsilon_param)),
+            epsilon,
+            rtol=5e-14,
+        )
+        epsilon_grad = ops.convert_to_numpy(gradients[-1])
+        assert np.isfinite(ops.convert_to_numpy(output)).all()
+        assert np.isfinite(epsilon_grad).all() and np.abs(epsilon_grad).max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+def test_float64_rejects_softplus_underflow(
+    layer_cls, kernel_size, input_shape
+):
+    layer = _make(layer_cls, kernel_size, 5e-324, "float64")
+    with pytest.raises(ValueError, match="not representable"):
+        layer(ops.ones(input_shape, dtype="float64"))

--- a/tests/test_keras/test_stable_learnable_epsilon.py
+++ b/tests/test_keras/test_stable_learnable_epsilon.py
@@ -225,3 +225,21 @@ def test_float64_rejects_softplus_underflow(
     layer = _make(layer_cls, kernel_size, 5e-324, "float64")
     with pytest.raises(ValueError, match="not representable"):
         layer(ops.ones(input_shape, dtype="float64"))
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+def test_jax_float64_requires_x64_backing_storage(
+    layer_cls, kernel_size, input_shape
+):
+    if BACKEND != "jax":
+        pytest.skip("JAX-specific backing dtype guard")
+    import jax
+
+    previous_x64 = jax.config.x64_enabled
+    jax.config.update("jax_enable_x64", False)
+    try:
+        layer = _make(layer_cls, kernel_size, 1e150, "float64")
+        with pytest.raises(ValueError, match="jax_enable_x64=True"):
+            layer(ops.ones(input_shape, dtype="float32"))
+    finally:
+        jax.config.update("jax_enable_x64", previous_x64)

--- a/tests/test_linen/test_stable_learnable_epsilon.py
+++ b/tests/test_linen/test_stable_learnable_epsilon.py
@@ -29,7 +29,7 @@ FAMILIES = (
 )
 
 
-def _make(layer_cls, kernel_size, epsilon):
+def _make(layer_cls, kernel_size, epsilon, dtype=None):
     kwargs = dict(
         features=1,
         epsilon=epsilon,
@@ -37,6 +37,14 @@ def _make(layer_cls, kernel_size, epsilon):
         use_bias=False,
         use_alpha=False,
     )
+    if dtype is not None:
+        kwargs.update(
+            dtype=dtype,
+            param_dtype=dtype,
+            kernel_init=lambda key, shape, init_dtype: jnp.zeros(
+                shape, init_dtype
+            ),
+        )
     if kernel_size is not None:
         kwargs["kernel_size"] = kernel_size
     return layer_cls(**kwargs)
@@ -103,3 +111,83 @@ def test_default_epsilon_remains_backward_compatible():
         1e-5,
         rtol=2e-6,
     )
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", [1e-8, 1e-20, 1e5])
+def test_float16_uses_fp32_epsilon_storage(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, jnp.float16)
+    inputs = jnp.full(input_shape, 0.2, dtype=jnp.float16)
+    variables = layer.init(jax.random.key(3), inputs)
+    variables = {
+        "params": dict(
+            variables["params"],
+            kernel=jnp.full_like(variables["params"]["kernel"], 0.3),
+        )
+    }
+
+    def loss(epsilon_param):
+        params = dict(variables["params"], epsilon_param=epsilon_param)
+        return layer.apply({"params": params}, inputs).astype(jnp.float32).sum()
+
+    epsilon_param = variables["params"]["epsilon_param"]
+    output = jax.jit(layer.apply)(variables, inputs)
+    epsilon_grad = jax.jit(jax.grad(loss))(epsilon_param)
+    assert epsilon_param.dtype == jnp.float32
+    np.testing.assert_allclose(
+        np.asarray(jax.nn.softplus(epsilon_param)), epsilon, rtol=2e-6
+    )
+    assert output.dtype == jnp.float16 and jnp.isfinite(output).all()
+    assert jnp.isfinite(epsilon_grad).all() and jnp.abs(epsilon_grad).max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [5e-324, 1e-46, 1e39])
+def test_float32_rejects_unrepresentable_epsilon(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, jnp.float32)
+    with pytest.raises(ValueError, match="not representable"):
+        layer.init(jax.random.key(4), jnp.ones(input_shape, jnp.float32))
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [2.0 ** -1022, 1e150])
+def test_float64_extreme_epsilon_is_effective_and_differentiable(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    with jax.enable_x64():
+        layer = _make(layer_cls, kernel_size, epsilon, jnp.float64)
+        inputs = jnp.full(input_shape, 0.2, dtype=jnp.float64)
+        variables = layer.init(jax.random.key(5), inputs)
+        variables = {
+            "params": dict(
+                variables["params"],
+                kernel=jnp.full_like(variables["params"]["kernel"], 0.3),
+            )
+        }
+        epsilon_param = variables["params"]["epsilon_param"]
+
+        def loss(raw_epsilon):
+            params = dict(variables["params"], epsilon_param=raw_epsilon)
+            return layer.apply({"params": params}, inputs).sum()
+
+        output = layer.apply(variables, inputs)
+        epsilon_grad = jax.grad(loss)(epsilon_param)
+        np.testing.assert_allclose(
+            np.asarray(jax.nn.softplus(epsilon_param)), epsilon, rtol=5e-14
+        )
+        assert jnp.isfinite(output).all() and jnp.isfinite(epsilon_grad).all()
+        assert jnp.abs(epsilon_grad).max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+def test_float64_rejects_softplus_underflow(
+    layer_cls, kernel_size, input_shape
+):
+    with jax.enable_x64():
+        layer = _make(layer_cls, kernel_size, 5e-324, jnp.float64)
+        with pytest.raises(ValueError, match="not representable"):
+            layer.init(jax.random.key(6), jnp.ones(input_shape, jnp.float64))

--- a/tests/test_linen/test_stable_learnable_epsilon.py
+++ b/tests/test_linen/test_stable_learnable_epsilon.py
@@ -1,0 +1,105 @@
+"""Stable learnable-epsilon initialization across Linen YAT families."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import serialization
+
+from nmn.linen import (
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatNMN,
+)
+
+
+EPSILONS = (1e-20, 1e-5, 1000.0)
+FAMILIES = (
+    (YatNMN, None, (1, 2)),
+    (YatConv1D, (1,), (1, 1, 1)),
+    (YatConv2D, (1, 1), (1, 1, 1, 1)),
+    (YatConv3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+    (YatConvTranspose1D, (1,), (1, 1, 1)),
+    (YatConvTranspose2D, (1, 1), (1, 1, 1, 1)),
+    (YatConvTranspose3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+)
+
+
+def _make(layer_cls, kernel_size, epsilon):
+    kwargs = dict(
+        features=1,
+        epsilon=epsilon,
+        learnable_epsilon=True,
+        use_bias=False,
+        use_alpha=False,
+    )
+    if kernel_size is not None:
+        kwargs["kernel_size"] = kernel_size
+    return layer_cls(**kwargs)
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_learnable_epsilon_jit_forward_and_gradients(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon)
+    inputs = jnp.full(input_shape, 0.2, dtype=jnp.float32)
+    variables = layer.init(jax.random.key(0), inputs)
+    params = dict(variables["params"])
+    params["kernel"] = jnp.full_like(params["kernel"], 0.3)
+
+    def loss(param_values, input_values):
+        output = layer.apply({"params": param_values}, input_values)
+        return output.sum(), output
+
+    (_, output), (param_grads, input_grads) = jax.jit(
+        jax.value_and_grad(loss, argnums=(0, 1), has_aux=True)
+    )(params, inputs)
+
+    effective = jax.nn.softplus(params["epsilon_param"])
+    np.testing.assert_allclose(
+        np.asarray(effective), epsilon, rtol=2e-6, atol=0.0
+    )
+    assert jnp.isfinite(output).all()
+    assert jnp.isfinite(input_grads).all()
+    assert jnp.isfinite(param_grads["kernel"]).all()
+    assert jnp.isfinite(param_grads["epsilon_param"]).all()
+    assert jnp.abs(param_grads["epsilon_param"]).max() > 0.0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,_", FAMILIES)
+@pytest.mark.parametrize("epsilon", [0.0, -1.0, float("nan"), float("inf")])
+def test_epsilon_must_be_finite_and_strictly_positive(
+    layer_cls, kernel_size, _, epsilon
+):
+    with pytest.raises(ValueError, match="positive and finite"):
+        _make(layer_cls, kernel_size, epsilon)
+
+
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_dense_params_serialize_roundtrip(epsilon):
+    layer = _make(YatNMN, None, epsilon)
+    inputs = jnp.full((1, 2), 0.2)
+    variables = layer.init(jax.random.key(1), inputs)
+    encoded = serialization.to_bytes(variables)
+    restored = serialization.from_bytes(variables, encoded)
+    np.testing.assert_array_equal(
+        np.asarray(restored["params"]["epsilon_param"]),
+        np.asarray(variables["params"]["epsilon_param"]),
+    )
+
+
+def test_default_epsilon_remains_backward_compatible():
+    layer = YatNMN(features=1, learnable_epsilon=True)
+    variables = layer.init(jax.random.key(2), jnp.ones((1, 2)))
+    assert layer.epsilon == 1e-5
+    np.testing.assert_allclose(
+        np.asarray(jax.nn.softplus(variables["params"]["epsilon_param"])),
+        1e-5,
+        rtol=2e-6,
+    )

--- a/tests/test_tf/test_stable_learnable_epsilon.py
+++ b/tests/test_tf/test_stable_learnable_epsilon.py
@@ -27,13 +27,15 @@ FAMILIES = (
 )
 
 
-def _make(layer_cls, kernel_size, epsilon):
+def _make(layer_cls, kernel_size, epsilon, dtype=None):
     kwargs = dict(
         epsilon=epsilon,
         learnable_epsilon=True,
         use_bias=False,
         use_alpha=False,
     )
+    if dtype is not None:
+        kwargs["dtype"] = dtype
     if kernel_size is None:
         return layer_cls(features=1, **kwargs)
     return layer_cls(filters=1, kernel_size=kernel_size, **kwargs)
@@ -100,3 +102,70 @@ def test_default_epsilon_remains_backward_compatible():
     np.testing.assert_allclose(
         tf.nn.softplus(layer.epsilon_param).numpy(), 1e-5, rtol=2e-6
     )
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", [1e-8, 1e-20, 1e5])
+def test_float16_uses_fp32_epsilon_storage(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, tf.float16)
+    inputs = tf.Variable(tf.fill(input_shape, tf.constant(0.2, tf.float16)))
+    layer(inputs)
+    layer.kernel.assign(tf.fill(layer.kernel.shape, tf.constant(0.3, tf.float16)))
+
+    @tf.function
+    def evaluate():
+        with tf.GradientTape() as tape:
+            output = layer(inputs)
+            loss = tf.reduce_sum(tf.cast(output, tf.float32))
+        return output, tape.gradient(loss, layer.epsilon_param)
+
+    output, epsilon_grad = evaluate()
+    assert layer.epsilon_param.dtype == tf.float32
+    np.testing.assert_allclose(
+        tf.nn.softplus(layer.epsilon_param).numpy(), epsilon, rtol=2e-6
+    )
+    assert output.dtype == tf.float16 and np.isfinite(output.numpy()).all()
+    assert np.isfinite(epsilon_grad.numpy()).all()
+    assert np.abs(epsilon_grad.numpy()).max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [5e-324, 1e-46, 1e39])
+def test_float32_rejects_unrepresentable_epsilon(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, tf.float32)
+    with pytest.raises(ValueError, match="not representable"):
+        layer(tf.ones(input_shape, tf.float32))
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [2.0 ** -1022, 1e150])
+def test_float64_extreme_epsilon_is_effective_and_differentiable(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, tf.float64)
+    inputs = tf.Variable(tf.fill(input_shape, tf.constant(0.2, tf.float64)))
+    layer(inputs)
+    layer.kernel.assign(tf.fill(layer.kernel.shape, tf.constant(0.3, tf.float64)))
+    with tf.GradientTape() as tape:
+        output = layer(inputs)
+        loss = tf.reduce_sum(output)
+    epsilon_grad = tape.gradient(loss, layer.epsilon_param)
+    np.testing.assert_allclose(
+        tf.nn.softplus(layer.epsilon_param).numpy(), epsilon, rtol=5e-14
+    )
+    assert np.isfinite(output.numpy()).all()
+    assert np.isfinite(epsilon_grad.numpy()).all()
+    assert np.abs(epsilon_grad.numpy()).max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES[:2])
+def test_float64_rejects_softplus_underflow(
+    layer_cls, kernel_size, input_shape
+):
+    layer = _make(layer_cls, kernel_size, 5e-324, tf.float64)
+    with pytest.raises(ValueError, match="not representable"):
+        layer(tf.ones(input_shape, tf.float64))

--- a/tests/test_tf/test_stable_learnable_epsilon.py
+++ b/tests/test_tf/test_stable_learnable_epsilon.py
@@ -1,0 +1,102 @@
+"""Stable learnable-epsilon initialization across TensorFlow YAT families."""
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from nmn.tf import (
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatNMN,
+)
+
+
+EPSILONS = (1e-20, 1e-5, 1000.0)
+FAMILIES = (
+    (YatNMN, None, (1, 2)),
+    (YatConv1D, 1, (1, 1, 1)),
+    (YatConv2D, (1, 1), (1, 1, 1, 1)),
+    (YatConv3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+    (YatConvTranspose1D, 1, (1, 1, 1)),
+    (YatConvTranspose2D, (1, 1), (1, 1, 1, 1)),
+    (YatConvTranspose3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+)
+
+
+def _make(layer_cls, kernel_size, epsilon):
+    kwargs = dict(
+        epsilon=epsilon,
+        learnable_epsilon=True,
+        use_bias=False,
+        use_alpha=False,
+    )
+    if kernel_size is None:
+        return layer_cls(features=1, **kwargs)
+    return layer_cls(filters=1, kernel_size=kernel_size, **kwargs)
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_learnable_epsilon_tf_function_forward_and_gradients(
+    layer_cls, kernel_size, input_shape, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon)
+    inputs = tf.Variable(tf.fill(input_shape, 0.2))
+    layer(inputs)
+    layer.kernel.assign(tf.fill(layer.kernel.shape, 0.3))
+
+    @tf.function
+    def evaluate():
+        with tf.GradientTape() as tape:
+            output = layer(inputs)
+            loss = tf.reduce_sum(output)
+        gradients = tape.gradient(
+            loss, (inputs, layer.kernel, layer.epsilon_param)
+        )
+        return output, gradients
+
+    output, gradients = evaluate()
+    effective = tf.nn.softplus(layer.epsilon_param)
+    np.testing.assert_allclose(effective.numpy(), epsilon, rtol=2e-6, atol=0.0)
+    assert np.isfinite(output.numpy()).all()
+    for gradient in gradients:
+        assert np.isfinite(gradient.numpy()).all()
+    assert np.abs(gradients[-1].numpy()).max() > 0.0
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,_", FAMILIES)
+@pytest.mark.parametrize("epsilon", [0.0, -1.0, float("nan"), float("inf")])
+def test_epsilon_must_be_finite_and_strictly_positive(
+    layer_cls, kernel_size, _, epsilon
+):
+    with pytest.raises(ValueError, match="positive and finite"):
+        _make(layer_cls, kernel_size, epsilon)
+
+
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_dense_checkpoint_roundtrip(tmp_path, epsilon):
+    layer = _make(YatNMN, None, epsilon)
+    inputs = tf.fill((1, 2), 0.2)
+    layer(inputs)
+    checkpoint = tf.train.Checkpoint(layer=layer)
+    path = checkpoint.save(str(tmp_path / "epsilon"))
+
+    restored = _make(YatNMN, None, epsilon)
+    restored(inputs)
+    tf.train.Checkpoint(layer=restored).restore(path).assert_consumed()
+    np.testing.assert_array_equal(
+        restored.epsilon_param.numpy(), layer.epsilon_param.numpy()
+    )
+
+
+def test_default_epsilon_remains_backward_compatible():
+    layer = YatNMN(features=1, learnable_epsilon=True)
+    layer(tf.ones((1, 2)))
+    assert layer.epsilon == 1e-5
+    np.testing.assert_allclose(
+        tf.nn.softplus(layer.epsilon_param).numpy(), 1e-5, rtol=2e-6
+    )

--- a/tests/test_torch/test_issue_regressions.py
+++ b/tests/test_torch/test_issue_regressions.py
@@ -420,7 +420,13 @@ def test_untied_yat_nmn_supports_constructor_device_and_later_migration():
     layer = YatNMN(4, 2, learnable_epsilon=True, device="cpu")
     migrated = layer.to(dtype=torch.float64)
     assert migrated is layer
-    assert all(value.dtype == torch.float64 for value in layer.state_dict().values())
+    state = layer.state_dict()
+    assert state["epsilon_param"].dtype == torch.float32
+    assert all(
+        value.dtype == torch.float64
+        for name, value in state.items()
+        if name != "epsilon_param"
+    )
 
 
 def test_attention_compute_and_parameter_dtypes_round_trip():

--- a/tests/test_torch/test_stable_learnable_epsilon.py
+++ b/tests/test_torch/test_stable_learnable_epsilon.py
@@ -1,0 +1,91 @@
+"""Stable learnable-epsilon initialization across Torch YAT families."""
+
+import io
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from nmn.torch import (
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatNMN,
+)
+
+
+EPSILONS = (1e-20, 1e-5, 1000.0)
+FAMILIES = (
+    (YatNMN, (2, 1), (1, 2)),
+    (YatConv1D, (1, 1, 1), (1, 1, 1)),
+    (YatConv2D, (1, 1, 1, 1), (1, 1, 1)),
+    (YatConv3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+    (YatConvTranspose1D, (1, 1, 1), (1, 1, 1)),
+    (YatConvTranspose2D, (1, 1, 1, 1), (1, 1, 1)),
+    (YatConvTranspose3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+)
+
+
+def _make(layer_cls, args, epsilon):
+    kwargs = dict(epsilon=epsilon, learnable_epsilon=True)
+    if layer_cls is YatNMN:
+        kwargs["bias"] = False
+        kwargs["alpha"] = False
+    else:
+        kwargs["bias"] = False
+        kwargs["use_alpha"] = False
+    return layer_cls(*args, **kwargs)
+
+
+@pytest.mark.parametrize("layer_cls,args,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_learnable_epsilon_constructs_runs_and_differentiates(
+    layer_cls, args, input_shape, epsilon
+):
+    layer = _make(layer_cls, args, epsilon)
+    with torch.no_grad():
+        layer.weight.fill_(0.3)
+    inputs = torch.full(input_shape, 0.2, requires_grad=True)
+    output = layer(inputs)
+    input_grad, kernel_grad, epsilon_grad = torch.autograd.grad(
+        output.sum(), (inputs, layer.weight, layer.epsilon_param)
+    )
+
+    effective = F.softplus(layer.epsilon_param.detach()).item()
+    assert effective == pytest.approx(epsilon, rel=2e-6, abs=0.0)
+    assert output.isfinite().all()
+    assert input_grad.isfinite().all()
+    assert kernel_grad.isfinite().all()
+    assert epsilon_grad.isfinite().all()
+    assert epsilon_grad.abs().item() > 0.0
+
+
+@pytest.mark.parametrize("layer_cls,args,_", FAMILIES)
+@pytest.mark.parametrize("epsilon", [0.0, -1.0, float("nan"), float("inf")])
+def test_epsilon_must_be_finite_and_strictly_positive(layer_cls, args, _, epsilon):
+    with pytest.raises(ValueError, match="positive and finite"):
+        _make(layer_cls, args, epsilon)
+
+
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_dense_learnable_epsilon_traces_and_state_dict_roundtrips(epsilon):
+    layer = _make(YatNMN, (2, 1), epsilon)
+    inputs = torch.full((1, 2), 0.2)
+    traced = torch.jit.trace(layer, inputs)
+    assert traced(inputs).isfinite().all()
+
+    buffer = io.BytesIO()
+    torch.save(layer.state_dict(), buffer)
+    buffer.seek(0)
+    restored = _make(YatNMN, (2, 1), epsilon)
+    restored.load_state_dict(torch.load(buffer, weights_only=True))
+    torch.testing.assert_close(restored.epsilon_param, layer.epsilon_param)
+
+
+def test_default_epsilon_remains_backward_compatible():
+    layer = YatNMN(1, 2, learnable_epsilon=True)
+    assert layer.epsilon == 1e-5
+    assert F.softplus(layer.epsilon_param).item() == pytest.approx(1e-5, rel=2e-6)

--- a/tests/test_torch/test_stable_learnable_epsilon.py
+++ b/tests/test_torch/test_stable_learnable_epsilon.py
@@ -29,8 +29,10 @@ FAMILIES = (
 )
 
 
-def _make(layer_cls, args, epsilon):
+def _make(layer_cls, args, epsilon, dtype=None):
     kwargs = dict(epsilon=epsilon, learnable_epsilon=True)
+    if dtype is not None:
+        kwargs.update(dtype=dtype, param_dtype=dtype)
     if layer_cls is YatNMN:
         kwargs["bias"] = False
         kwargs["alpha"] = False
@@ -89,3 +91,55 @@ def test_default_epsilon_remains_backward_compatible():
     layer = YatNMN(1, 2, learnable_epsilon=True)
     assert layer.epsilon == 1e-5
     assert F.softplus(layer.epsilon_param).item() == pytest.approx(1e-5, rel=2e-6)
+
+
+@pytest.mark.parametrize("layer_cls,args,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", [1e-8, 1e-20, 1e5])
+def test_float16_uses_fp32_epsilon_storage(
+    layer_cls, args, input_shape, epsilon
+):
+    layer = _make(layer_cls, args, epsilon, torch.float16)
+    with torch.no_grad():
+        layer.weight.fill_(0.3)
+    inputs = torch.full(input_shape, 0.2, dtype=torch.float16, requires_grad=True)
+    output = layer(inputs)
+    (epsilon_grad,) = torch.autograd.grad(
+        output.float().sum(), (layer.epsilon_param,)
+    )
+    assert layer.epsilon_param.dtype == torch.float32
+    assert F.softplus(layer.epsilon_param).item() == pytest.approx(
+        epsilon, rel=2e-6
+    )
+    assert output.dtype == torch.float16 and output.isfinite().all()
+    assert epsilon_grad.isfinite().all() and epsilon_grad.abs().max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,args,_", [FAMILIES[0], FAMILIES[1]])
+@pytest.mark.parametrize("epsilon", [5e-324, 1e-46, 1e39])
+def test_float32_rejects_unrepresentable_epsilon(layer_cls, args, _, epsilon):
+    with pytest.raises(ValueError, match="not representable"):
+        _make(layer_cls, args, epsilon, torch.float32)
+
+
+@pytest.mark.parametrize("layer_cls,args,input_shape", [FAMILIES[0], FAMILIES[1]])
+@pytest.mark.parametrize("epsilon", [2.0 ** -1022, 1e150])
+def test_float64_extreme_epsilon_is_effective_and_differentiable(
+    layer_cls, args, input_shape, epsilon
+):
+    layer = _make(layer_cls, args, epsilon, torch.float64)
+    with torch.no_grad():
+        layer.weight.fill_(0.3)
+    inputs = torch.full(input_shape, 0.2, dtype=torch.float64, requires_grad=True)
+    output = layer(inputs)
+    (epsilon_grad,) = torch.autograd.grad(output.sum(), (layer.epsilon_param,))
+    assert F.softplus(layer.epsilon_param).item() == pytest.approx(
+        epsilon, rel=2e-14
+    )
+    assert output.isfinite().all() and epsilon_grad.isfinite().all()
+    assert epsilon_grad.abs().max() > 0
+
+
+@pytest.mark.parametrize("layer_cls,args,_", [FAMILIES[0], FAMILIES[1]])
+def test_float64_rejects_softplus_underflow(layer_cls, args, _):
+    with pytest.raises(ValueError, match="not representable"):
+        _make(layer_cls, args, 5e-324, torch.float64)

--- a/tests/test_torch/test_stable_learnable_epsilon.py
+++ b/tests/test_torch/test_stable_learnable_epsilon.py
@@ -143,3 +143,48 @@ def test_float64_extreme_epsilon_is_effective_and_differentiable(
 def test_float64_rejects_softplus_underflow(layer_cls, args, _):
     with pytest.raises(ValueError, match="not representable"):
         _make(layer_cls, args, 5e-324, torch.float64)
+
+
+@pytest.mark.parametrize("layer_cls,args,input_shape", FAMILIES[:2])
+@pytest.mark.parametrize("epsilon", [1e-20, 1e5])
+@pytest.mark.parametrize(
+    "migration,target_dtype",
+    [
+        ("half", torch.float16),
+        ("bfloat16", torch.bfloat16),
+        ("to", torch.float16),
+    ],
+)
+def test_module_dtype_migration_preserves_epsilon_storage_identity_and_gradient(
+    layer_cls, args, input_shape, epsilon, migration, target_dtype
+):
+    layer = _make(layer_cls, args, epsilon)
+    epsilon_param = layer.epsilon_param
+    if migration == "to":
+        layer.to(dtype=target_dtype)
+    else:
+        getattr(layer, migration)()
+
+    assert layer.epsilon_param is epsilon_param
+    assert layer.epsilon_param.dtype == torch.float32
+    assert layer.weight.dtype == target_dtype
+    assert layer.state_dict()["epsilon_param"].dtype == torch.float32
+
+    with torch.no_grad():
+        layer.weight.fill_(0.3)
+    inputs = torch.full(input_shape, 0.2, dtype=target_dtype)
+    output = layer(inputs)
+    (epsilon_grad,) = torch.autograd.grad(
+        output.float().sum(), (layer.epsilon_param,)
+    )
+    assert output.isfinite().all()
+    assert epsilon_grad.isfinite().all() and epsilon_grad.abs().max() > 0
+
+    restored = _make(layer_cls, args, epsilon)
+    if migration == "to":
+        restored.to(dtype=target_dtype)
+    else:
+        getattr(restored, migration)()
+    restored.load_state_dict(layer.state_dict())
+    assert restored.epsilon_param.dtype == torch.float32
+    torch.testing.assert_close(restored.epsilon_param, layer.epsilon_param)


### PR DESCRIPTION
Fixes #94. Replaces unstable inverse-softplus initialization across Torch, Linen, Keras, and TensorFlow dense plus all convolution/transpose families; validates finite positive dtype-representable epsilon values; uses protected fp32 epsilon storage for low-precision layers; preserves PyTorch epsilon parameter, gradient, optimizer, and state identity across dtype migration; and guards Keras-JAX float64 when x64 backing storage is disabled. Includes tiny/default/large/extreme construction, forward, gradient, transform, and serialization coverage. Independently approved.