### PR TITLE
fix(nnx): modernize variable updates

### DIFF
--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -233,7 +233,7 @@ class YatConv(Module):
                         new_kernel_val = new_kernel_val.at[
                             ..., :existing_bank_size
                         ].set(old_kernel)
-                        shared_kernel.value = new_kernel_val
+                        shared_kernel.set_value(new_kernel_val)
                     # elif bank_out_features < existing_bank_size: bank is larger, slice used below
 
             self.kernel = shared_kernel
@@ -321,7 +321,7 @@ class YatConv(Module):
             kernel_norm = jnp.sqrt(
                 jnp.sum(kernel_val**2, axis=reduce_axes, keepdims=True)
             )
-            self.kernel.value = kernel_val / (kernel_norm + 1e-8)
+            self.kernel[...] = kernel_val / (kernel_norm + 1e-8)
 
         if use_dropconnect:
             self.dropconnect_key = rngs.dropout.fork()

--- a/src/nmn/nnx/layers/embed.py
+++ b/src/nmn/nnx/layers/embed.py
@@ -154,7 +154,7 @@ class Embed(Module):
         if self.weight_normalized:
             embedding_val = self.embedding[...]
             embedding_norm = jnp.sqrt(jnp.sum(embedding_val**2, axis=1, keepdims=True))
