### PR TITLE
ci: expand and organize MyPy coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,7 +381,7 @@ jobs:
       run: isort --check-only --diff src/nmn tests
 
   mypy:
-    name: Type Check (MyPy, typed core)
+    name: Type Check (MyPy, package surface)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -394,28 +394,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install "mypy==2.3.1" "numpy<2.3"
-        pip install -e ".[dev]"
+        pip install -e ".[dev]" "numpy<2.3"
         pip install torch --index-url https://download.pytorch.org/whl/cpu
         pip install "jax==0.9.1" "jaxlib==0.9.1" "flax==0.12.5"
         # NumPy 2.5 stubs use Python 3.12 syntax, while NMN's MyPy target is 3.10.
         pip install "numpy<2.3"
 
-    - name: Run MyPy on the PyTorch typed core
-      run: |
-        mypy \
-          src/nmn/torch/squashers.py \
-          src/nmn/torch/attention/yat_attention.py \
-          src/nmn/torch/attention/performer_yat.py \
-          --ignore-missing-imports --no-error-summary
-
-    - name: Run MyPy on the NNX typed core
-      run: |
-        mypy \
-          src/nmn/nnx/layers/_numerics.py \
-          src/nmn/nnx/layers/conv/utils.py \
-          src/nmn/nnx/layers/attention/masks.py \
-          src/nmn/nnx/layers/attention/dot_product.py \
-          src/nmn/nnx/layers/attention/maclaurin_yat.py \
-          src/nmn/nnx/layers/attention/radial_yat.py \
-          --ignore-missing-imports --no-error-summary
+    - name: Run MyPy on the configured package surface
+      run: mypy --no-error-summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "black>=23.0.0",
     "flake8>=6.0.0",
     "isort>=5.12.0",
-    "mypy>=1.0.0",
+    "mypy==2.3.1",
     "hatch-vcs>=0.3.0",
     "tomli>=1.1.0; python_version < '3.11'",
 ]
@@ -103,6 +103,30 @@ markers = [
 
 [tool.mypy]
 python_version = "3.10"
+files = ["src/nmn"]
+follow_imports = "skip"
+ignore_missing_imports = true
+exclude = [
+    '^src/nmn/keras/conv[.]py$',
+    '^src/nmn/mlx/conv[.]py$',
+    '^src/nmn/mlx/fused[.]py$',
+    '^src/nmn/nnx/examples/language/m3za[.]py$',
+    '^src/nmn/nnx/examples/language/m3za_perf[.]py$',
+    '^src/nmn/nnx/examples/vision/aether_resnet50_tpu[.]py$',
+    '^src/nmn/nnx/layers/attention/multi_head[.]py$',
+    '^src/nmn/nnx/layers/attention/rotary_yat[.]py$',
+    '^src/nmn/nnx/layers/conv/yat_conv[.]py$',
+    '^src/nmn/nnx/layers/conv/yat_conv_transpose[.]py$',
+    '^src/nmn/nnx/layers/nmn[.]py$',
+    '^src/nmn/tf/conv[.]py$',
+    '^src/nmn/tf/nmn[.]py$',
+    '^src/nmn/torch/_precision[.]py$',
+    '^src/nmn/torch/base[.]py$',
+    '^src/nmn/torch/layers/yat_conv1d[.]py$',
+    '^src/nmn/torch/layers/yat_conv2d[.]py$',
+    '^src/nmn/torch/layers/yat_conv3d[.]py$',
+    '^src/nmn/torch/nmn/yat_nmn[.]py$',
+]
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
@@ -115,21 +139,6 @@ warn_unused_ignores = true
 warn_no_return = true
 warn_unreachable = true
 strict_equality = true
-
-[[tool.mypy.overrides]]
-module = [
-    "jax.*",
-    "flax.*",
-    "torch.*",
-    "tensorflow.*",
-    "keras.*",
-    "numpy.*",
-    "matplotlib.*",
-    "seaborn.*",
-    "sklearn.*",
-    "optax.*",
-]
-ignore_missing_imports = true
 
 [tool.coverage.run]
 source = ["src/nmn"]

--- a/src/nmn/cli.py
+++ b/src/nmn/cli.py
@@ -124,7 +124,7 @@ def _version() -> str:
     try:
         from nmn import __version__
 
-        return __version__
+        return str(__version__)
     except Exception:  # pragma: no cover - defensive
         return "0.0.0"
 

--- a/src/nmn/keras/performer_yat.py
+++ b/src/nmn/keras/performer_yat.py
@@ -67,7 +67,7 @@ and shared by q and k); the per-token feature maps and the attention readout use
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import numpy as np
 from keras.src import ops
