### PR TITLE
Publish packages only from version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,15 +2,14 @@ name: Publish Python 🐍 distribution to PyPI
 
 on:
   push:
-    branches:
-      - master
     tags:
       - 'v*.*.*'
   workflow_dispatch:
 
-# TestPyPI runs on every master push (smoke-test the publish path with dev
-# versions). PyPI publish is gated on version tags so we don't pollute the
-# production index with per-commit dev releases.
+# Package indexes reject the local ``+g<sha>`` suffix produced by hatch-vcs for
+# untagged commits. Release uploads therefore run only for version tags. A
+# manual workflow dispatch still builds and validates the artifacts without
+# publishing an invalid development version.
 
 permissions:
   contents: read
@@ -46,7 +45,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish to TestPyPI
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -1,0 +1,29 @@
+"""Regression tests for CI/CD workflow policy."""
+
+from pathlib import Path
+
+WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
+
+
+def test_publish_uploads_only_version_tags():
+    workflow = (WORKFLOWS / "publish.yml").read_text()
+    trigger_block = workflow.split("permissions:", 1)[0]
+
+    assert "branches:" not in trigger_block
+    assert "- 'v*.*.*'" in trigger_block
+    assert "if: startsWith(github.ref, 'refs/tags/v')" in workflow
+
+
+def test_ci_actions_use_node24_compatible_releases():
+    workflows = "\n".join(path.read_text() for path in WORKFLOWS.glob("*.yml"))
+
+    assert "actions/setup-python@v5" not in workflows
+    assert "codecov/codecov-action@v4" not in workflows
+    assert "codecov/codecov-action@v5" not in workflows
+
+
+def test_codecov_uses_current_files_input():
+    workflow = (WORKFLOWS / "test.yml").read_text()
+
+    assert "        file: ./coverage.xml" not in workflow
+    assert workflow.count("        files: ./coverage.xml") == 3


### PR DESCRIPTION
## Summary

- stop publishing untagged hatch-vcs local versions to TestPyPI on every master push
- keep manual dispatch as a build-only artifact validation path
- publish TestPyPI and PyPI artifacts only for `v*.*.*` release tags
- add workflow policy regressions for release triggers, Node 24-compatible actions, and Codecov inputs

## Verification

- `pytest -q tests/test_workflow_policy.py` (3 passed)
- workflow YAML parses
- Black, isort, and `git diff --check` pass

Closes #101