-            self.embedding.value = embedding_val / (embedding_norm + 1e-8)
+            self.embedding[...] = embedding_val / (embedding_norm + 1e-8)
 
     def __call__(self, inputs: jax.Array) -> jax.Array:
         """Embeds the inputs along the last dimension.

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -248,7 +248,7 @@ class YatNMN(Module):
                         new_kernel_val = new_kernel_val.at[:, :existing_bank_size].set(
                             old_kernel
                         )
-                        shared_kernel.value = new_kernel_val
+                        shared_kernel.set_value(new_kernel_val)
                     # elif bank_out_features < existing_bank_size: bank is larger, slice used below
 
             self.kernel = shared_kernel
@@ -358,7 +358,7 @@ class YatNMN(Module):
         if self.weight_normalized:
             kernel_val = self.kernel[...]
             kernel_norm = jnp.sqrt(jnp.sum(kernel_val**2, axis=0, keepdims=True))
-            self.kernel.value = kernel_val / (kernel_norm + 1e-8)
+            self.kernel[...] = kernel_val / (kernel_norm + 1e-8)
 
         if use_dropconnect:
             self.dropconnect_key = rngs.dropout.fork()

--- a/tests/integration/test_cross_framework.py
+++ b/tests/integration/test_cross_framework.py
@@ -281,11 +281,11 @@ def get_nnx_output(inputs_np, weights_np, bias_np=None, alpha_np=None, epsilon=1
     )
 
     # Set weights
-    layer.kernel.value = jnp.array(weights_np)
+    layer.kernel[...] = jnp.array(weights_np)
     if bias_np is not None:
-        layer.bias.value = jnp.array(bias_np)
+        layer.bias[...] = jnp.array(bias_np)
     if alpha_np is not None:
-        layer.alpha.value = jnp.array([alpha_np])
+        layer.alpha[...] = jnp.array([alpha_np])
 
     x = jnp.array(inputs_np)
     output = layer(x)

--- a/tests/integration/test_cross_framework_consistency.py
+++ b/tests/integration/test_cross_framework_consistency.py
@@ -206,11 +206,11 @@ def run_nnx_dense(
     )
 
     # NNX kernel is (in_features, out_features)
-    layer.kernel.value = jnp.array(weights)
+    layer.kernel[...] = jnp.array(weights)
     if bias is not None:
-        layer.bias.value = jnp.array(bias)
+        layer.bias[...] = jnp.array(bias)
     if alpha is not None:
-        layer.alpha.value = jnp.array([alpha])
+        layer.alpha[...] = jnp.array([alpha])
 
     x = jnp.array(inputs)
     output = layer(x)

--- a/tests/test_nnx/test_variable_updates.py
+++ b/tests/test_nnx/test_variable_updates.py
@@ -1,0 +1,118 @@
+"""Regressions for modern Flax NNX variable mutation semantics."""
+
+from __future__ import annotations
+
+import re
+import warnings
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from nmn.nnx import Embed, YatConv, YatNMN
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEPRECATED_SETTER = "'.value' setter is now deprecated"
+
+
+def _without_deprecated_setter_warning(factory):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = factory()
+
+    deprecated = [
+        warning for warning in caught if DEPRECATED_SETTER in str(warning.message)
+    ]
+    assert not deprecated
+    return result
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv", "embed"])
+def test_weight_normalization_uses_same_shape_variable_update(kind):
+    if kind == "dense":
+        layer = _without_deprecated_setter_warning(
+            lambda: YatNMN(3, 4, weight_normalized=True, rngs=nnx.Rngs(0))
+        )
+        values = np.asarray(layer.kernel[...])
+        norms = np.linalg.norm(values, axis=0)
+    elif kind == "conv":
+        layer = _without_deprecated_setter_warning(
+            lambda: YatConv(2, 4, 3, weight_normalized=True, rngs=nnx.Rngs(0))
+        )
+        values = np.asarray(layer.kernel[...])
+        norms = np.linalg.norm(values, axis=(0, 1))
+    else:
+        layer = _without_deprecated_setter_warning(
+            lambda: Embed(5, 3, weight_normalized=True, rngs=nnx.Rngs(0))
+        )
+        values = np.asarray(layer.embedding[...])
+        norms = np.linalg.norm(values, axis=1)
+
+    np.testing.assert_allclose(norms, np.ones_like(norms), rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv"])
+def test_shared_bank_shape_expansion_uses_replacement_update(kind):
+    bank_id = f"issue-111-{kind}"
+    if kind == "dense":
+        narrow = YatNMN(
+            2,
+            2,
+            tie_kernel_bank=True,
+            kernel_bank_id=bank_id,
+            rngs=nnx.Rngs(0),
+        )
+        old_values = np.asarray(narrow.kernel[...]).copy()
+        wide = _without_deprecated_setter_warning(
+            lambda: YatNMN(
+                2,
+                4,
+                tie_kernel_bank=True,
+                kernel_bank_id=bank_id,
+                rngs=nnx.Rngs(1),
+            )
+        )
+        inputs = jnp.ones((3, 2), dtype=jnp.float32)
+    else:
+        narrow = YatConv(
+            2,
+            2,
+            1,
+            tie_kernel_bank=True,
+            kernel_bank_id=bank_id,
+            rngs=nnx.Rngs(0),
+        )
+        old_values = np.asarray(narrow.kernel[...]).copy()
+        wide = _without_deprecated_setter_warning(
+            lambda: YatConv(
+                2,
+                4,
+                1,
+                tie_kernel_bank=True,
+                kernel_bank_id=bank_id,
+                rngs=nnx.Rngs(1),
+            )
+        )
+        inputs = jnp.ones((3, 5, 2), dtype=jnp.float32)
+
+    assert narrow.kernel is wide.kernel
+    assert wide.kernel[...].shape[-1] == 4
+    np.testing.assert_array_equal(np.asarray(wide.kernel[..., :2]), old_values)
+
+    grads = nnx.grad(lambda module, x: jnp.sum(module(x)))(wide, inputs)
+    assert grads.kernel[...].shape == wide.kernel[...].shape
+    assert np.isfinite(np.asarray(grads.kernel[...])).all()
+
+
+def test_no_direct_nnx_variable_value_assignments_remain():
+    pattern = re.compile(r"(?:self\.(?:kernel|embedding)|shared_kernel)\.value\s*=")
+    paths = (
+        ROOT / "src/nmn/nnx/layers/nmn.py",
+        ROOT / "src/nmn/nnx/layers/conv/yat_conv.py",
+        ROOT / "src/nmn/nnx/layers/embed.py",
+    )
+    for path in paths:
+        assert pattern.search(path.read_text(encoding="utf-8")) is None

--- a/tests/test_nnx/test_variable_updates.py
+++ b/tests/test_nnx/test_variable_updates.py
@@ -13,7 +13,6 @@ from flax import nnx
 
 from nmn.nnx import Embed, YatConv, YatNMN
 
-
 ROOT = Path(__file__).resolve().parents[2]
 DEPRECATED_SETTER = "'.value' setter is now deprecated"
 


### PR DESCRIPTION
## Summary

- replace deprecated direct Flax NNX `Variable.value` assignments with indexed same-shape updates or `set_value` for shape-changing shared-bank expansion
- modernize the cross-framework synchronization harness so it no longer emits the same deprecation warning
- add regressions for warning-free dense/conv/embed normalization, shared-bank identity and slice preservation, and finite post-expansion gradients

## Verification

- new variable-update regressions: 6 passed
- NNX + integration suite: 512 passed, 10 skipped
- warning-as-error affected suite: 28 passed, 2 skipped
- `python -m py_compile tests/test_nnx/test_variable_updates.py`
- `git diff --check`

Fixes #111