### PR TITLE
Move release artifact transfers to Node 24

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: hatch build
 
       - name: Store distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -53,7 +53,7 @@ jobs:
       url: https://test.pypi.org/p/nmn
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -74,7 +74,7 @@ jobs:
       url: https://pypi.org/p/nmn
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -20,6 +20,8 @@ def test_ci_actions_use_node24_compatible_releases():
     assert "actions/setup-python@v5" not in workflows
     assert "codecov/codecov-action@v4" not in workflows
     assert "codecov/codecov-action@v5" not in workflows
+    assert "actions/upload-artifact@v4" not in workflows
+    assert "actions/download-artifact@v4" not in workflows
 
 
 def test_codecov_uses_current_files_input():


### PR DESCRIPTION
## Summary

- update `actions/upload-artifact` from v4 to v7
- update `actions/download-artifact` from v4 to v8
- extend workflow policy tests so deprecated Node 20 artifact actions cannot return

This removes the final deprecation annotations observed during the successful v0.3.3 release.

## Verification

- workflow policy tests: 3 passed
- publish workflow YAML parses
- Black, isort, and diff check pass
