### PR TITLE
docs: correct accelerator installation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,9 @@ differences and gotchas below.
 `YatNMN` is a drop-in replacement for `Linear + activation`. The non-linearity is
 intrinsic: `y = (x·W)² / (||x − W||² + ε) · alpha`. The same layer family
 (`YatNMN`, YAT conv, YAT embedding, YAT multi-head attention) ships across six
-frameworks with numerically equivalent outputs. Current release: 0.3.2.
+frameworks with numerically equivalent outputs. Release information is maintained
+on [PyPI](https://pypi.org/project/nmn/) and
+[GitHub Releases](https://github.com/azettaai/nmn/releases).
 
 ## Pick a framework
 

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,9 @@
 > same `YatNMN` layer (plus YAT conv, embedding, and attention) ships across six
 > frameworks — PyTorch, Flax NNX, Flax Linen, Keras 3, TensorFlow, and MLX (Apple
 > Silicon) — with numerically equivalent outputs. Each backend is an independent
-> optional install (`pip install nmn[<framework>]`). Current release: 0.3.2.
+> optional install (`pip install nmn[<framework>]`). Release information is
+> maintained on [PyPI](https://pypi.org/project/nmn/) and
+> [GitHub Releases](https://github.com/azettaai/nmn/releases).
 
 ## Docs
 

--- a/src/nmn/nnx/README.md
+++ b/src/nmn/nnx/README.md
@@ -27,22 +27,30 @@ Comprehensive Flax NNX implementation of YAT (Yet Another Transformation) neural
 git clone <repository-url>
 cd nmn
 
-# Install in development mode with JAX/Flax support
-pip install -e .
+# Install in development mode with CPU JAX/Flax support
+pip install -e ".[nnx]"
 
-# For TPU support
-pip install -e ".[tpu]"
+# For TPU support, install the official JAX accelerator wheel first
+pip install --upgrade "jax[tpu]>=0.9.1"
+pip install -e ".[nnx]"
 
-# For GPU support (CUDA)
-pip install -e ".[gpu]"
+# For NVIDIA GPU support (CUDA 13), install the official JAX wheel first
+pip install --upgrade "jax[cuda13]>=0.9.1"
+pip install -e ".[nnx]"
 ```
 
-**Dependencies:**
-- JAX >= 0.4.0
-- Flax >= 0.7.0
-- Optax (for optimization)
-- Orbax (for checkpointing)
-- Grain (optional, for efficient data loading on TPU)
+See the [JAX installation guide](https://docs.jax.dev/en/latest/installation.html)
+for platform requirements and alternative CUDA versions.
+
+**Core dependencies installed by `nmn[nnx]`:**
+
+- JAX >= 0.9.1
+- Flax >= 0.12.5
+
+**Optional example dependencies:**
+
+- Optax (`pip install optax`) for the training example
+- Grain (`pip install grain`) for the TPU data-loading example
 
 ## Quick Start
 
@@ -685,6 +693,8 @@ print(f"Test Accuracy: {accuracy:.4f}")
 YAT layers are designed for efficient TPU execution:
 
 ### 1. **Use Grain for Data Loading**
+
+This optional example requires Grain (`pip install grain`).
 
 ```python
 import grain.python as grain

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,6 +7,7 @@ The suite is organized by the boundary it verifies:
 - `benchmarks/` — small performance assertions that are safe in CI;
 - `test_cli.py` — import-light command-line behavior;
 - `test_collection_policy.py` — optional-backend and collection isolation;
+- `test_documentation_policy.py` — installation and release-metadata invariants;
 - `test_workflow_policy.py` — CI/CD configuration invariants.
 
 Exploratory programs, reports, and long-running benchmarks belong in the
@@ -19,7 +20,10 @@ Useful commands:
 python -m pytest -q -m "not slow"
 python -m pytest tests/test_nnx -q
 python -m pytest tests/integration -q
-python -m pytest tests/test_workflow_policy.py tests/test_collection_policy.py -q
+python -m pytest \
+  tests/test_workflow_policy.py \
+  tests/test_collection_policy.py \
+  tests/test_documentation_policy.py -q
 ```
 
 Tests for unavailable optional backends are skipped before importing that

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -1,0 +1,66 @@
+"""Offline policy checks for user- and agent-facing installation docs."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 only
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+OPTIONAL_DEPENDENCIES = PYPROJECT["project"]["optional-dependencies"]
+NNX_README = (ROOT / "src/nmn/nnx/README.md").read_text(encoding="utf-8")
+
+
+def _minimum_version(extra: str, package: str) -> str:
+    requirement = next(
+        item
+        for item in OPTIONAL_DEPENDENCIES[extra]
+        if re.match(rf"{re.escape(package)}(?:\[.*\])?>=", item, re.IGNORECASE)
+    )
+    return requirement.split(">=", maxsplit=1)[1]
+
+
+def test_nnx_readme_only_advertises_defined_project_extras():
+    documented = re.findall(
+        r"pip install(?: --upgrade)?(?: -e)? [\"']?\.\[([^\]]+)\]", NNX_README
+    )
+    assert documented, "expected at least one local editable-install example"
+
+    undefined = {
+        extra.strip()
+        for group in documented
+        for extra in group.split(",")
+        if extra.strip() not in OPTIONAL_DEPENDENCIES
+    }
+    assert not undefined, f"undefined project extras in NNX README: {sorted(undefined)}"
+
+
+def test_nnx_accelerator_commands_use_official_jax_extras():
+    jax_minimum = _minimum_version("nnx", "jax")
+    assert f'"jax[tpu]>={jax_minimum}"' in NNX_README
+    assert f'"jax[cuda13]>={jax_minimum}"' in NNX_README
+    assert '".[tpu]"' not in NNX_README
+    assert '".[gpu]"' not in NNX_README
+
+
+def test_nnx_dependency_minimums_follow_project_metadata():
+    assert f"JAX >= {_minimum_version('nnx', 'jax')}" in NNX_README
+    assert f"Flax >= {_minimum_version('nnx', 'flax')}" in NNX_README
+
+
+def test_optional_grain_example_documents_its_install():
+    assert "pip install grain" in NNX_README
+
+
+def test_agent_docs_link_to_release_sources_instead_of_hard_coding_version():
+    for relative_path in ("AGENTS.md", "llms.txt"):
+        content = (ROOT / relative_path).read_text(encoding="utf-8")
+        assert "Current release:" not in content
+        assert "https://pypi.org/project/nmn/" in content
+        assert "https://github.com/azettaai/nmn/releases" in content


### PR DESCRIPTION
## Summary

- replace nonexistent NMN `tpu`/`gpu` extras with the real `nnx` extra plus
  official JAX `tpu` and `cuda13` accelerator wheels
- align the NNX dependency minimums with project metadata and distinguish core
  dependencies from optional example tools
- remove release numbers that drift in agent-facing docs and link to canonical
  release sources instead
- add offline policy tests that reject undefined extras and future metadata drift

## Verification

- `PYTHONPATH=src python -m pytest -q` — 1196 passed, 16 skipped
- focused documentation/collection/workflow policy suite — 19 passed
- `python -m py_compile tests/test_documentation_policy.py`
- `git diff --check`

Fixes #109
