### PR TITLE
fix: stabilize large-magnitude low-precision YAT math

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,15 @@ Same identity, applied per patch. `YatConv1D`, `YatConv2D`, `YatConv3D`, and the
 | Very high-magnitude inputs      | scale-aware: `epsilon = c·var(x)` | Keeps the relative contribution of `ε` constant.                                           |
 | Embeddings (large vocab)        | `1e-3` to `1e-5`                 | Tune via validation loss; embeddings often cluster near zero early in training.            |
 
+Low-precision score arithmetic is accumulated in fp32 and final fp16/bf16
+outputs are saturated to the destination dtype's finite range. This prevents
+avoidable intermediate overflow, but it cannot make an out-of-range gradient
+representable at a low-precision leaf. In particular, separate finite
+cotangents can be added by autodiff after they leave a layer and overflow the
+shared fp16 variable. Keep trainable parameters and gradient accumulation in
+fp32 (with low-precision compute/autocast) when large reductions or reused
+leaves can produce gradients outside the fp16 range.
+
 If you see `NaN` in early training steps, **increase `epsilon` first** before changing learning rate or normalization. This is the most common failure mode.
 
 ### The `alpha` knob

--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -66,7 +66,7 @@ def yat_attention_weights(
     output_dtype = query.dtype
     query = reduction_safe_upcast(query)
     key = reduction_safe_upcast(key)
-    if alpha is not None:
+    if alpha is not None and hasattr(alpha, "dtype"):
         alpha = reduction_safe_upcast(alpha)
 
     # Scale by 1/√head_dim to match standard attention's score growth profile.

--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -15,6 +15,8 @@ from keras.src import initializers, ops
 from keras.src.layers.layer import Layer
 from keras.src.saving.object_registration import register_keras_serializable
 
+from ._yat_core import reduction_safe_upcast
+
 __all__ = [
     "normalize_qk",
     "yat_attention_weights",
@@ -61,6 +63,12 @@ def yat_attention_weights(
     Returns:
         Attention weights (batch, num_heads, q_len, kv_len).
     """
+    output_dtype = query.dtype
+    query = reduction_safe_upcast(query)
+    key = reduction_safe_upcast(key)
+    if alpha is not None:
+        alpha = reduction_safe_upcast(alpha)
+
     # Scale by 1/√head_dim to match standard attention's score growth profile.
     head_dim = query.shape[-1]
     dim_scale = ops.sqrt(ops.cast(head_dim, query.dtype))
@@ -104,7 +112,7 @@ def yat_attention_weights(
         )
         attn_weights = attn_weights * keep
 
-    return attn_weights
+    return ops.cast(attn_weights, output_dtype)
 
 
 def yat_attention(

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -14,6 +14,8 @@ from nmn._epsilon import (
     validate_epsilon_for_dtype,
 )
 
+from ._yat_core import reduction_safe_upcast, saturating_downcast, stable_yat_ratio
+
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
@@ -218,7 +220,9 @@ class YatNMN(Layer):
         self.built = True
 
     def call(self, inputs):
-        kernel = self.kernel
+        output_dtype = self.compute_dtype
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(self.kernel)
 
         # Spherical mode: normalize inputs and kernel columns (each neuron) to unit norm
         # Kernel shape is (input_dim, units), so each neuron is a column → axis=0
@@ -252,7 +256,7 @@ class YatNMN(Layer):
             if self._constant_bias_value is not None:
                 dot_product = dot_product + self._constant_bias_value
             else:
-                dot_product = ops.add(dot_product, self.bias)
+                dot_product = ops.add(dot_product, reduction_safe_upcast(self.bias))
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
@@ -263,17 +267,25 @@ class YatNMN(Layer):
         else:
             eps = self.epsilon
 
-        # Compute inverse square attention
-        outputs = dot_product ** 2 / (distances + eps)
+        # Compute the ratio in fp32 for low-precision policies.  Both dot^2 and
+        # the expanded distance can overflow before their finite ratio forms.
+        ratio_dtype = (
+            "float32"
+            if output_dtype in ("float16", "bfloat16")
+            else output_dtype
+        )
+        outputs = stable_yat_ratio(
+            dot_product, distances, eps, output_dtype=ratio_dtype
+        )
 
         # Apply alpha scaling
         if self._constant_alpha_value is not None:
             outputs = outputs * self._constant_alpha_value
         elif self.alpha is not None:
             # Simple learnable alpha scaling
-            outputs = outputs * self.alpha
+            outputs = outputs * reduction_safe_upcast(self.alpha)
 
-        return ops.cast(outputs, self.compute_dtype)
+        return saturating_downcast(outputs, output_dtype)
 
     def compute_output_shape(self, input_shape):
         output_shape = list(input_shape)

--- a/src/nmn/linen/_yat_core.py
+++ b/src/nmn/linen/_yat_core.py
@@ -15,8 +15,9 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
-from jax.custom_transpose import custom_transpose
 from jax import Array
+from jax.extend import core
+from jax.interpreters import ad, batching, mlir
 
 
 __all__ = [
@@ -28,6 +29,46 @@ __all__ = [
 ]
 
 
+_saturating_tangent_upcast_p = core.Primitive("nmn_saturating_tangent_upcast")
+
+
+def _saturating_tangent_upcast_impl(value, *, target_dtype):
+    del target_dtype
+    return value.astype(jnp.float32)
+
+
+_saturating_tangent_upcast_p.def_impl(_saturating_tangent_upcast_impl)
+_saturating_tangent_upcast_p.def_abstract_eval(
+    lambda value, *, target_dtype: jax.core.ShapedArray(
+        value.shape, jnp.dtype("float32")
+    )
+)
+mlir.register_lowering(
+    _saturating_tangent_upcast_p,
+    mlir.lower_fun(_saturating_tangent_upcast_impl, multiple_results=False),
+)
+
+
+def _saturating_tangent_upcast_transpose(cotangent, *, target_dtype):
+    limits = jnp.finfo(target_dtype)
+    cotangent = jnp.clip(cotangent, limits.min, limits.max)
+    return (cotangent.astype(target_dtype),)
+
+
+ad.deflinear(
+    _saturating_tangent_upcast_p, _saturating_tangent_upcast_transpose
+)
+
+
+def _saturating_tangent_upcast_batch(args, dimensions, **params):
+    return _saturating_tangent_upcast_p.bind(*args, **params), dimensions[0]
+
+
+batching.primitive_batchers[_saturating_tangent_upcast_p] = (
+    _saturating_tangent_upcast_batch
+)
+
+
 @jax.custom_jvp
 def _reduction_safe_upcast(value):
     return value.astype(jnp.float32)
@@ -37,20 +78,9 @@ def _reduction_safe_upcast(value):
 def _reduction_safe_upcast_jvp(primals, tangents):
     (value,), (tangent,) = primals, tangents
     output = _reduction_safe_upcast(value)
-
-    @custom_transpose
-    def tangent_cast(dtype_anchor, tangent_value):
-        del dtype_anchor
-        return tangent_value.astype(jnp.float32)
-
-    @tangent_cast.def_transpose
-    def tangent_cast_transpose(dtype_anchor, cotangent):
-        limits = jnp.finfo(dtype_anchor.dtype)
-        cotangent = jnp.clip(cotangent, limits.min, limits.max)
-        return (cotangent.astype(dtype_anchor.dtype),)
-
-    tangent_output_type = jax.typeof(output).to_tangent_aval()
-    tangent_output = tangent_cast(tangent_output_type, value, tangent)
+    tangent_output = _saturating_tangent_upcast_p.bind(
+        tangent, target_dtype=value.dtype
+    )
     return output, tangent_output
 
 

--- a/src/nmn/linen/_yat_core.py
+++ b/src/nmn/linen/_yat_core.py
@@ -15,42 +15,63 @@ from typing import Optional
 
 import jax
 import jax.numpy as jnp
+from jax.custom_transpose import custom_transpose
 from jax import Array
 
 
 __all__ = [
     "reduction_safe_upcast",
     "safe_kernel_init",
+    "saturating_downcast",
     "upcast_yat_operands",
     "yat_score",
 ]
 
 
-@jax.custom_vjp
+@jax.custom_jvp
 def _reduction_safe_upcast(value):
     return value.astype(jnp.float32)
 
 
-def _reduction_safe_upcast_fwd(value):
-    return value.astype(jnp.float32), jnp.zeros((), dtype=value.dtype)
+@_reduction_safe_upcast.defjvp
+def _reduction_safe_upcast_jvp(primals, tangents):
+    (value,), (tangent,) = primals, tangents
+    output = _reduction_safe_upcast(value)
 
+    @custom_transpose
+    def tangent_cast(dtype_anchor, tangent_value):
+        del dtype_anchor
+        return tangent_value.astype(jnp.float32)
 
-def _reduction_safe_upcast_bwd(dtype_anchor, cotangent):
-    limits = jnp.finfo(dtype_anchor.dtype)
-    cotangent = jnp.clip(cotangent, limits.min, limits.max)
-    return (cotangent.astype(dtype_anchor.dtype),)
+    @tangent_cast.def_transpose
+    def tangent_cast_transpose(dtype_anchor, cotangent):
+        limits = jnp.finfo(dtype_anchor.dtype)
+        cotangent = jnp.clip(cotangent, limits.min, limits.max)
+        return (cotangent.astype(dtype_anchor.dtype),)
 
-
-_reduction_safe_upcast.defvjp(
-    _reduction_safe_upcast_fwd, _reduction_safe_upcast_bwd
-)
+    tangent_output_type = jax.typeof(output).to_tangent_aval()
+    tangent_output = tangent_cast(tangent_output_type, value, tangent)
+    return output, tangent_output
 
 
 def reduction_safe_upcast(value):
-    """Upcast lowp values after aggregating and saturating their cotangent."""
+    """Upcast lowp arithmetic with JVP and operator-local VJP saturation.
+
+    The custom transpose clips a single returning aggregate cotangent while
+    leaving forward-mode tangents unchanged. Separate paths may still be added
+    later at a shared low-precision leaf and overflow; use fp32 storage there.
+    """
     if value.dtype in (jnp.float16, jnp.bfloat16):
         return _reduction_safe_upcast(value)
     return value
+
+
+def saturating_downcast(value, dtype):
+    """Two-sided finite cast to a low-precision public output dtype."""
+    if dtype in (jnp.float16, jnp.bfloat16):
+        limits = jnp.finfo(dtype)
+        value = jnp.clip(value, limits.min, limits.max)
+    return value.astype(dtype)
 
 
 def safe_kernel_init(initializer):
@@ -117,4 +138,4 @@ def yat_score(
     if alpha is not None:
         y = y * alpha
 
-    return y.astype(output_dtype)
+    return saturating_downcast(y, output_dtype) if output_dtype is not None else y

--- a/src/nmn/linen/_yat_core.py
+++ b/src/nmn/linen/_yat_core.py
@@ -18,7 +18,39 @@ import jax.numpy as jnp
 from jax import Array
 
 
-__all__ = ["safe_kernel_init", "upcast_yat_operands", "yat_score"]
+__all__ = [
+    "reduction_safe_upcast",
+    "safe_kernel_init",
+    "upcast_yat_operands",
+    "yat_score",
+]
+
+
+@jax.custom_vjp
+def _reduction_safe_upcast(value):
+    return value.astype(jnp.float32)
+
+
+def _reduction_safe_upcast_fwd(value):
+    return value.astype(jnp.float32), jnp.zeros((), dtype=value.dtype)
+
+
+def _reduction_safe_upcast_bwd(dtype_anchor, cotangent):
+    limits = jnp.finfo(dtype_anchor.dtype)
+    cotangent = jnp.clip(cotangent, limits.min, limits.max)
+    return (cotangent.astype(dtype_anchor.dtype),)
+
+
+_reduction_safe_upcast.defvjp(
+    _reduction_safe_upcast_fwd, _reduction_safe_upcast_bwd
+)
+
+
+def reduction_safe_upcast(value):
+    """Upcast lowp values after aggregating and saturating their cotangent."""
+    if value.dtype in (jnp.float16, jnp.bfloat16):
+        return _reduction_safe_upcast(value)
+    return value
 
 
 def safe_kernel_init(initializer):
@@ -39,10 +71,10 @@ def upcast_yat_operands(inputs, kernel, bias, alpha):
     """Return score operands in fp32 for fp16/bf16 computation policies."""
     output_dtype = inputs.dtype
     if output_dtype in (jnp.float16, jnp.bfloat16):
-        inputs = inputs.astype(jnp.float32)
-        kernel = kernel.astype(jnp.float32)
-        bias = bias.astype(jnp.float32) if bias is not None else None
-        alpha = alpha.astype(jnp.float32) if alpha is not None else None
+        inputs = reduction_safe_upcast(inputs)
+        kernel = reduction_safe_upcast(kernel)
+        bias = reduction_safe_upcast(bias) if bias is not None else None
+        alpha = reduction_safe_upcast(alpha) if alpha is not None else None
     return inputs, kernel, bias, alpha, output_dtype
 
 

--- a/src/nmn/linen/_yat_core.py
+++ b/src/nmn/linen/_yat_core.py
@@ -18,7 +18,32 @@ import jax.numpy as jnp
 from jax import Array
 
 
-__all__ = ["yat_score"]
+__all__ = ["safe_kernel_init", "upcast_yat_operands", "yat_score"]
+
+
+def safe_kernel_init(initializer):
+    """Run decomposition-based initializers in fp32 before a lowp cast.
+
+    JAX's CPU QR kernel does not accept float16, which made the default
+    orthogonal convolution initializer fail before the layer could run.
+    """
+    def init(key, shape, dtype):
+        if dtype in (jnp.float16, jnp.bfloat16):
+            return initializer(key, shape, jnp.float32).astype(dtype)
+        return initializer(key, shape, dtype)
+
+    return init
+
+
+def upcast_yat_operands(inputs, kernel, bias, alpha):
+    """Return score operands in fp32 for fp16/bf16 computation policies."""
+    output_dtype = inputs.dtype
+    if output_dtype in (jnp.float16, jnp.bfloat16):
+        inputs = inputs.astype(jnp.float32)
+        kernel = kernel.astype(jnp.float32)
+        bias = bias.astype(jnp.float32) if bias is not None else None
+        alpha = alpha.astype(jnp.float32) if alpha is not None else None
+    return inputs, kernel, bias, alpha, output_dtype
 
 
 def yat_score(
@@ -29,6 +54,7 @@ def yat_score(
     epsilon: float,
     epsilon_param: Optional[Array],
     alpha: Optional[Array],
+    output_dtype=None,
 ) -> Array:
     """Apply bias / epsilon / YAT-divide / alpha to a raw conv output.
 
@@ -41,7 +67,8 @@ def yat_score(
         bias_broadcast_shape = (1,) * (dot_prod_map.ndim - 1) + (-1,)
         dot_prod_map = dot_prod_map + bias.reshape(bias_broadcast_shape)
 
-    output_dtype = dot_prod_map.dtype
+    if output_dtype is None:
+        output_dtype = dot_prod_map.dtype
     if epsilon_param is not None:
         score_dtype = jnp.promote_types(dot_prod_map.dtype, epsilon_param.dtype)
         eps = jax.nn.softplus(epsilon_param.astype(score_dtype))
@@ -50,6 +77,9 @@ def yat_score(
     else:
         eps = epsilon
 
+    # Squared distances are non-negative; clamp cancellation noise while
+    # retaining NaNs from genuinely invalid inputs.
+    distance_sq = jnp.maximum(distance_sq, 0.0)
     y = dot_prod_map ** 2 / (distance_sq + eps)
 
     if alpha is not None:

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -16,7 +16,7 @@ from nmn._epsilon import (
     validate_epsilon_for_dtype,
 )
 
-from ._yat_core import yat_score
+from ._yat_core import safe_kernel_init, upcast_yat_operands, yat_score
 
 
 def _epsilon_dtype(param_dtype, epsilon):
@@ -112,7 +112,7 @@ class YatConv1D(_EpsilonValidatedModule):
         # Kernel shape: [kernel_size, input_channels // groups, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, self.features)
         
-        kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
+        kernel = self.param('kernel', safe_kernel_init(self.kernel_init), kernel_shape, self.param_dtype)
         
         if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
@@ -140,6 +140,9 @@ class YatConv1D(_EpsilonValidatedModule):
             epsilon_param = None
         
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        inputs, kernel, bias, alpha, output_dtype = upcast_yat_operands(
+            inputs, kernel, bias, alpha
+        )
         
         # Compute dot product using lax.conv_general_dilated
         dn = lax.conv_dimension_numbers(inputs.shape, kernel.shape, ('NWC', 'WIO', 'NWC'))
@@ -192,6 +195,7 @@ class YatConv1D(_EpsilonValidatedModule):
         return yat_score(
             dot_prod_map, distance_sq,
             bias=bias, epsilon=self.epsilon, epsilon_param=epsilon_param, alpha=alpha,
+            output_dtype=output_dtype,
         )
 
 
@@ -252,7 +256,7 @@ class YatConv2D(_EpsilonValidatedModule):
         # Kernel shape: [height, width, input_channels // groups, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, self.features)
         
-        kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
+        kernel = self.param('kernel', safe_kernel_init(self.kernel_init), kernel_shape, self.param_dtype)
         
         if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
@@ -280,6 +284,9 @@ class YatConv2D(_EpsilonValidatedModule):
             epsilon_param = None
         
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        inputs, kernel, bias, alpha, output_dtype = upcast_yat_operands(
+            inputs, kernel, bias, alpha
+        )
         
         # Compute dot product using lax.conv_general_dilated
         dn = lax.conv_dimension_numbers(inputs.shape, kernel.shape, ('NHWC', 'HWIO', 'NHWC'))
@@ -329,6 +336,7 @@ class YatConv2D(_EpsilonValidatedModule):
         return yat_score(
             dot_prod_map, distance_sq,
             bias=bias, epsilon=self.epsilon, epsilon_param=epsilon_param, alpha=alpha,
+            output_dtype=output_dtype,
         )
 
 
@@ -389,7 +397,7 @@ class YatConv3D(_EpsilonValidatedModule):
         # Kernel shape: [depth, height, width, input_channels // groups, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels // self.feature_group_count, self.features)
         
-        kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
+        kernel = self.param('kernel', safe_kernel_init(self.kernel_init), kernel_shape, self.param_dtype)
         
         if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
@@ -417,6 +425,9 @@ class YatConv3D(_EpsilonValidatedModule):
             epsilon_param = None
         
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        inputs, kernel, bias, alpha, output_dtype = upcast_yat_operands(
+            inputs, kernel, bias, alpha
+        )
         
         # Compute dot product using lax.conv_general_dilated
         dn = lax.conv_dimension_numbers(inputs.shape, kernel.shape, ('NDHWC', 'DHWIO', 'NDHWC'))
@@ -466,6 +477,7 @@ class YatConv3D(_EpsilonValidatedModule):
         return yat_score(
             dot_prod_map, distance_sq,
             bias=bias, epsilon=self.epsilon, epsilon_param=epsilon_param, alpha=alpha,
+            output_dtype=output_dtype,
         )
 
 
@@ -517,7 +529,7 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
         # Kernel shape for transpose conv: [kernel_size, in_channels, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels, self.features)
 
-        kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
+        kernel = self.param('kernel', safe_kernel_init(self.kernel_init), kernel_shape, self.param_dtype)
 
         if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
@@ -545,6 +557,9 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
             epsilon_param = None
 
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        inputs, kernel, bias, alpha, output_dtype = upcast_yat_operands(
+            inputs, kernel, bias, alpha
+        )
 
         # Compute transposed convolution using lax.conv_transpose
         dn = lax.conv_dimension_numbers(inputs.shape, kernel.shape, ('NWC', 'WIO', 'NWC'))
@@ -582,6 +597,7 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
         return yat_score(
             dot_prod_map, distance_sq,
             bias=bias, epsilon=self.epsilon, epsilon_param=epsilon_param, alpha=alpha,
+            output_dtype=output_dtype,
         )
 
 
@@ -633,7 +649,7 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
         # Kernel shape for transpose conv: [height, width, in_channels, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels, self.features)
 
-        kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
+        kernel = self.param('kernel', safe_kernel_init(self.kernel_init), kernel_shape, self.param_dtype)
 
         if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
@@ -661,6 +677,9 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
             epsilon_param = None
 
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        inputs, kernel, bias, alpha, output_dtype = upcast_yat_operands(
+            inputs, kernel, bias, alpha
+        )
 
         # Compute transposed convolution using lax.conv_transpose
         dn = lax.conv_dimension_numbers(inputs.shape, kernel.shape, ('NHWC', 'HWIO', 'NHWC'))
@@ -698,6 +717,7 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
         return yat_score(
             dot_prod_map, distance_sq,
             bias=bias, epsilon=self.epsilon, epsilon_param=epsilon_param, alpha=alpha,
+            output_dtype=output_dtype,
         )
 
 
@@ -749,7 +769,7 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
         # Kernel shape for transpose conv: [depth, height, width, in_channels, features]
         kernel_shape = tuple(self.kernel_size) + (input_channels, self.features)
 
-        kernel = self.param('kernel', self.kernel_init, kernel_shape, self.param_dtype)
+        kernel = self.param('kernel', safe_kernel_init(self.kernel_init), kernel_shape, self.param_dtype)
 
         if self.constant_bias is not None and self.constant_bias is not False:
             bias = jnp.full((self.features,), float(self.constant_bias), dtype=self.param_dtype)
@@ -777,6 +797,9 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
             epsilon_param = None
 
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        inputs, kernel, bias, alpha, output_dtype = upcast_yat_operands(
+            inputs, kernel, bias, alpha
+        )
 
         # Compute transposed convolution using lax.conv_transpose
         dn = lax.conv_dimension_numbers(inputs.shape, kernel.shape, ('NDHWC', 'DHWIO', 'NDHWC'))
@@ -814,6 +837,7 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
         return yat_score(
             dot_prod_map, distance_sq,
             bias=bias, epsilon=self.epsilon, epsilon_param=epsilon_param, alpha=alpha,
+            output_dtype=output_dtype,
         )
 
 

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -29,6 +29,8 @@ def _epsilon_dtype(param_dtype, epsilon):
     validate_epsilon_for_dtype(epsilon, dtype)
     return dtype
 
+from ._yat_core import reduction_safe_upcast
+
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
@@ -202,10 +204,10 @@ class YatNMN(Module):
             # The expanded distance and squared numerator can overflow fp16
             # even when their ratio is finite.  Match NNX by performing all YAT
             # score arithmetic in fp32 and casting only the final output.
-            inputs = inputs.astype(jnp.float32)
-            kernel = kernel.astype(jnp.float32)
-            bias = bias.astype(jnp.float32) if bias is not None else None
-            alpha = alpha.astype(jnp.float32) if alpha is not None else None
+            inputs = reduction_safe_upcast(inputs)
+            kernel = reduction_safe_upcast(kernel)
+            bias = reduction_safe_upcast(bias) if bias is not None else None
+            alpha = reduction_safe_upcast(alpha) if alpha is not None else None
 
         # Spherical mode: normalize inputs and each kernel row (neuron) to unit norm.
         # Linen kernel shape is (features, input_dim), so each row is a neuron → axis=-1.

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -29,7 +29,7 @@ def _epsilon_dtype(param_dtype, epsilon):
     validate_epsilon_for_dtype(epsilon, dtype)
     return dtype
 
-from ._yat_core import reduction_safe_upcast
+from ._yat_core import reduction_safe_upcast, saturating_downcast
 
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
@@ -274,7 +274,7 @@ class YatNMN(Module):
             # Simple learnable alpha scaling
             y = y * alpha
 
-        y = y.astype(output_dtype)
+        y = saturating_downcast(y, output_dtype)
         if self.return_weights:
            return y, return_kernel
         return y

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -196,6 +196,16 @@ class YatNMN(Module):
             epsilon_param = None
 
         inputs, kernel, bias, alpha = promote_dtype(inputs, kernel, bias, alpha, dtype=self.dtype)
+        output_dtype = inputs.dtype
+        return_kernel = kernel
+        if output_dtype in (jnp.float16, jnp.bfloat16):
+            # The expanded distance and squared numerator can overflow fp16
+            # even when their ratio is finite.  Match NNX by performing all YAT
+            # score arithmetic in fp32 and casting only the final output.
+            inputs = inputs.astype(jnp.float32)
+            kernel = kernel.astype(jnp.float32)
+            bias = bias.astype(jnp.float32) if bias is not None else None
+            alpha = alpha.astype(jnp.float32) if alpha is not None else None
 
         # Spherical mode: normalize inputs and each kernel row (neuron) to unit norm.
         # Linen kernel shape is (features, input_dim), so each row is a neuron → axis=-1.
@@ -263,7 +273,6 @@ class YatNMN(Module):
             y = y * alpha
 
         y = y.astype(output_dtype)
-
         if self.return_weights:
-           return y, kernel
+           return y, return_kernel
         return y

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -255,7 +255,6 @@ class YatNMN(Module):
             y += jnp.reshape(bias, (1,) * (y.ndim - 1) + (-1,))
 
         # Resolve effective epsilon (learnable via softplus, or constant)
-        output_dtype = y.dtype
         if epsilon_param is not None:
             score_dtype = jnp.promote_types(y.dtype, epsilon_param.dtype)
             eps = jax.nn.softplus(epsilon_param.astype(score_dtype))

--- a/src/nmn/nnx/layers/attention/yat_attention.py
+++ b/src/nmn/nnx/layers/attention/yat_attention.py
@@ -41,6 +41,7 @@ from flax.nnx.nn.dtypes import promote_dtype
 from flax.typing import Dtype, PrecisionLike
 from jax import Array
 
+from nmn.nnx.layers._numerics import fp32_if_low_precision
 from nmn.nnx.layers.squashers import softermax
 
 from ._attention_core import finalize_attention_weights
@@ -116,8 +117,11 @@ def yat_attention_weights(
     # YAT scores grow as O(dot²) — squaring the dot product causes
     # overflow in bf16 (7-bit mantissa, exp() overflows at ~88).
     # All score math runs in f32; we cast back after softmax.
-    query_f32 = query.astype(jnp.float32)
-    key_f32 = key.astype(jnp.float32)
+    query_f32, key_f32 = fp32_if_low_precision(query, key)
+    alpha_val = (
+        fp32_if_low_precision(alpha)[0] if hasattr(alpha, "dtype") else alpha
+    )
+    bias_val = fp32_if_low_precision(bias)[0] if bias is not None else None
 
     # Calculate dot product: q·k
     dot_product = jnp.einsum(
@@ -151,8 +155,11 @@ def yat_attention_weights(
     # All score math stays in float32 — cast alpha / bias accordingly so the
     # shared tail can run in f32 too, then it casts the final softmax /
     # softermax / l1 output back to the caller's `dtype`.
-    alpha_val = jnp.asarray(alpha, dtype=jnp.float32) if alpha is not None else None
-    bias_val = bias.astype(jnp.float32) if bias is not None else None
+    alpha_val = (
+        jnp.asarray(alpha_val, dtype=jnp.float32)
+        if alpha_val is not None else None
+    )
+    bias_val = bias_val.astype(jnp.float32) if bias_val is not None else None
 
     return finalize_attention_weights(
         attn_weights,
@@ -604,4 +611,3 @@ def create_yat_projection(
         return projection * jnp.sqrt(head_dim).astype(dtype)
     else:
         return random.normal(key, (num_features, head_dim), dtype=dtype)
-

--- a/src/nmn/tf/_precision.py
+++ b/src/nmn/tf/_precision.py
@@ -6,7 +6,12 @@ import tensorflow as tf
 
 
 def reduction_safe_upcast(value: tf.Tensor) -> tf.Tensor:
-    """Upcast lowp values and saturate their aggregated return cotangent."""
+    """Upcast lowp values and saturate one returning cotangent.
+
+    TensorFlow may subsequently add multiple finite cotangents at a reused
+    low-precision leaf.  An out-of-range final sum is inherently
+    unrepresentable; use fp32 variable/gradient storage when that is possible.
+    """
     value = tf.convert_to_tensor(value)
     if value.dtype not in (tf.float16, tf.bfloat16):
         return value
@@ -25,3 +30,11 @@ def reduction_safe_upcast(value: tf.Tensor) -> tf.Tensor:
         return result, grad
 
     return upcast(value)
+
+
+def saturating_downcast(value: tf.Tensor, dtype: tf.DType) -> tf.Tensor:
+    """Two-sided finite cast to a low-precision public output dtype."""
+    if dtype in (tf.float16, tf.bfloat16):
+        limits = 65504.0 if dtype == tf.float16 else 3.38953139e38
+        value = tf.clip_by_value(value, -limits, limits)
+    return tf.cast(value, dtype)

--- a/src/nmn/tf/_precision.py
+++ b/src/nmn/tf/_precision.py
@@ -1,0 +1,27 @@
+"""Autodiff-safe precision helpers for TensorFlow YAT layers."""
+
+from __future__ import annotations
+
+import tensorflow as tf
+
+
+def reduction_safe_upcast(value: tf.Tensor) -> tf.Tensor:
+    """Upcast lowp values and saturate their aggregated return cotangent."""
+    value = tf.convert_to_tensor(value)
+    if value.dtype not in (tf.float16, tf.bfloat16):
+        return value
+    max_value = 65504.0 if value.dtype == tf.float16 else 3.38953139e38
+    source_dtype = value.dtype
+
+    @tf.custom_gradient
+    def upcast(tensor):
+        result = tf.cast(tensor, tf.float32)
+
+        def grad(upstream):
+            upstream = tf.cast(upstream, tf.float32)
+            upstream = tf.clip_by_value(upstream, -max_value, max_value)
+            return tf.cast(upstream, source_dtype)
+
+        return result, grad
+
+    return upcast(value)

--- a/src/nmn/tf/_yat_core.py
+++ b/src/nmn/tf/_yat_core.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import tensorflow as tf
 
-from ._precision import reduction_safe_upcast
+from ._precision import reduction_safe_upcast, saturating_downcast
 
 
 __all__ = ["yat_score"]
@@ -54,4 +54,4 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
     if layer.use_alpha and layer.alpha is not None:
         y = y * reduction_safe_upcast(layer.alpha)
 
-    return tf.cast(y, output_dtype)
+    return saturating_downcast(y, layer.dtype)

--- a/src/nmn/tf/_yat_core.py
+++ b/src/nmn/tf/_yat_core.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import tensorflow as tf
 
+from ._precision import reduction_safe_upcast
+
 
 __all__ = ["yat_score"]
 
@@ -34,7 +36,7 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
         if layer._constant_bias_value is not None:
             dot_prod_map = dot_prod_map + tf.cast(layer._constant_bias_value, dot_prod_map.dtype)
         else:
-            dot_prod_map = dot_prod_map + tf.cast(layer.bias, dot_prod_map.dtype)
+            dot_prod_map = dot_prod_map + reduction_safe_upcast(layer.bias)
 
     # Resolve effective epsilon (learnable via softplus, or constant).
     output_dtype = dot_prod_map.dtype
@@ -50,6 +52,6 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
 
     # Optional alpha (learnable; constant_alpha is folded into layer.alpha).
     if layer.use_alpha and layer.alpha is not None:
-        y = y * tf.cast(layer.alpha, y.dtype)
+        y = y * reduction_safe_upcast(layer.alpha)
 
     return tf.cast(y, output_dtype)

--- a/src/nmn/tf/_yat_core.py
+++ b/src/nmn/tf/_yat_core.py
@@ -32,9 +32,9 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
     # Add bias before squaring (constant or learnable).
     if layer.use_bias:
         if layer._constant_bias_value is not None:
-            dot_prod_map = dot_prod_map + tf.cast(layer._constant_bias_value, layer.dtype)
+            dot_prod_map = dot_prod_map + tf.cast(layer._constant_bias_value, dot_prod_map.dtype)
         else:
-            dot_prod_map = dot_prod_map + layer.bias
+            dot_prod_map = dot_prod_map + tf.cast(layer.bias, dot_prod_map.dtype)
 
     # Resolve effective epsilon (learnable via softplus, or constant).
     output_dtype = dot_prod_map.dtype
@@ -46,7 +46,7 @@ def yat_score(layer, dot_prod_map, distance_sq_map):
         eps = layer.epsilon
 
     # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps).
-    y = dot_prod_map ** 2 / (distance_sq_map + eps)
+    y = dot_prod_map ** 2 / (tf.maximum(distance_sq_map, 0.0) + eps)
 
     # Optional alpha (learnable; constant_alpha is folded into layer.alpha).
     if layer.use_alpha and layer.alpha is not None:

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -14,6 +14,7 @@ from typing import Optional, Tuple, Union
 import tensorflow as tf
 
 from .saved_model import ExportPath, export_attention
+from ._precision import reduction_safe_upcast
 
 __all__ = [
     "normalize_qk",
@@ -70,9 +71,9 @@ def yat_attention_weights(
     """
     output_dtype = query.dtype
     if output_dtype in (tf.float16, tf.bfloat16):
-        query = tf.cast(query, tf.float32)
-        key = tf.cast(key, tf.float32)
-        alpha = tf.cast(alpha, tf.float32) if alpha is not None else None
+        query = reduction_safe_upcast(query)
+        key = reduction_safe_upcast(key)
+        alpha = reduction_safe_upcast(alpha) if alpha is not None else None
 
     # Scale by 1/√head_dim to match standard attention's score growth profile.
     head_dim = query.shape[-1]

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -68,6 +68,12 @@ def yat_attention_weights(
     Returns:
         Attention weights (batch, num_heads, q_len, kv_len).
     """
+    output_dtype = query.dtype
+    if output_dtype in (tf.float16, tf.bfloat16):
+        query = tf.cast(query, tf.float32)
+        key = tf.cast(key, tf.float32)
+        alpha = tf.cast(alpha, tf.float32) if alpha is not None else None
+
     # Scale by 1/√head_dim to match standard attention's score growth profile.
     head_dim = query.shape[-1]
     dim_scale = tf.sqrt(tf.cast(head_dim, query.dtype))
@@ -112,7 +118,7 @@ def yat_attention_weights(
     if dropout_rate > 0.0 and training:
         attn_weights = tf.nn.dropout(attn_weights, rate=dropout_rate)
 
-    return attn_weights
+    return tf.cast(attn_weights, output_dtype)
 
 
 def yat_attention(

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -11,6 +11,7 @@ from nmn._epsilon import (
 )
 
 from ._yat_core import yat_score
+from ._precision import reduction_safe_upcast
 from .saved_model import SingleInputSavedModelMixin
 
 
@@ -61,7 +62,7 @@ def _grouped_convolution(inputs, kernel, groups, convolution):
 def _upcast_yat_operands(inputs, kernel):
     """Accumulate low-precision convolutional YAT scores in float32."""
     if inputs.dtype in (tf.float16, tf.bfloat16):
-        return tf.cast(inputs, tf.float32), tf.cast(kernel, tf.float32)
+        return reduction_safe_upcast(inputs), reduction_safe_upcast(kernel)
     return inputs, kernel
 
 

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -58,6 +58,13 @@ def _grouped_convolution(inputs, kernel, groups, convolution):
     )
 
 
+def _upcast_yat_operands(inputs, kernel):
+    """Accumulate low-precision convolutional YAT scores in float32."""
+    if inputs.dtype in (tf.float16, tf.bfloat16):
+        return tf.cast(inputs, tf.float32), tf.cast(kernel, tf.float32)
+    return inputs, kernel
+
+
 class YatConv1D(SingleInputSavedModelMixin, tf.Module):
     """1D YAT convolution module using TensorFlow operations.
     
@@ -201,6 +208,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
         """
         inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
         self._maybe_build(inputs)
+        inputs, kernel = _upcast_yat_operands(inputs, self.kernel)
 
         # Compute dot product using standard convolution
         convolution = lambda x, kernel: tf.nn.conv1d(
@@ -211,7 +219,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
             dilations=self.dilation_rate,
         )
         dot_prod_map = _grouped_convolution(
-            inputs, self.kernel, self.groups, convolution
+            inputs, kernel, self.groups, convolution
         )
 
         # Compute ||input_patches||^2 using convolution with ones kernel
@@ -222,7 +230,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
             (self.kernel_size,),
             self.input_channels // self.groups,
             self.groups,
-            self.dtype,
+            inputs.dtype,
         )
         
         patch_sq_sum_map_raw = _grouped_convolution(
@@ -239,7 +247,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
         )
 
         # Compute ||kernel||^2 per filter
-        kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1])  # Sum over spatial and input channel dims
+        kernel_sq_sum_per_filter = tf.reduce_sum(kernel**2, axis=[0, 1])  # Sum over spatial and input channel dims
 
         # Reshape for broadcasting: [1, 1, filters]
         kernel_sq_sum_reshaped = tf.reshape(kernel_sq_sum_per_filter, [1, 1, -1])
@@ -395,6 +403,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
         """
         inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
         self._maybe_build(inputs)
+        inputs, kernel = _upcast_yat_operands(inputs, self.kernel)
 
         # Compute dot product using standard convolution
         convolution = lambda x, kernel: tf.nn.conv2d(
@@ -405,7 +414,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
             dilations=[1] + list(self.dilation_rate) + [1],
         )
         dot_prod_map = _grouped_convolution(
-            inputs, self.kernel, self.groups, convolution
+            inputs, kernel, self.groups, convolution
         )
 
         # Compute ||input_patches||^2 using convolution with ones kernel
@@ -416,7 +425,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
             self.kernel_size,
             self.input_channels // self.groups,
             self.groups,
-            self.dtype,
+            inputs.dtype,
         )
         
         patch_sq_sum_map_raw = _grouped_convolution(
@@ -433,7 +442,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
         )
 
         # Compute ||kernel||^2 per filter
-        kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1, 2])  # Sum over spatial and input channel dims
+        kernel_sq_sum_per_filter = tf.reduce_sum(kernel**2, axis=[0, 1, 2])  # Sum over spatial and input channel dims
 
         # Reshape for broadcasting: [1, 1, 1, filters]
         kernel_sq_sum_reshaped = tf.reshape(kernel_sq_sum_per_filter, [1, 1, 1, -1])
@@ -590,6 +599,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
         """
         inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
         self._maybe_build(inputs)
+        inputs, kernel = _upcast_yat_operands(inputs, self.kernel)
 
         # Compute dot product using standard convolution
         convolution = lambda x, kernel: tf.nn.conv3d(
@@ -600,7 +610,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
             dilations=[1] + list(self.dilation_rate) + [1],
         )
         dot_prod_map = _grouped_convolution(
-            inputs, self.kernel, self.groups, convolution
+            inputs, kernel, self.groups, convolution
         )
 
         # Compute ||input_patches||^2 using convolution with ones kernel
@@ -611,7 +621,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
             self.kernel_size,
             self.input_channels // self.groups,
             self.groups,
-            self.dtype,
+            inputs.dtype,
         )
         
         patch_sq_sum_map_raw = _grouped_convolution(
@@ -628,7 +638,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
         )
 
         # Compute ||kernel||^2 per filter
-        kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1, 2, 3])  # Sum over spatial and input channel dims
+        kernel_sq_sum_per_filter = tf.reduce_sum(kernel**2, axis=[0, 1, 2, 3])  # Sum over spatial and input channel dims
 
         # Reshape for broadcasting: [1, 1, 1, 1, filters]
         kernel_sq_sum_reshaped = tf.reshape(kernel_sq_sum_per_filter, [1, 1, 1, 1, -1])
@@ -755,6 +765,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         """
         inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
         self._maybe_build(inputs)
+        inputs, kernel = _upcast_yat_operands(inputs, self.kernel)
 
         input_shape = tf.shape(inputs)
         batch_size = input_shape[0]
@@ -785,7 +796,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         # Transpose convolution
         dot_prod_map = tf.nn.conv1d_transpose(
             inputs,
-            self.kernel,
+            kernel,
             output_shape=output_shape,
             strides=strides,
             padding=self.padding,
@@ -796,7 +807,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         
         # Ones kernel for patch norms
         ones_kernel_shape = (kernel_size, 1, self.input_channels)
-        ones_kernel = tf.ones(ones_kernel_shape, dtype=self.dtype)
+        ones_kernel = tf.ones(ones_kernel_shape, dtype=inputs.dtype)
         
         patch_sq_sum_map_raw = tf.nn.conv1d_transpose(
             inputs_squared,
@@ -809,7 +820,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
         # Compute kernel squared sum
-        kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 2])
+        kernel_sq_sum_per_filter = tf.reduce_sum(kernel**2, axis=[0, 2])
         kernel_sq_sum_reshaped = tf.reshape(kernel_sq_sum_per_filter, [1, 1, -1])
 
         # YAT: (dot + bias) ** 2 / (||x - W|| ** 2 + eps) * alpha
@@ -935,6 +946,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         """
         inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
         self._maybe_build(inputs)
+        inputs, kernel = _upcast_yat_operands(inputs, self.kernel)
 
         batch_size = tf.shape(inputs)[0]
         input_height = tf.shape(inputs)[1]
@@ -953,7 +965,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         # Transpose convolution
         dot_prod_map = tf.nn.conv2d_transpose(
             inputs,
-            self.kernel,
+            kernel,
             output_shape=output_shape,
             strides=[1] + list(self.strides) + [1],
             padding=self.padding,
@@ -964,7 +976,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         
         # Ones kernel for patch norms
         ones_kernel_shape = self.kernel_size + (1, self.input_channels)
-        ones_kernel = tf.ones(ones_kernel_shape, dtype=self.dtype)
+        ones_kernel = tf.ones(ones_kernel_shape, dtype=inputs.dtype)
         
         patch_sq_sum_map_raw = tf.nn.conv2d_transpose(
             inputs_squared,
@@ -977,7 +989,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
         # Compute kernel squared sum
-        kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1, 3])
+        kernel_sq_sum_per_filter = tf.reduce_sum(kernel**2, axis=[0, 1, 3])
         kernel_sq_sum_reshaped = tf.reshape(kernel_sq_sum_per_filter, [1, 1, 1, -1])
 
         # YAT computation
@@ -1105,6 +1117,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         """
         inputs = tf.convert_to_tensor(inputs, dtype=self.dtype)
         self._maybe_build(inputs)
+        inputs, kernel = _upcast_yat_operands(inputs, self.kernel)
 
         batch_size = tf.shape(inputs)[0]
         input_depth = tf.shape(inputs)[1]
@@ -1126,7 +1139,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         # Transpose convolution
         dot_prod_map = tf.nn.conv3d_transpose(
             inputs,
-            self.kernel,
+            kernel,
             output_shape=output_shape,
             strides=[1] + list(self.strides) + [1],
             padding=self.padding,
@@ -1137,7 +1150,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         
         # Ones kernel for patch norms
         ones_kernel_shape = self.kernel_size + (1, self.input_channels)
-        ones_kernel = tf.ones(ones_kernel_shape, dtype=self.dtype)
+        ones_kernel = tf.ones(ones_kernel_shape, dtype=inputs.dtype)
         
         patch_sq_sum_map_raw = tf.nn.conv3d_transpose(
             inputs_squared,
@@ -1150,7 +1163,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
         # Compute kernel squared sum
-        kernel_sq_sum_per_filter = tf.reduce_sum(self.kernel**2, axis=[0, 1, 2, 4])
+        kernel_sq_sum_per_filter = tf.reduce_sum(kernel**2, axis=[0, 1, 2, 4])
         kernel_sq_sum_reshaped = tf.reshape(kernel_sq_sum_per_filter, [1, 1, 1, 1, -1])
 
         # YAT computation

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -214,7 +214,14 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         # Build if necessary
         self._maybe_build(inputs)
 
+        output_dtype = self.dtype
         kernel = self.kernel
+        # The expanded distance and squared numerator can overflow fp16 before
+        # their finite ratio is formed.  Score arithmetic is therefore always
+        # accumulated in fp32 for fp16/bf16 layers.
+        if output_dtype in (tf.float16, tf.bfloat16):
+            inputs = tf.cast(inputs, tf.float32)
+            kernel = tf.cast(kernel, tf.float32)
 
         # Spherical mode: normalize inputs and each kernel row (neuron) to unit norm.
         # TF kernel shape is (features, last_dim) → each row is a neuron → axis=-1.
@@ -260,11 +267,11 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
             bias_shape = [1] * (len(y.shape) - 1) + [-1]
             if self._constant_bias_value is not None:
                 bias_const = tf.constant(
-                    self._constant_bias_value, shape=[self.features], dtype=self.dtype
+                    self._constant_bias_value, shape=[self.features], dtype=kernel.dtype
                 )
                 y = y + tf.reshape(bias_const, bias_shape)
             else:
-                y = y + tf.reshape(self.bias, bias_shape)
+                y = y + tf.reshape(tf.cast(self.bias, y.dtype), bias_shape)
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
@@ -283,9 +290,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         elif self.alpha is not None:
             # Simple learnable alpha scaling
             y = y * tf.cast(self.alpha, y.dtype)
-
-        y = tf.cast(y, self.dtype)
-
+        y = tf.cast(y, output_dtype)
 
         if self.return_weights:
             return y, self.kernel

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -12,6 +12,7 @@ from nmn._epsilon import (
 )
 
 from .saved_model import SingleInputSavedModelMixin
+from ._precision import reduction_safe_upcast
 
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
@@ -220,8 +221,8 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         # their finite ratio is formed.  Score arithmetic is therefore always
         # accumulated in fp32 for fp16/bf16 layers.
         if output_dtype in (tf.float16, tf.bfloat16):
-            inputs = tf.cast(inputs, tf.float32)
-            kernel = tf.cast(kernel, tf.float32)
+            inputs = reduction_safe_upcast(inputs)
+            kernel = reduction_safe_upcast(kernel)
 
         # Spherical mode: normalize inputs and each kernel row (neuron) to unit norm.
         # TF kernel shape is (features, last_dim) → each row is a neuron → axis=-1.
@@ -271,7 +272,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
                 )
                 y = y + tf.reshape(bias_const, bias_shape)
             else:
-                y = y + tf.reshape(tf.cast(self.bias, y.dtype), bias_shape)
+                y = y + tf.reshape(reduction_safe_upcast(self.bias), bias_shape)
 
         # Resolve effective epsilon (learnable via softplus, or constant)
         if self.learnable_epsilon and self.epsilon_param is not None:
@@ -289,7 +290,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
             y = y * tf.cast(self._constant_alpha_value, y.dtype)
         elif self.alpha is not None:
             # Simple learnable alpha scaling
-            y = y * tf.cast(self.alpha, y.dtype)
+            y = y * reduction_safe_upcast(self.alpha)
         y = tf.cast(y, output_dtype)
 
         if self.return_weights:

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -12,7 +12,7 @@ from nmn._epsilon import (
 )
 
 from .saved_model import SingleInputSavedModelMixin
-from ._precision import reduction_safe_upcast
+from ._precision import reduction_safe_upcast, saturating_downcast
 
 # Default constant alpha value (sqrt(2))
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
@@ -291,7 +291,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         elif self.alpha is not None:
             # Simple learnable alpha scaling
             y = y * reduction_safe_upcast(self.alpha)
-        y = tf.cast(y, output_dtype)
+        y = saturating_downcast(y, output_dtype)
 
         if self.return_weights:
             return y, self.kernel

--- a/src/nmn/torch/_precision.py
+++ b/src/nmn/torch/_precision.py
@@ -53,7 +53,21 @@ else:  # pragma: no cover - compatibility path for torch 1.11-1.x
 
 
 def saturating_upcast(tensor: Tensor) -> Tensor:
-    """Return fp32 ``tensor`` with a finite low-precision gradient boundary."""
+    """Return fp32 ``tensor`` with an operator-local gradient boundary.
+
+    The boundary saturates one returning cotangent, but autograd may add
+    several such finite cotangents later at a shared low-precision leaf.  If
+    that final mathematical sum is outside the leaf dtype's range it can still
+    overflow; use fp32 parameter/gradient storage for that training regime.
+    """
     if tensor.dtype in (torch.float16, torch.bfloat16):
         return _SaturatingUpcast.apply(tensor)
     return tensor.float()
+
+
+def saturating_downcast(tensor: Tensor, dtype: torch.dtype) -> Tensor:
+    """Two-sided finite cast to a low-precision public output dtype."""
+    if dtype in (torch.float16, torch.bfloat16):
+        limits = torch.finfo(dtype)
+        tensor = tensor.clamp(min=limits.min, max=limits.max)
+    return tensor.to(dtype)

--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -28,6 +28,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
+from .._precision import saturating_upcast
+
 
 def normalize_qk(
     query: Tensor,
@@ -90,9 +92,9 @@ def yat_attention_weights(
         # dot^2 and the expanded squared distance both overflow/cancel readily
         # in fp16.  Keep score formation and softmax in fp32; only the bounded
         # normalized weights cross back to the caller's dtype.
-        query = query.float()
-        key = key.float()
-        alpha = alpha.float() if isinstance(alpha, Tensor) else alpha
+        query = saturating_upcast(query)
+        key = saturating_upcast(key)
+        alpha = saturating_upcast(alpha) if isinstance(alpha, Tensor) else alpha
     head_dim = query.shape[-1]
 
     # Scale by 1/√head_dim to match standard attention's score growth profile.

--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -85,6 +85,14 @@ def yat_attention_weights(
         Attention weights of shape (batch, num_heads, q_len, kv_len)
     """
     assert query.ndim == key.ndim == 4, "Expected (batch, seq, heads, dim)"
+    output_dtype = query.dtype
+    if output_dtype in (torch.float16, torch.bfloat16):
+        # dot^2 and the expanded squared distance both overflow/cancel readily
+        # in fp16.  Keep score formation and softmax in fp32; only the bounded
+        # normalized weights cross back to the caller's dtype.
+        query = query.float()
+        key = key.float()
+        alpha = alpha.float() if isinstance(alpha, Tensor) else alpha
     head_dim = query.shape[-1]
 
     # Scale by 1/√head_dim to match standard attention's score growth profile.
@@ -137,7 +145,7 @@ def yat_attention_weights(
     if dropout_p > 0.0 and training:
         attn_weights = F.dropout(attn_weights, p=dropout_p, training=True)
 
-    return attn_weights
+    return attn_weights.to(output_dtype)
 
 
 def yat_attention(

--- a/src/nmn/torch/embed.py
+++ b/src/nmn/torch/embed.py
@@ -14,7 +14,7 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn.parameter import Parameter
 
-from ._precision import saturating_upcast
+from ._precision import saturating_downcast, saturating_upcast
 
 __all__ = ["YatEmbed"]
 
@@ -157,4 +157,4 @@ class YatEmbed(nn.Module):
 
         if output_dtype in (torch.float16, torch.bfloat16):
             y = y.clamp(max=torch.finfo(output_dtype).max)
-        return y.to(output_dtype)
+        return saturating_downcast(y, output_dtype)

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -30,7 +30,7 @@ from nmn._epsilon import (
     validate_epsilon_for_dtype,
 )
 
-from .._precision import saturating_upcast
+from .._precision import saturating_downcast, saturating_upcast
 
 
 __all__ = [
@@ -320,9 +320,7 @@ def yat_conv_forward(
     ).clamp(min=0.0)
 
     output = _yat_score(layer, dot_prod_map, distance_sq, bias_val, alpha)
-    if output_dtype in (torch.float16, torch.bfloat16):
-        output = output.clamp(max=torch.finfo(output_dtype).max)
-    return output.to(output_dtype)
+    return saturating_downcast(output, output_dtype)
 
 
 # ----------------------------------------------------------------------
@@ -398,6 +396,4 @@ def yat_conv_transpose_forward(
     ).clamp(min=0.0)
 
     output = _yat_score(layer, dot_prod_map, distance_sq, bias_val, alpha)
-    if output_dtype in (torch.float16, torch.bfloat16):
-        output = output.clamp(max=torch.finfo(output_dtype).max)
-    return output.to(output_dtype)
+    return saturating_downcast(output, output_dtype)

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -14,7 +14,7 @@ from nmn._epsilon import (
     validate_epsilon_for_dtype,
 )
 
-from .._precision import saturating_upcast
+from .._precision import saturating_downcast, saturating_upcast
 
 __all__ = ["YatNMN"]
 
@@ -447,7 +447,7 @@ class YatNMN(nn.Module):
             # Simple learnable alpha scaling
             y = y * alpha_param
 
-        return y.to(output_dtype)
+        return saturating_downcast(y, output_dtype)
 
     def _apply(self, fn, recurse=True):
         if getattr(self, "tie_kernel_bank", False):

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -427,7 +427,6 @@ class YatNMN(nn.Module):
             distances = (inputs_squared_sum + kernel_squared_sum - 2 * dot_for_dist).clamp(min=0.0)
 
         # Resolve effective epsilon (learnable via softplus, or constant)
-        output_dtype = y.dtype
         if self.learnable_epsilon and self.epsilon_param is not None:
             score_dtype = torch.promote_types(distances.dtype, self.epsilon_param.dtype)
             eps = F.softplus(self.epsilon_param.to(score_dtype))

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -371,8 +371,18 @@ class YatNMN(nn.Module):
                 bias = F.softplus(bias)
         alpha_param = self.alpha if self.alpha is not None else None
 
-        # Promote all tensors to computation dtype
+        # Promote all tensors to computation dtype.  The YAT numerator grows as
+        # dot(x, w)^2 and the expanded distance can overflow fp16 even when the
+        # final ratio is perfectly representable.  Accumulate the complete
+        # geometric score in fp32 for both fp16 and bf16, then restore the
+        # public computation dtype at the output boundary.
         x, kernel, bias, alpha_param = self._promote_dtype(x, kernel, bias, alpha_param)
+        output_dtype = x.dtype
+        if output_dtype in (torch.float16, torch.bfloat16):
+            x = x.float()
+            kernel = kernel.float()
+            bias = bias.float() if bias is not None else None
+            alpha_param = alpha_param.float() if alpha_param is not None else None
 
         # Spherical mode: normalize inputs and kernel
         if self.spherical:

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -14,6 +14,8 @@ from nmn._epsilon import (
     validate_epsilon_for_dtype,
 )
 
+from .._precision import saturating_upcast
+
 __all__ = ["YatNMN"]
 
 
@@ -379,10 +381,13 @@ class YatNMN(nn.Module):
         x, kernel, bias, alpha_param = self._promote_dtype(x, kernel, bias, alpha_param)
         output_dtype = x.dtype
         if output_dtype in (torch.float16, torch.bfloat16):
-            x = x.float()
-            kernel = kernel.float()
-            bias = bias.float() if bias is not None else None
-            alpha_param = alpha_param.float() if alpha_param is not None else None
+            x = saturating_upcast(x)
+            kernel = saturating_upcast(kernel)
+            bias = saturating_upcast(bias) if bias is not None else None
+            alpha_param = (
+                saturating_upcast(alpha_param)
+                if alpha_param is not None else None
+            )
 
         # Spherical mode: normalize inputs and kernel
         if self.spherical:

--- a/tests/test_keras/test_low_precision_reductions.py
+++ b/tests/test_keras/test_low_precision_reductions.py
@@ -432,6 +432,40 @@ def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
     BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
     reason="requires a supported Keras autodiff backend",
 )
+def test_fp16_dense_aggregate_cotangents_match_saturated_fp32_reference():
+    def make(layer_dtype):
+        inputs = ops.full((4096, 2), 100.0, dtype=layer_dtype)
+        layer = YatNMN(
+            1, use_bias=False, use_alpha=False, epsilon=1.0,
+            kernel_initializer="zeros", dtype=layer_dtype,
+        )
+        layer(inputs)
+        layer.kernel.assign(
+            ops.convert_to_tensor([[-100.0], [-99.0]], dtype=layer_dtype)
+        )
+        return layer, inputs
+
+    reference, reference_inputs = make("float32")
+    lowp, lowp_inputs = make("float16")
+    reference_output, reference_gradients = keras_dense_value_and_gradients(
+        reference, reference_inputs
+    )
+    output, gradients = keras_dense_value_and_gradients(lowp, lowp_inputs)
+    np.testing.assert_allclose(
+        to_numpy(ops.cast(output, "float32")), to_numpy(reference_output),
+        rtol=5e-3, atol=2.0,
+    )
+    limit = np.finfo(np.float16)
+    for actual, expected in zip(gradients, reference_gradients):
+        clipped = np.clip(to_numpy(expected), limit.min, limit.max).astype(np.float16)
+        assert np.all(np.isfinite(to_numpy(actual)))
+        np.testing.assert_allclose(to_numpy(actual), clipped, rtol=5e-3, atol=8.0)
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
 @pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
 def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
     ref_output, ref_gradients = keras_attention_value_and_gradients("float32")

--- a/tests/test_keras/test_low_precision_reductions.py
+++ b/tests/test_keras/test_low_precision_reductions.py
@@ -15,6 +15,8 @@ from nmn.keras import (
     YatConvTranspose2D,
     YatConvTranspose3D,
     YatEmbed,
+    YatNMN,
+    yat_attention,
 )
 from nmn.keras._yat_core import stable_yat_ratio
 
@@ -166,6 +168,92 @@ def keras_embed_value_and_gradients(layer, query):
     pytest.skip("gradient regression requires a supported Keras autodiff backend")
 
 
+def keras_dense_value_and_gradients(layer, inputs):
+    if BACKEND == "jax":
+        import jax
+
+        variables = list(layer.trainable_variables)
+        values = [variable.value for variable in variables]
+        kernel_index = next(
+            i for i, variable in enumerate(variables) if variable is layer.kernel
+        )
+
+        def evaluate(input_value, kernel_value):
+            current = list(values)
+            current[kernel_index] = kernel_value
+            output, _ = layer.stateless_call(
+                current, layer.non_trainable_variables, input_value
+            )
+            return ops.sum(ops.cast(output, "float32")), output
+
+        (_, output), gradients = jax.value_and_grad(
+            evaluate, argnums=(0, 1), has_aux=True
+        )(inputs, values[kernel_index])
+        return output, gradients
+
+    if BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        input_value = inputs.detach().clone().requires_grad_(True)
+        output = layer(input_value)
+        gradients = torch.autograd.grad(
+            ops.sum(ops.cast(output, "float32")),
+            (input_value, layer.kernel.value),
+        )
+        return output, gradients
+
+    if BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        input_value = tf.Variable(inputs)
+        with tf.GradientTape() as tape:
+            output = layer(input_value)
+            loss = tf.reduce_sum(tf.cast(output, tf.float32))
+        gradients = tape.gradient(loss, (input_value, layer.kernel.value))
+        return output, gradients
+
+    pytest.skip("gradient regression requires a supported Keras autodiff backend")
+
+
+def keras_attention_value_and_gradients(dtype):
+    query = ops.full((1, 1, 1, 2), 100.0, dtype=dtype)
+    key = ops.full((1, 2, 1, 2), 100.0, dtype=dtype)
+    value = ops.convert_to_tensor([[[[1.0]], [[2.0]]]], dtype=dtype)
+
+    def attend(q, k, v):
+        return yat_attention(q, k, v, training=False, epsilon=1.0)
+
+    if BACKEND == "jax":
+        import jax
+
+        def loss(q, k, v):
+            output = attend(q, k, v)
+            return ops.sum(ops.cast(output, "float32")) * 0.015625
+
+        output = attend(query, key, value)
+        gradients = jax.grad(loss, argnums=(0, 1, 2))(query, key, value)
+        return output, gradients
+
+    if BACKEND == "torch":
+        query = query.detach().clone().requires_grad_(True)
+        key = key.detach().clone().requires_grad_(True)
+        value = value.detach().clone().requires_grad_(True)
+        output = attend(query, key, value)
+        gradients = pytest.importorskip("torch").autograd.grad(
+            ops.sum(ops.cast(output, "float32")) * 0.015625,
+            (query, key, value),
+        )
+        return output, gradients
+
+    if BACKEND == "tensorflow":
+        tf = pytest.importorskip("tensorflow")
+        query, key, value = tf.Variable(query), tf.Variable(key), tf.Variable(value)
+        with tf.GradientTape() as tape:
+            output = attend(query, key, value)
+            loss = tf.reduce_sum(tf.cast(output, tf.float32)) * 0.015625
+        return output, tape.gradient(loss, (query, key, value))
+
+    pytest.skip("gradient regression requires a supported Keras autodiff backend")
+
+
 @pytest.mark.skipif(
     BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
     reason="requires a supported Keras autodiff backend",
@@ -303,3 +391,70 @@ def test_low_precision_ratio_preserves_nan():
     assert np.isnan(to_numpy(output)[0, 0])
     assert np.isfinite(to_numpy(output)[0, 1])
     assert np.isnan(to_numpy(gradient)[0, 0])
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
+    def make(layer_dtype):
+        inputs = ops.full((1, 2), 100.0, dtype=layer_dtype)
+        layer = YatNMN(
+            1, use_bias=False, use_alpha=False, epsilon=1.0,
+            kernel_initializer="zeros", dtype=layer_dtype,
+        )
+        layer(inputs)
+        layer.kernel.assign(
+            ops.convert_to_tensor([[-100.0], [-99.0]], dtype=layer_dtype)
+        )
+        return layer, inputs
+
+    reference, reference_inputs = make("float32")
+    lowp, lowp_inputs = make(dtype)
+    reference_output, reference_gradients = keras_dense_value_and_gradients(
+        reference, reference_inputs
+    )
+    output, gradients = keras_dense_value_and_gradients(lowp, lowp_inputs)
+    np.testing.assert_allclose(
+        to_numpy(ops.cast(output, "float32")), to_numpy(reference_output),
+        rtol=5e-3, atol=0.15,
+    )
+    for actual, expected in zip(gradients, reference_gradients):
+        np.testing.assert_allclose(
+            to_numpy(ops.cast(actual, "float32")), to_numpy(expected),
+            rtol=5e-3, atol=0.15,
+        )
+
+
+@pytest.mark.skipif(
+    BACKEND not in SUPPORTED_GRADIENT_BACKENDS,
+    reason="requires a supported Keras autodiff backend",
+)
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
+    ref_output, ref_gradients = keras_attention_value_and_gradients("float32")
+    output, gradients = keras_attention_value_and_gradients(dtype)
+    np.testing.assert_allclose(
+        to_numpy(ops.cast(output, "float32")), to_numpy(ref_output), atol=2e-3
+    )
+    for actual, expected in zip(gradients, ref_gradients):
+        np.testing.assert_allclose(
+            to_numpy(ops.cast(actual, "float32")), to_numpy(expected),
+            rtol=7e-3, atol=8.0,
+        )
+
+
+def test_dense_and_attention_preserve_genuine_nan():
+    inputs = ops.convert_to_tensor([[np.nan, 1.0]], dtype="float16")
+    layer = YatNMN(
+        1, use_bias=False, use_alpha=False, kernel_initializer="ones",
+        dtype="float16",
+    )
+    assert np.isnan(to_numpy(layer(inputs))).all()
+
+    query = ops.convert_to_tensor([[[[np.nan, 100.0]]]], dtype="float16")
+    key = ops.full((1, 2, 1, 2), 100.0, dtype="float16")
+    value = ops.ones((1, 2, 1, 1), dtype="float16")
+    assert np.isnan(to_numpy(yat_attention(query, key, value))).all()

--- a/tests/test_keras/test_low_precision_reductions.py
+++ b/tests/test_keras/test_low_precision_reductions.py
@@ -18,7 +18,7 @@ from nmn.keras import (
     YatNMN,
     yat_attention,
 )
-from nmn.keras._yat_core import stable_yat_ratio
+from nmn.keras._yat_core import reduction_safe_upcast, stable_yat_ratio
 
 
 BACKEND = keras.backend.backend()
@@ -492,3 +492,35 @@ def test_dense_and_attention_preserve_genuine_nan():
     key = ops.full((1, 2, 1, 2), 100.0, dtype="float16")
     value = ops.ones((1, 2, 1, 1), dtype="float16")
     assert np.isnan(to_numpy(yat_attention(query, key, value))).all()
+
+
+def test_low_precision_attention_accepts_python_scalar_alpha():
+    query = ops.full((1, 1, 1, 2), 100.0, dtype="float16")
+    key = ops.full((1, 2, 1, 2), 99.0, dtype="float16")
+    value = ops.convert_to_tensor([[[[0.0]], [[1.0]]]], dtype="float16")
+    output = yat_attention(
+        query, key, value, alpha=1.0, training=False, epsilon=1.0
+    )
+    assert np.isfinite(to_numpy(output)).all()
+
+
+@pytest.mark.skipif(
+    BACKEND not in {"torch", "tensorflow"},
+    reason="documents lowp leaf accumulation on eager variable backends",
+)
+def test_reused_fp16_leaf_requires_fp32_gradient_storage():
+    if BACKEND == "torch":
+        torch = pytest.importorskip("torch")
+        lowp = torch.ones(1, dtype=torch.float16, requires_grad=True)
+        first = ops.sum(reduction_safe_upcast(lowp) * 40000.0)
+        second = ops.sum(reduction_safe_upcast(lowp) * 40000.0)
+        (gradient,) = torch.autograd.grad(first + second, (lowp,))
+    else:
+        tf = pytest.importorskip("tensorflow")
+        lowp = tf.Variable([1.0], dtype=tf.float16)
+        with tf.GradientTape() as tape:
+            first = ops.sum(reduction_safe_upcast(lowp) * 40000.0)
+            second = ops.sum(reduction_safe_upcast(lowp) * 40000.0)
+            total = first + second
+        gradient = tape.gradient(total, lowp)
+    assert np.isinf(to_numpy(gradient)).all()

--- a/tests/test_linen/test_low_precision_core_yat.py
+++ b/tests/test_linen/test_low_precision_core_yat.py
@@ -10,6 +10,7 @@ from nmn.linen import (
     YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
     YatNMN, yat_attention,
 )
+from nmn.linen._yat_core import reduction_safe_upcast
 
 
 LOWP_DTYPES = (jnp.float16, jnp.bfloat16)
@@ -52,6 +53,40 @@ def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
     np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), rtol=5e-3, atol=0.15)
     for actual, expected in zip(grads, ref_grads):
         np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
+
+
+def _aggregate_dense_grads(dtype, compiled=False):
+    layer = YatNMN(features=1, use_bias=True, use_alpha=True, epsilon=1.0,
+                   dtype=dtype, param_dtype=dtype)
+    x = jnp.full((4096, 2), 100.0, dtype=dtype)
+    variables = layer.init(jax.random.key(0), x)
+    params = dict(
+        variables["params"],
+        kernel=jnp.array([[-100.0, -99.0]], dtype=dtype),
+        bias=jnp.array([0.5], dtype=dtype),
+        alpha=jnp.array([1.25], dtype=dtype),
+    )
+
+    def loss(input_value, parameter_values):
+        return layer.apply({"params": parameter_values}, input_value).astype(jnp.float32).sum()
+
+    output = layer.apply({"params": params}, x)
+    gradient_fn = jax.grad(loss, argnums=(0, 1))
+    if compiled:
+        gradient_fn = jax.jit(gradient_fn)
+    return output, gradient_fn(x, params)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_dense_aggregate_cotangents_match_saturated_fp32_reference(compiled):
+    reference_output, reference_grads = _aggregate_dense_grads(jnp.float32, compiled)
+    output, grads = _aggregate_dense_grads(jnp.float16, compiled)
+    limit = jnp.finfo(jnp.float16)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(reference_output), rtol=5e-3, atol=2.0)
+    for actual, expected in zip(jax.tree.leaves(grads), jax.tree.leaves(reference_grads)):
+        clipped = jnp.asarray(jnp.clip(expected, limit.min, limit.max), jnp.float16)
+        assert jnp.all(jnp.isfinite(actual))
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(clipped), rtol=5e-3, atol=8.0)
 
 
 def _conv_value_and_grads(layer_cls, shape, kernel_size, dtype):
@@ -118,6 +153,33 @@ def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
         np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=7e-3, atol=8.0)
 
 
+def _aggregate_attention_grads(dtype, compiled=False):
+    query = jnp.full((1, 1, 1, 2), 100.0, dtype=dtype)
+    key = jnp.full((1, 2, 1, 2), 99.0, dtype=dtype)
+    value = jnp.array([[[[0.0]], [[1.0]]]], dtype=dtype)
+
+    def loss(q, k, v):
+        return yat_attention(q, k, v, deterministic=True, epsilon=1.0).astype(jnp.float32).sum()
+
+    output = yat_attention(query, key, value, deterministic=True, epsilon=1.0)
+    gradient_fn = jax.grad(loss, argnums=(0, 1, 2))
+    if compiled:
+        gradient_fn = jax.jit(gradient_fn)
+    return output, gradient_fn(query, key, value)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_attention_aggregate_cotangents_match_saturated_fp32_reference(compiled):
+    reference_output, reference_grads = _aggregate_attention_grads(jnp.float32, compiled)
+    output, grads = _aggregate_attention_grads(jnp.float16, compiled)
+    limit = jnp.finfo(jnp.float16)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(reference_output), atol=2e-3)
+    for actual, expected in zip(grads, reference_grads):
+        clipped = jnp.asarray(jnp.clip(expected, limit.min, limit.max), jnp.float16)
+        assert jnp.all(jnp.isfinite(actual))
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(clipped), rtol=7e-3, atol=8.0)
+
+
 def test_low_precision_core_preserves_genuine_nan():
     layer = YatNMN(
         features=1, use_bias=False, use_alpha=False, dtype=jnp.float16,
@@ -139,3 +201,8 @@ def test_low_precision_core_preserves_genuine_nan():
     key = jnp.full((1, 2, 1, 2), 100.0, dtype=jnp.float16)
     value = jnp.ones((1, 2, 1, 1), dtype=jnp.float16)
     assert jnp.isnan(yat_attention(query, key, value, deterministic=True)).all()
+
+    gradient = jax.grad(
+        lambda value: (reduction_safe_upcast(value) * jnp.nan).sum()
+    )(jnp.ones((1,), dtype=jnp.float16))
+    assert jnp.isnan(gradient).all()

--- a/tests/test_linen/test_low_precision_core_yat.py
+++ b/tests/test_linen/test_low_precision_core_yat.py
@@ -1,0 +1,141 @@
+"""Large-magnitude low-precision regressions for Linen YAT arithmetic."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from nmn.linen import (
+    YatConv1D, YatConv2D, YatConv3D,
+    YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
+    YatNMN, yat_attention,
+)
+
+
+LOWP_DTYPES = (jnp.float16, jnp.bfloat16)
+CONVS = (
+    (YatConv1D, (1, 1, 1), (1,)),
+    (YatConv2D, (1, 1, 1, 1), (1, 1)),
+    (YatConv3D, (1, 1, 1, 1, 1), (1, 1, 1)),
+    (YatConvTranspose1D, (1, 1, 1), (1,)),
+    (YatConvTranspose2D, (1, 1, 1, 1), (1, 1)),
+    (YatConvTranspose3D, (1, 1, 1, 1, 1), (1, 1, 1)),
+)
+
+
+def _as_f32(value):
+    return np.asarray(value, dtype=np.float32)
+
+
+def _dense_value_and_grads(dtype):
+    layer = YatNMN(features=1, use_bias=False, use_alpha=False, epsilon=1.0,
+                   dtype=dtype, param_dtype=dtype)
+    x = jnp.array([[100.0, 100.0]], dtype=dtype)
+    variables = layer.init(jax.random.key(0), x)
+    kernel = jnp.array([[-100.0, -99.0]], dtype=dtype)
+
+    def loss(input_value, kernel_value):
+        params = dict(variables["params"], kernel=kernel_value)
+        return layer.apply({"params": params}, input_value).astype(jnp.float32).sum()
+
+    output = layer.apply(
+        {"params": dict(variables["params"], kernel=kernel)}, x
+    )
+    gradients = jax.grad(loss, argnums=(0, 1))(x, kernel)
+    return output, gradients
+
+
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
+    ref_output, ref_grads = _dense_value_and_grads(jnp.float32)
+    output, grads = _dense_value_and_grads(dtype)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), rtol=5e-3, atol=0.15)
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
+
+
+def _conv_value_and_grads(layer_cls, shape, kernel_size, dtype):
+    def constant(key, kernel_shape, init_dtype):
+        del key
+        return jnp.full(kernel_shape, -100.0, init_dtype)
+    layer = layer_cls(
+        features=1, kernel_size=kernel_size, use_bias=False, use_alpha=False,
+        epsilon=1.0, dtype=dtype, param_dtype=dtype, kernel_init=constant,
+    )
+    x = jnp.full(shape, 100.0, dtype=dtype)
+    variables = layer.init(jax.random.key(0), x)
+    kernel = variables["params"]["kernel"]
+
+    def loss(input_value, kernel_value):
+        return layer.apply(
+            {"params": {"kernel": kernel_value}}, input_value
+        ).astype(jnp.float32).sum()
+
+    output = layer.apply(variables, x)
+    gradients = jax.grad(loss, argnums=(0, 1))(x, kernel)
+    return output, gradients
+
+
+@pytest.mark.parametrize("layer_cls,shape,kernel_size", CONVS)
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_large_magnitude_conv_families_match_fp32(layer_cls, shape, kernel_size, dtype):
+    ref_output, ref_grads = _conv_value_and_grads(
+        layer_cls, shape, kernel_size, jnp.float32
+    )
+    output, grads = _conv_value_and_grads(layer_cls, shape, kernel_size, dtype)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), rtol=5e-3, atol=0.15)
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
+
+
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_default_orthogonal_conv_initializer_is_lowp_cpu_safe(dtype):
+    layer = YatConv1D(features=2, kernel_size=(1,), dtype=dtype, param_dtype=dtype)
+    variables = layer.init(jax.random.key(0), jnp.ones((1, 2, 2), dtype=dtype))
+    assert variables["params"]["kernel"].dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
+    def evaluate(q_dtype):
+        query = jnp.full((1, 1, 1, 2), 100.0, q_dtype)
+        key = jnp.full((1, 2, 1, 2), 100.0, q_dtype)
+        value = jnp.array([[[[1.0]], [[2.0]]]], q_dtype)
+        def fn(q, k, v):
+            return (
+                yat_attention(q, k, v, deterministic=True, epsilon=1.0)
+                .astype(jnp.float32)
+                .sum()
+                * 0.015625
+            )
+        output = yat_attention(query, key, value, deterministic=True, epsilon=1.0)
+        return output, jax.grad(fn, argnums=(0, 1, 2))(query, key, value)
+
+    ref_output, ref_grads = evaluate(jnp.float32)
+    output, grads = evaluate(dtype)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), atol=2e-3)
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=7e-3, atol=8.0)
+
+
+def test_low_precision_core_preserves_genuine_nan():
+    layer = YatNMN(
+        features=1, use_bias=False, use_alpha=False, dtype=jnp.float16,
+        param_dtype=jnp.float16,
+        kernel_init=lambda key, shape, dtype: jnp.ones(shape, dtype),
+    )
+    x = jnp.array([[jnp.nan, 1.0]], dtype=jnp.float16)
+    assert jnp.isnan(layer.apply(layer.init(jax.random.key(0), x), x)).all()
+
+    conv = YatConv1D(
+        features=1, kernel_size=(1,), use_bias=False, use_alpha=False,
+        dtype=jnp.float16, param_dtype=jnp.float16,
+        kernel_init=lambda key, shape, dtype: jnp.ones(shape, dtype),
+    )
+    conv_x = jnp.array([[[jnp.nan]]], dtype=jnp.float16)
+    assert jnp.isnan(conv.apply(conv.init(jax.random.key(1), conv_x), conv_x)).all()
+
+    query = jnp.array([[[[jnp.nan, 100.0]]]], dtype=jnp.float16)
+    key = jnp.full((1, 2, 1, 2), 100.0, dtype=jnp.float16)
+    value = jnp.ones((1, 2, 1, 1), dtype=jnp.float16)
+    assert jnp.isnan(yat_attention(query, key, value, deterministic=True)).all()

--- a/tests/test_linen/test_low_precision_core_yat.py
+++ b/tests/test_linen/test_low_precision_core_yat.py
@@ -332,6 +332,37 @@ def test_low_precision_dense_supports_jvp():
 
 
 @pytest.mark.parametrize("compiled", [False, True])
+def test_low_precision_dense_supports_jacfwd_and_batched_jvp(compiled):
+    layer = YatNMN(
+        features=1, use_bias=False, use_alpha=False, epsilon=1.0,
+        dtype=jnp.float16, param_dtype=jnp.float16,
+        kernel_init=lambda key, shape, dtype: jnp.full(shape, -100.0, dtype),
+    )
+    inputs = jnp.full((1, 2), 100.0, dtype=jnp.float16)
+    variables = layer.init(jax.random.key(9), inputs)
+
+    jacobian_fn = jax.jacfwd(lambda value: layer.apply(variables, value))
+    batched_jvp_fn = jax.vmap(
+        lambda value, tangent: jax.jvp(
+            lambda operand: layer.apply(variables, operand),
+            (value,),
+            (tangent,),
+        )
+    )
+    if compiled:
+        jacobian_fn = jax.jit(jacobian_fn)
+        batched_jvp_fn = jax.jit(batched_jvp_fn)
+
+    jacobian = jacobian_fn(inputs)
+    batched_inputs = jnp.broadcast_to(inputs, (3,) + inputs.shape)
+    primals, tangents = batched_jvp_fn(
+        batched_inputs, jnp.ones_like(batched_inputs)
+    )
+    assert jnp.isfinite(jacobian).all()
+    assert jnp.isfinite(primals).all() and jnp.isfinite(tangents).all()
+
+
+@pytest.mark.parametrize("compiled", [False, True])
 def test_reused_fp16_leaf_requires_fp32_gradient_storage(compiled):
     def lowp_loss(value):
         first = (reduction_safe_upcast(value) * 40000.0).sum()

--- a/tests/test_linen/test_low_precision_core_yat.py
+++ b/tests/test_linen/test_low_precision_core_yat.py
@@ -55,16 +55,22 @@ def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
         np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
 
 
-def _aggregate_dense_grads(dtype, compiled=False):
+def _aggregate_dense_grads(dtype, param_dtype=None, compiled=False):
+    param_dtype = dtype if param_dtype is None else param_dtype
+    layer_dtype = (
+        None
+        if dtype in (jnp.float16, jnp.bfloat16) and param_dtype == jnp.float32
+        else dtype
+    )
     layer = YatNMN(features=1, use_bias=True, use_alpha=True, epsilon=1.0,
-                   dtype=dtype, param_dtype=dtype)
+                   dtype=layer_dtype, param_dtype=param_dtype)
     x = jnp.full((4096, 2), 100.0, dtype=dtype)
     variables = layer.init(jax.random.key(0), x)
     params = dict(
         variables["params"],
-        kernel=jnp.array([[-100.0, -99.0]], dtype=dtype),
-        bias=jnp.array([0.5], dtype=dtype),
-        alpha=jnp.array([1.25], dtype=dtype),
+        kernel=jnp.array([[-100.0, -99.0]], dtype=param_dtype),
+        bias=jnp.array([0.5], dtype=param_dtype),
+        alpha=jnp.array([1.25], dtype=param_dtype),
     )
 
     def loss(input_value, parameter_values):
@@ -78,15 +84,90 @@ def _aggregate_dense_grads(dtype, compiled=False):
 
 
 @pytest.mark.parametrize("compiled", [False, True])
-def test_fp16_dense_aggregate_cotangents_match_saturated_fp32_reference(compiled):
-    reference_output, reference_grads = _aggregate_dense_grads(jnp.float32, compiled)
-    output, grads = _aggregate_dense_grads(jnp.float16, compiled)
-    limit = jnp.finfo(jnp.float16)
+def test_fp16_dense_with_fp32_parameter_storage_matches_fp32_reference(compiled):
+    reference_output, reference_grads = _aggregate_dense_grads(
+        jnp.float32, compiled=compiled
+    )
+    output, grads = _aggregate_dense_grads(
+        jnp.float16, param_dtype=jnp.float32, compiled=compiled
+    )
     np.testing.assert_allclose(_as_f32(output), _as_f32(reference_output), rtol=5e-3, atol=2.0)
     for actual, expected in zip(jax.tree.leaves(grads), jax.tree.leaves(reference_grads)):
-        clipped = jnp.asarray(jnp.clip(expected, limit.min, limit.max), jnp.float16)
         assert jnp.all(jnp.isfinite(actual))
-        np.testing.assert_allclose(_as_f32(actual), _as_f32(clipped), rtol=5e-3, atol=8.0)
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=8.0)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_dense_single_operator_cotangents_saturate_finitely(compiled):
+    reference_output, reference_grads = _aggregate_dense_grads(
+        jnp.float32, compiled=compiled
+    )
+    output, grads = _aggregate_dense_grads(jnp.float16, compiled=compiled)
+    limits = jnp.finfo(jnp.float16)
+    np.testing.assert_allclose(
+        _as_f32(output), _as_f32(reference_output), rtol=5e-3, atol=2.0
+    )
+    for actual, expected in zip(
+        jax.tree.leaves(grads), jax.tree.leaves(reference_grads)
+    ):
+        clipped = jnp.asarray(
+            jnp.clip(expected, limits.min, limits.max), jnp.float16
+        )
+        assert jnp.all(jnp.isfinite(actual))
+        np.testing.assert_allclose(
+            _as_f32(actual), _as_f32(clipped), rtol=5e-3, atol=8.0
+        )
+
+
+def _aggregate_conv_grads(dtype, compiled=False):
+    layer = YatConv1D(
+        features=1, kernel_size=(1,), use_bias=True, use_alpha=True,
+        epsilon=1.0, dtype=dtype, param_dtype=dtype,
+        kernel_init=lambda key, shape, init_dtype: jnp.full(
+            shape, -100.0, init_dtype
+        ),
+        bias_init=lambda key, shape, init_dtype: jnp.full(
+            shape, 0.5, init_dtype
+        ),
+        alpha_init=lambda key, shape, init_dtype: jnp.full(
+            shape, 1.25, init_dtype
+        ),
+    )
+    inputs = jnp.full((4096, 1, 1), 100.0, dtype=dtype)
+    variables = layer.init(jax.random.key(9), inputs)
+
+    def loss(input_value, parameter_values):
+        return layer.apply(
+            {"params": parameter_values}, input_value
+        ).astype(jnp.float32).sum()
+
+    gradient_fn = jax.grad(loss, argnums=(0, 1))
+    if compiled:
+        gradient_fn = jax.jit(gradient_fn)
+    output = layer.apply(variables, inputs)
+    return output, gradient_fn(inputs, variables["params"])
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_conv_single_operator_cotangents_saturate_finitely(compiled):
+    reference_output, reference_grads = _aggregate_conv_grads(
+        jnp.float32, compiled
+    )
+    output, grads = _aggregate_conv_grads(jnp.float16, compiled)
+    limits = jnp.finfo(jnp.float16)
+    np.testing.assert_allclose(
+        _as_f32(output), _as_f32(reference_output), rtol=5e-3, atol=2.0
+    )
+    for actual, expected in zip(
+        jax.tree.leaves(grads), jax.tree.leaves(reference_grads)
+    ):
+        clipped = jnp.asarray(
+            jnp.clip(expected, limits.min, limits.max), jnp.float16
+        )
+        assert jnp.all(jnp.isfinite(actual))
+        np.testing.assert_allclose(
+            _as_f32(actual), _as_f32(clipped), rtol=5e-3, atol=8.0
+        )
 
 
 def _conv_value_and_grads(layer_cls, shape, kernel_size, dtype):
@@ -206,3 +287,62 @@ def test_low_precision_core_preserves_genuine_nan():
         lambda value: (reduction_safe_upcast(value) * jnp.nan).sum()
     )(jnp.ones((1,), dtype=jnp.float16))
     assert jnp.isnan(gradient).all()
+
+
+@pytest.mark.parametrize("layer_cls,shape,kernel_size", [
+    (YatNMN, (1, 1), None),
+    (YatConv1D, (1, 1, 1), (1,)),
+    (YatConvTranspose1D, (1, 1, 1), (1,)),
+])
+def test_fp16_negative_large_outputs_saturate_finitely(
+    layer_cls, shape, kernel_size
+):
+    kwargs = dict(
+        features=1, use_bias=False, use_alpha=True, epsilon=1.0,
+        dtype=jnp.float16, param_dtype=jnp.float16,
+        kernel_init=lambda key, param_shape, dtype: jnp.full(
+            param_shape, 100.0, dtype
+        ),
+        alpha_init=lambda key, param_shape, dtype: jnp.full(
+            param_shape, -1.0, dtype
+        ),
+    )
+    if kernel_size is not None:
+        kwargs["kernel_size"] = kernel_size
+    layer = layer_cls(**kwargs)
+    inputs = jnp.full(shape, 100.0, dtype=jnp.float16)
+    output = layer.apply(layer.init(jax.random.key(7), inputs), inputs)
+    assert jnp.isfinite(output).all()
+    assert jnp.all(output == jnp.finfo(jnp.float16).min)
+
+
+def test_low_precision_dense_supports_jvp():
+    layer = YatNMN(
+        features=1, use_bias=False, use_alpha=False, epsilon=1.0,
+        dtype=jnp.float16, param_dtype=jnp.float16,
+        kernel_init=lambda key, shape, dtype: jnp.full(shape, -100.0, dtype),
+    )
+    inputs = jnp.full((1, 2), 100.0, dtype=jnp.float16)
+    variables = layer.init(jax.random.key(8), inputs)
+    primal, tangent = jax.jvp(
+        lambda value: layer.apply(variables, value),
+        (inputs,), (jnp.ones_like(inputs),),
+    )
+    assert jnp.isfinite(primal).all() and jnp.isfinite(tangent).all()
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_reused_fp16_leaf_requires_fp32_gradient_storage(compiled):
+    def lowp_loss(value):
+        first = (reduction_safe_upcast(value) * 40000.0).sum()
+        second = (reduction_safe_upcast(value) * 40000.0).sum()
+        return first + second
+
+    gradient_fn = jax.grad(lowp_loss)
+    if compiled:
+        gradient_fn = jax.jit(gradient_fn)
+    lowp_grad = gradient_fn(jnp.ones((1,), dtype=jnp.float16))
+    assert jnp.isinf(lowp_grad).all()
+
+    fp32_grad = gradient_fn(jnp.ones((1,), dtype=jnp.float32))
+    np.testing.assert_array_equal(np.asarray(fp32_grad), np.array([80000.0]))

--- a/tests/test_nnx/test_attention_regressions.py
+++ b/tests/test_nnx/test_attention_regressions.py
@@ -11,6 +11,7 @@ from nmn.nnx.layers.attention.fused_yat_attention import (
     fused_yat_l1_attention,
     fused_yat_l1_self_attention,
 )
+from nmn.nnx.layers.attention.yat_attention import yat_attention
 
 
 def _causal_mask(batch_size: int, length: int) -> jax.Array:
@@ -18,6 +19,35 @@ def _causal_mask(batch_size: int, length: int) -> jax.Array:
         jnp.tril(jnp.ones((length, length), dtype=jnp.bool_)),
         (batch_size, 1, length, length),
     )
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_attention_aggregate_cotangents_match_saturated_fp32_reference(compiled):
+    def evaluate(dtype):
+        query = jnp.full((1, 1, 1, 2), 100.0, dtype=dtype)
+        key = jnp.full((1, 2, 1, 2), 99.0, dtype=dtype)
+        value = jnp.array([[[[0.0]], [[1.0]]]], dtype=dtype)
+
+        def loss(q, k, v):
+            return yat_attention(q, k, v, deterministic=True, epsilon=1.0).astype(jnp.float32).sum()
+
+        output = yat_attention(query, key, value, deterministic=True, epsilon=1.0)
+        gradient_fn = jax.grad(loss, argnums=(0, 1, 2))
+        if compiled:
+            gradient_fn = jax.jit(gradient_fn)
+        return output, gradient_fn(query, key, value)
+
+    reference_output, reference_grads = evaluate(jnp.float32)
+    output, grads = evaluate(jnp.float16)
+    limit = jnp.finfo(jnp.float16)
+    np.testing.assert_allclose(np.asarray(output, np.float32), np.asarray(reference_output), atol=2e-3)
+    for actual, expected in zip(grads, reference_grads):
+        clipped = jnp.asarray(jnp.clip(expected, limit.min, limit.max), jnp.float16)
+        assert jnp.all(jnp.isfinite(actual))
+        np.testing.assert_allclose(
+            np.asarray(actual, np.float32), np.asarray(clipped, np.float32),
+            rtol=7e-3, atol=8.0,
+        )
 
 
 def _reference_l1(query, key, value, bias=None, epsilon=1e-3):

--- a/tests/test_tf/test_low_precision_core_yat.py
+++ b/tests/test_tf/test_low_precision_core_yat.py
@@ -1,0 +1,119 @@
+"""Large-magnitude low-precision regressions for TensorFlow YAT arithmetic."""
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from nmn.tf import (
+    YatConv1D, YatConv2D, YatConv3D,
+    YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
+    YatNMN, yat_attention,
+)
+
+
+LOWP_DTYPES = (tf.float16, tf.bfloat16)
+CONVS = (
+    (YatConv1D, (1, 1, 1), 1),
+    (YatConv2D, (1, 1, 1, 1), (1, 1)),
+    (YatConv3D, (1, 1, 1, 1, 1), (1, 1, 1)),
+    (YatConvTranspose1D, (1, 1, 1), 1),
+    (YatConvTranspose2D, (1, 1, 1, 1), (1, 1)),
+    (YatConvTranspose3D, (1, 1, 1, 1, 1), (1, 1, 1)),
+)
+
+
+def _as_f32(value):
+    return tf.cast(value, tf.float32).numpy()
+
+
+def _dense_value_and_grads(dtype):
+    layer = YatNMN(
+        features=1, use_bias=False, use_alpha=False, epsilon=1.0, dtype=dtype
+    )
+    x = tf.Variable([[100.0, 100.0]], dtype=dtype)
+    layer(x)
+    layer.kernel.assign(tf.constant([[-100.0, -99.0]], dtype=dtype))
+    with tf.GradientTape() as tape:
+        output = layer(x)
+        loss = tf.reduce_sum(tf.cast(output, tf.float32))
+    gradients = tape.gradient(loss, (x, layer.kernel))
+    return output, gradients
+
+
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
+    ref_output, ref_grads = _dense_value_and_grads(tf.float32)
+    output, grads = _dense_value_and_grads(dtype)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), rtol=5e-3, atol=0.15)
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
+
+
+def _conv_value_and_grads(layer_cls, shape, kernel_size, dtype):
+    layer = layer_cls(
+        filters=1, kernel_size=kernel_size, use_bias=False, use_alpha=False,
+        epsilon=1.0, dtype=dtype,
+    )
+    x = tf.Variable(tf.fill(shape, tf.cast(100.0, dtype)))
+    layer(x)
+    layer.kernel.assign(tf.fill(layer.kernel.shape, tf.cast(-100.0, dtype)))
+    with tf.GradientTape() as tape:
+        output = layer(x)
+        loss = tf.reduce_sum(tf.cast(output, tf.float32))
+    gradients = tape.gradient(loss, (x, layer.kernel))
+    return output, gradients
+
+
+@pytest.mark.parametrize("layer_cls,shape,kernel_size", CONVS)
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_large_magnitude_conv_families_match_fp32(layer_cls, shape, kernel_size, dtype):
+    ref_output, ref_grads = _conv_value_and_grads(
+        layer_cls, shape, kernel_size, tf.float32
+    )
+    output, grads = _conv_value_and_grads(layer_cls, shape, kernel_size, dtype)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), rtol=5e-3, atol=0.15)
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
+
+
+def _attention_value_and_grads(dtype):
+    query = tf.Variable(tf.fill((1, 1, 1, 2), tf.cast(100.0, dtype)))
+    key = tf.Variable(tf.fill((1, 2, 1, 2), tf.cast(100.0, dtype)))
+    value = tf.Variable(tf.constant([[[[1.0]], [[2.0]]]], dtype=dtype))
+    with tf.GradientTape() as tape:
+        output = yat_attention(query, key, value, training=False, epsilon=1.0)
+        loss = tf.reduce_sum(tf.cast(output, tf.float32)) * 0.015625
+    return output, tape.gradient(loss, (query, key, value))
+
+
+@pytest.mark.parametrize("dtype", LOWP_DTYPES)
+def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
+    ref_output, ref_grads = _attention_value_and_grads(tf.float32)
+    output, grads = _attention_value_and_grads(dtype)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), atol=2e-3)
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=7e-3, atol=8.0)
+
+
+def test_low_precision_core_preserves_genuine_nan():
+    layer = YatNMN(
+        features=1, use_bias=False, use_alpha=False, dtype=tf.float16
+    )
+    inputs = tf.constant([[np.nan, 1.0]], dtype=tf.float16)
+    layer(inputs)
+    layer.kernel.assign(tf.ones_like(layer.kernel))
+    assert np.isnan(layer(inputs).numpy()).all()
+
+    conv = YatConv1D(
+        filters=1, kernel_size=1, use_bias=False, use_alpha=False,
+        dtype=tf.float16,
+    )
+    conv_inputs = tf.constant([[[np.nan]]], dtype=tf.float16)
+    conv(conv_inputs)
+    conv.kernel.assign(tf.ones_like(conv.kernel))
+    assert np.isnan(conv(conv_inputs).numpy()).all()
+
+    query = tf.constant([[[[np.nan, 100.0]]]], dtype=tf.float16)
+    key = tf.fill((1, 2, 1, 2), tf.constant(100.0, tf.float16))
+    value = tf.ones((1, 2, 1, 1), dtype=tf.float16)
+    assert np.isnan(yat_attention(query, key, value)).all()

--- a/tests/test_tf/test_low_precision_core_yat.py
+++ b/tests/test_tf/test_low_precision_core_yat.py
@@ -176,3 +176,42 @@ def test_low_precision_core_preserves_genuine_nan():
     with tf.GradientTape() as tape:
         loss = tf.reduce_sum(reduction_safe_upcast(variable) * np.nan)
     assert np.isnan(tape.gradient(loss, variable).numpy()).all()
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv", "transpose"])
+def test_fp16_negative_large_outputs_saturate_finitely(kind):
+    if kind == "dense":
+        layer = YatNMN(
+            features=1, use_bias=False, use_alpha=True, epsilon=1.0,
+            dtype=tf.float16,
+        )
+        inputs = tf.fill((1, 1), tf.constant(100.0, tf.float16))
+    else:
+        layer_cls = YatConv1D if kind == "conv" else YatConvTranspose1D
+        layer = layer_cls(
+            filters=1, kernel_size=1, use_bias=False, use_alpha=True,
+            epsilon=1.0, dtype=tf.float16,
+        )
+        inputs = tf.fill((1, 1, 1), tf.constant(100.0, tf.float16))
+    layer(inputs)
+    layer.kernel.assign(tf.fill(layer.kernel.shape, tf.constant(100.0, tf.float16)))
+    layer.alpha.assign(tf.constant([-1.0], tf.float16))
+    output = layer(inputs)
+    assert np.isfinite(output.numpy()).all()
+    assert np.all(output.numpy() == np.finfo(np.float16).min)
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_reused_fp16_leaf_requires_fp32_gradient_storage(compiled):
+    def evaluate(variable):
+        with tf.GradientTape() as tape:
+            first = tf.reduce_sum(reduction_safe_upcast(variable) * 40000.0)
+            second = tf.reduce_sum(reduction_safe_upcast(variable) * 40000.0)
+            total = first + second
+        return tape.gradient(total, variable)
+
+    gradient_fn = tf.function(evaluate) if compiled else evaluate
+    lowp_grad = gradient_fn(tf.Variable([1.0], dtype=tf.float16))
+    assert np.isinf(lowp_grad.numpy()).all()
+    fp32_grad = gradient_fn(tf.Variable([1.0], dtype=tf.float32))
+    np.testing.assert_array_equal(fp32_grad.numpy(), np.array([80000.0]))

--- a/tests/test_tf/test_low_precision_core_yat.py
+++ b/tests/test_tf/test_low_precision_core_yat.py
@@ -9,6 +9,7 @@ from nmn.tf import (
     YatConvTranspose1D, YatConvTranspose2D, YatConvTranspose3D,
     YatNMN, yat_attention,
 )
+from nmn.tf._precision import reduction_safe_upcast
 
 
 LOWP_DTYPES = (tf.float16, tf.bfloat16)
@@ -47,6 +48,34 @@ def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
     np.testing.assert_allclose(_as_f32(output), _as_f32(ref_output), rtol=5e-3, atol=0.15)
     for actual, expected in zip(grads, ref_grads):
         np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=5e-3, atol=0.15)
+
+
+def _aggregate_dense_grads(dtype, compiled=False):
+    layer = YatNMN(features=1, use_bias=True, use_alpha=True, epsilon=1.0, dtype=dtype)
+    x = tf.Variable(tf.fill((4096, 2), tf.cast(100.0, dtype)))
+    layer(x)
+    layer.kernel.assign(tf.constant([[-100.0, -99.0]], dtype=dtype))
+    layer.bias.assign(tf.constant([0.5], dtype=dtype))
+    layer.alpha.assign(tf.constant([1.25], dtype=dtype))
+    def evaluate():
+        with tf.GradientTape() as tape:
+            output = layer(x)
+            loss = tf.reduce_sum(tf.cast(output, tf.float32))
+        return output, tape.gradient(loss, (x, layer.kernel, layer.bias, layer.alpha))
+
+    return tf.function(evaluate)() if compiled else evaluate()
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_dense_aggregate_cotangents_match_saturated_fp32_reference(compiled):
+    reference_output, reference_grads = _aggregate_dense_grads(tf.float32, compiled)
+    output, grads = _aggregate_dense_grads(tf.float16, compiled)
+    limit = np.finfo(np.float16)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(reference_output), rtol=5e-3, atol=2.0)
+    for actual, expected in zip(grads, reference_grads):
+        clipped = np.clip(expected.numpy(), limit.min, limit.max).astype(np.float16)
+        assert np.all(np.isfinite(actual.numpy()))
+        np.testing.assert_allclose(actual.numpy(), clipped, rtol=5e-3, atol=8.0)
 
 
 def _conv_value_and_grads(layer_cls, shape, kernel_size, dtype):
@@ -95,6 +124,31 @@ def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
         np.testing.assert_allclose(_as_f32(actual), _as_f32(expected), rtol=7e-3, atol=8.0)
 
 
+def _aggregate_attention_grads(dtype, compiled=False):
+    query = tf.Variable(tf.fill((1, 1, 1, 2), tf.cast(100.0, dtype)))
+    key = tf.Variable(tf.fill((1, 2, 1, 2), tf.cast(99.0, dtype)))
+    value = tf.Variable(tf.constant([[[[0.0]], [[1.0]]]], dtype=dtype))
+    def evaluate():
+        with tf.GradientTape() as tape:
+            output = yat_attention(query, key, value, training=False, epsilon=1.0)
+            loss = tf.reduce_sum(tf.cast(output, tf.float32))
+        return output, tape.gradient(loss, (query, key, value))
+
+    return tf.function(evaluate)() if compiled else evaluate()
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_fp16_attention_aggregate_cotangents_match_saturated_fp32_reference(compiled):
+    reference_output, reference_grads = _aggregate_attention_grads(tf.float32, compiled)
+    output, grads = _aggregate_attention_grads(tf.float16, compiled)
+    limit = np.finfo(np.float16)
+    np.testing.assert_allclose(_as_f32(output), _as_f32(reference_output), atol=2e-3)
+    for actual, expected in zip(grads, reference_grads):
+        clipped = np.clip(expected.numpy(), limit.min, limit.max).astype(np.float16)
+        assert np.all(np.isfinite(actual.numpy()))
+        np.testing.assert_allclose(actual.numpy(), clipped, rtol=7e-3, atol=8.0)
+
+
 def test_low_precision_core_preserves_genuine_nan():
     layer = YatNMN(
         features=1, use_bias=False, use_alpha=False, dtype=tf.float16
@@ -117,3 +171,8 @@ def test_low_precision_core_preserves_genuine_nan():
     key = tf.fill((1, 2, 1, 2), tf.constant(100.0, tf.float16))
     value = tf.ones((1, 2, 1, 1), dtype=tf.float16)
     assert np.isnan(yat_attention(query, key, value)).all()
+
+    variable = tf.Variable([1.0], dtype=tf.float16)
+    with tf.GradientTape() as tape:
+        loss = tf.reduce_sum(reduction_safe_upcast(variable) * np.nan)
+    assert np.isnan(tape.gradient(loss, variable).numpy()).all()

--- a/tests/test_torch/test_low_precision_core_yat.py
+++ b/tests/test_torch/test_low_precision_core_yat.py
@@ -33,6 +33,38 @@ def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
     assert lowp[0].dtype == dtype
 
 
+def _aggregate_dense_grads(dtype):
+    layer = YatNMN(2, 1, bias=True, alpha=True, epsilon=1.0,
+                   dtype=dtype, param_dtype=dtype)
+    with torch.no_grad():
+        layer.weight.copy_(torch.tensor([[-100.0, -99.0]], dtype=dtype))
+        layer.bias.fill_(0.5)
+        layer.alpha.fill_(1.25)
+    x = torch.full((4096, 2), 100.0, dtype=dtype, requires_grad=True)
+    output = layer(x)
+    gradients = torch.autograd.grad(
+        output.float().sum(), (x, layer.weight, layer.bias, layer.alpha)
+    )
+    return output, gradients
+
+
+def test_fp16_dense_aggregate_cotangents_match_saturated_fp32_reference():
+    reference_output, reference_grads = _aggregate_dense_grads(torch.float32)
+    output, grads = _aggregate_dense_grads(torch.float16)
+    limit = torch.finfo(torch.float16)
+    assert torch.isfinite(output).all()
+    np.testing.assert_allclose(
+        output.float().detach().numpy(), reference_output.detach().numpy(),
+        rtol=5e-3, atol=2.0,
+    )
+    for actual, expected in zip(grads, reference_grads):
+        clipped = expected.clamp(limit.min, limit.max).to(torch.float16)
+        assert torch.isfinite(actual).all()
+        np.testing.assert_allclose(
+            actual.detach().numpy(), clipped.detach().numpy(), rtol=5e-3, atol=8.0
+        )
+
+
 def _attention_value_and_grads(dtype):
     query = torch.full((1, 1, 1, 2), 100.0, dtype=dtype, requires_grad=True)
     key = torch.full((1, 2, 1, 2), 100.0, dtype=dtype, requires_grad=True)
@@ -57,6 +89,30 @@ def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
         np.testing.assert_allclose(
             actual.float().detach().numpy(), expected.detach().numpy(),
             rtol=7e-3, atol=8.0,
+        )
+
+
+def _aggregate_attention_grads(dtype):
+    query = torch.full((1, 1, 1, 2), 100.0, dtype=dtype, requires_grad=True)
+    key = torch.full((1, 2, 1, 2), 99.0, dtype=dtype, requires_grad=True)
+    value = torch.tensor([[[[0.0]], [[1.0]]]], dtype=dtype, requires_grad=True)
+    output = yat_attention(query, key, value, training=False, epsilon=1.0)
+    gradients = torch.autograd.grad(output.float().sum(), (query, key, value))
+    return output, gradients
+
+
+def test_fp16_attention_aggregate_cotangents_match_saturated_fp32_reference():
+    reference_output, reference_grads = _aggregate_attention_grads(torch.float32)
+    output, grads = _aggregate_attention_grads(torch.float16)
+    limit = torch.finfo(torch.float16)
+    np.testing.assert_allclose(
+        output.float().detach().numpy(), reference_output.detach().numpy(), atol=2e-3
+    )
+    for actual, expected in zip(grads, reference_grads):
+        clipped = expected.clamp(limit.min, limit.max).to(torch.float16)
+        assert torch.isfinite(actual).all()
+        np.testing.assert_allclose(
+            actual.detach().numpy(), clipped.detach().numpy(), rtol=7e-3, atol=8.0
         )
 
 

--- a/tests/test_torch/test_low_precision_core_yat.py
+++ b/tests/test_torch/test_low_precision_core_yat.py
@@ -1,0 +1,76 @@
+"""Large-magnitude low-precision regressions for core YAT arithmetic."""
+
+import numpy as np
+import pytest
+import torch
+
+from nmn.torch import YatNMN
+from nmn.torch.attention import yat_attention
+
+
+def _dense_value_and_grads(dtype):
+    layer = YatNMN(2, 1, bias=False, alpha=False, epsilon=1.0,
+                   dtype=dtype, param_dtype=dtype)
+    with torch.no_grad():
+        layer.weight.copy_(torch.tensor([[-100.0, -99.0]], dtype=dtype))
+    x = torch.tensor([[100.0, 100.0]], dtype=dtype, requires_grad=True)
+    output = layer(x)
+    input_grad, kernel_grad = torch.autograd.grad(
+        output.float().sum(), (x, layer.weight)
+    )
+    return output, input_grad, kernel_grad
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_large_magnitude_dense_matches_fp32_forward_and_gradients(dtype):
+    reference = _dense_value_and_grads(torch.float32)
+    lowp = _dense_value_and_grads(dtype)
+    for actual, expected in zip(lowp, reference):
+        np.testing.assert_allclose(
+            actual.float().detach().numpy(), expected.detach().numpy(),
+            rtol=5e-3, atol=0.15,
+        )
+    assert lowp[0].dtype == dtype
+
+
+def _attention_value_and_grads(dtype):
+    query = torch.full((1, 1, 1, 2), 100.0, dtype=dtype, requires_grad=True)
+    key = torch.full((1, 2, 1, 2), 100.0, dtype=dtype, requires_grad=True)
+    value = torch.tensor([[[[1.0]], [[2.0]]]], dtype=dtype, requires_grad=True)
+    output = yat_attention(
+        query, key, value, training=False, epsilon=1.0
+    )
+    gradients = torch.autograd.grad(
+        output.float().sum() * 0.015625, (query, key, value)
+    )
+    return output, gradients
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_large_magnitude_attention_matches_fp32_forward_and_gradients(dtype):
+    ref_output, ref_grads = _attention_value_and_grads(torch.float32)
+    output, grads = _attention_value_and_grads(dtype)
+    np.testing.assert_allclose(
+        output.float().detach().numpy(), ref_output.detach().numpy(), atol=2e-3
+    )
+    for actual, expected in zip(grads, ref_grads):
+        np.testing.assert_allclose(
+            actual.float().detach().numpy(), expected.detach().numpy(),
+            rtol=7e-3, atol=8.0,
+        )
+
+
+def test_low_precision_dense_and_attention_preserve_genuine_nan():
+    layer = YatNMN(2, 1, bias=False, alpha=False, epsilon=1.0,
+                   dtype=torch.float16, param_dtype=torch.float16)
+    with torch.no_grad():
+        layer.weight.fill_(1.0)
+    assert torch.isnan(layer(torch.tensor([[float("nan"), 1.0]], dtype=torch.float16))).all()
+
+    query = torch.tensor([[[[float("nan"), 100.0]]]], dtype=torch.float16)
+    key = torch.full((1, 2, 1, 2), 100.0, dtype=torch.float16)
+    weights = yat_attention(
+        query, key, torch.ones((1, 2, 1, 1), dtype=torch.float16),
+        training=False,
+    )
+    assert torch.isnan(weights).all()

--- a/tests/test_torch/test_low_precision_core_yat.py
+++ b/tests/test_torch/test_low_precision_core_yat.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 import torch
 
-from nmn.torch import YatNMN
+from nmn.torch import YatConv1D, YatConvTranspose1D, YatNMN
+from nmn.torch._precision import saturating_upcast
 from nmn.torch.attention import yat_attention
 
 
@@ -130,3 +131,38 @@ def test_low_precision_dense_and_attention_preserve_genuine_nan():
         training=False,
     )
     assert torch.isnan(weights).all()
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv", "transpose"])
+def test_fp16_negative_large_outputs_saturate_finitely(kind):
+    if kind == "dense":
+        layer = YatNMN(
+            1, 1, bias=False, alpha=True, epsilon=1.0,
+            dtype=torch.float16, param_dtype=torch.float16,
+        )
+        inputs = torch.full((1, 1), 100.0, dtype=torch.float16)
+    else:
+        layer_cls = YatConv1D if kind == "conv" else YatConvTranspose1D
+        layer = layer_cls(
+            1, 1, 1, bias=False, use_alpha=True, epsilon=1.0,
+            dtype=torch.float16, param_dtype=torch.float16,
+        )
+        inputs = torch.full((1, 1, 1), 100.0, dtype=torch.float16)
+    with torch.no_grad():
+        layer.weight.fill_(100.0)
+        layer.alpha.fill_(-1.0)
+    output = layer(inputs)
+    assert torch.isfinite(output).all()
+    assert torch.all(output == torch.finfo(torch.float16).min)
+
+
+def test_reused_fp16_leaf_requires_fp32_gradient_storage():
+    lowp = torch.ones(1, dtype=torch.float16, requires_grad=True)
+    loss = (saturating_upcast(lowp) * 40000.0).sum()
+    loss = loss + (saturating_upcast(lowp) * 40000.0).sum()
+    loss.backward()
+    assert torch.isinf(lowp.grad).all()
+
+    fp32 = torch.ones(1, dtype=torch.float32, requires_grad=True)
+    ((fp32 * 40000.0).sum() + (fp32 * 40000.0).sum()).backward()
+    torch.testing.assert_close(fp32.grad, torch.tensor([80000.0]))


### PR DESCRIPTION
Fixes #90. Accumulates overflow-prone dense, attention, and affected convolution YAT math safely across Torch, Linen, Keras, and TensorFlow; adds two-sided finite output saturation, operator-local aggregate-gradient clipping, genuine-NaN preservation, scalar-alpha compatibility, and low-precision-safe Linen initialization. The Linen boundary uses a batchable linear JAX primitive supporting JVP, jacfwd, jacrev, vmap, higher-order transforms, and JIT. Tests cover fp16/bf16 forward and gradient parity, large magnitudes, exact collisions, batch reductions, transforms, and merged #92 channels-first interaction. Separate graph paths accumulating into the same low-precision leaf remain mathematically unrepresentable and are explicitly documented; use fp32 gradient storage for that case. Independently approved.