@@ -108,7 +108,7 @@ def maclaurin_coeffs(b: float, eps: float, nmax: int) -> np.ndarray:
     a = b * b * beta.copy()
     a[1:] += 2.0 * b * beta[:-1]
     a[2:] += beta[:-2]
-    return a
+    return cast(np.ndarray, a)
 
 
 # --------------------------------------------------------------------------

--- a/src/nmn/mlx/may.py
+++ b/src/nmn/mlx/may.py
@@ -46,7 +46,7 @@ is :func:`nmn.mlx.attention.yat_attention_normalized`.
 from __future__ import annotations
 
 import math
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import mlx.core as mx
 import numpy as np
@@ -80,7 +80,7 @@ def maclaurin_coeffs(b: float, epsilon: float, nmax: int) -> np.ndarray:
     a = (b * b) * beta.copy()
     a[1:] += 2.0 * b * beta[:-1]
     a[2:] += beta[:-2]
-    return a  # (nmax + 1,), all >= 0 for b >= 0
+    return cast(np.ndarray, a)  # (nmax + 1,), all >= 0 for b >= 0
 
 
 def create_maclaurin_projection(

--- a/src/nmn/nnx/layers/attention/maclaurin_yat.py
+++ b/src/nmn/nnx/layers/attention/maclaurin_yat.py
@@ -68,6 +68,8 @@ Public API (mirrors the SLAY file's signature style):
 
 from __future__ import annotations
 
+from typing import cast
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -97,7 +99,7 @@ def maclaurin_coeffs(b: float, epsilon: float, nmax: int) -> np.ndarray:
     a = (b * b) * beta.copy()
     a[1:] += 2.0 * b * beta[:-1]
     a[2:] += beta[:-2]
-    return a  # [nmax+1]
+    return cast(np.ndarray, a)  # [nmax+1]
 
 
 def create_maclaurin_projection(

--- a/src/nmn/tf/performer_yat.py
+++ b/src/nmn/tf/performer_yat.py
@@ -51,7 +51,7 @@ stored as TensorFlow constants, so the feature maps themselves are pure TF ops.
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import numpy as np
 import tensorflow as tf
@@ -97,7 +97,7 @@ def maclaurin_coeffs(b: float, eps: float, nmax: int) -> np.ndarray:
     a = b * b * beta.copy()
     a[1:] += 2.0 * b * beta[:-1]
     a[2:] += beta[:-2]
-    return a  # [nmax + 1], all >= 0 for b >= 0
+    return cast(np.ndarray, a)  # [nmax + 1], all >= 0 for b >= 0
 
 
 # --------------------------------------------------------------------------

--- a/src/nmn/torch/attention/performer_yat.py
+++ b/src/nmn/torch/attention/performer_yat.py
@@ -52,7 +52,7 @@ The exact (quadratic) reference these approximate is
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import numpy as np
 import torch
@@ -101,7 +101,7 @@ def maclaurin_coeffs(b: float, eps: float, nmax: int) -> np.ndarray:
     a = (b * b) * beta.copy()
     a[1:] += 2.0 * b * beta[:-1]
     a[2:] += beta[:-2]
-    return a  # [nmax+1], all >= 0 for b >= 0
+    return cast(np.ndarray, a)  # [nmax+1], all >= 0 for b >= 0
 
 
 # --------------------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,7 +24,13 @@ python -m pytest \
   tests/test_workflow_policy.py \
   tests/test_collection_policy.py \
   tests/test_documentation_policy.py -q
+mypy --no-error-summary
 ```
+
+MyPy discovers the supported package surface from `[tool.mypy]` in
+`pyproject.toml`. New Python modules below `src/nmn/` are checked automatically.
+The small explicit exclusion list records existing annotation debt tracked by
+GitHub issue #114; remove a path from that list in the same change that fixes it.
 
 Tests for unavailable optional backends are skipped before importing that
 backend. Keep new optional-backend imports inside their backend tree or guarded

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -4,8 +4,14 @@ import json
 import re
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
+
 WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
 DOCUSAURUS = WORKFLOWS.parents[1] / "website" / "docusaurus"
+ROOT = WORKFLOWS.parents[1]
 CHECKOUT_REF = re.compile(r"actions/checkout@([^\s'\"#]+)")
 
 
@@ -73,6 +79,45 @@ def test_lint_toolchain_is_reproducible_and_skips_generated_version_file():
     assert '"black==26.5.1"' in workflow
     assert '"isort==9.0.1"' in workflow
     assert "extend-exclude = 'src/nmn/_version\\.py'" in project
+
+
+def test_mypy_checks_the_package_from_one_drift_resistant_config():
+    workflow = (WORKFLOWS / "test.yml").read_text()
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    config = project["tool"]["mypy"]
+    package_files = sorted((ROOT / "src" / "nmn").rglob("*.py"))
+    excluded_patterns = [re.compile(pattern) for pattern in config["exclude"]]
+    relative_files = [path.relative_to(ROOT).as_posix() for path in package_files]
+    excluded_files = [
+        path
+        for path in relative_files
+        if any(pattern.search(path) for pattern in excluded_patterns)
+    ]
+
+    assert config["files"] == ["src/nmn"]
+    assert config["follow_imports"] == "skip"
+    assert "mypy==2.3.1" in project["project"]["optional-dependencies"]["dev"]
+    assert len(excluded_patterns) == 19
+    assert len(excluded_files) == len(excluded_patterns)
+    assert len(package_files) - len(excluded_files) >= 80
+    assert all(
+        sum(bool(pattern.search(path)) for path in relative_files) == 1
+        for pattern in excluded_patterns
+    )
+    assert not any(pattern.search("src/nmn/cli.py") for pattern in excluded_patterns)
+    assert not any(
+        pattern.search("src/nmn/torch/attention/yat_attention.py")
+        for pattern in excluded_patterns
+    )
+    assert not any(
+        pattern.search("src/nmn/nnx/layers/attention/pallas_yat_attention.py")
+        for pattern in excluded_patterns
+    )
+    assert workflow.count("mypy --no-error-summary") == 1
+    mypy_job = workflow.split("  mypy:", 1)[1]
+    assert 'pip install -e ".[dev]" "numpy<2.3"' in mypy_job
+    assert "src/nmn/torch/" not in mypy_job
+    assert "src/nmn/nnx/" not in mypy_job
 
 
 def test_mirror_fails_and_verifies_when_sync_is_unavailable():


### PR DESCRIPTION
## Summary

- replace two embedded nine-file MyPy invocations with one package-wide configured surface
- automatically check every new `src/nmn` Python module while explicitly tracking 19 legacy-debt exclusions in #114
- pin the local/CI MyPy version, consolidate optional-import handling, and add drift-resistant workflow policy coverage
- include the import-light CLI in the checked surface and make its version return contract explicit

Closes #113.

## Verification

- `mypy --no-error-summary` with MyPy 2.3.1: passed (80 package files)
- `pytest tests/test_workflow_policy.py -q`: 10 passed
- `PYTHONPATH=src pytest tests/test_workflow_policy.py tests/test_cli.py -q`: 63 passed, 4 skipped
- pinned Black/isort and `git diff --check`: passed
- focused performer/Maclaurin runtime suite after CI-driven type fixes: 34 passed
- full non-slow local suite before the type-only `cast` follow-up: 1,427 passed, 14 skipped, 4 MLX compile/GPU failures on locally installed MLX 0.31.1; the repository Apple runner validates the MLX suite on its supported current runtime

## Follow-up

- #114 records every remaining excluded module and requires shrinking the list as annotations are corrected.
