### PR TITLE
048: Prepare and publish NMN v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+No changes yet.
+
+---
+
+## [0.3.4] — 2026-09-02
+
+### Added
+- **Complete direct-package static analysis** — MyPy 2.3.1 now checks every
+  Python module under `src/nmn` through one canonical configuration. CI policy
+  tests reject package exclusions, duplicate MyPy invocations, and accidental
+  narrowing of the checked package surface. Imported third-party modules remain
+  skipped so each NMN module owns its errors consistently across the supported
+  minimum/latest dependency matrix.
+- **Website pull-request validation** — Docusaurus now builds on Node.js 24 for
+  website changes, using the same static-asset preparation path as deployment.
+- **Minimum and latest JAX/Flax coverage** within the existing CI matrix, plus
+  policy tests for dependency, documentation, optional-backend collection, and
+  workflow invariants.
+
+### Changed
+- Updated every GitHub Actions checkout to `actions/checkout@v7`, artifact
+  upload/download actions to their Node.js 24 releases, Docusaurus packages to
+  3.10.2, and React/React DOM to 19.2.8.
+- Reorganized the test tree so assertion-based regressions remain under pytest
+  while exploratory diagnostics and benchmarks live outside test collection.
+- Modernized Flax NNX variable updates to avoid deprecated `.value`
+  assignments while preserving shared-bank identity, slices, and gradients.
+- Corrected accelerator installation documentation to use the real `nmn[nnx]`
+  extra with the official JAX TPU/CUDA wheels and metadata-aligned minimums.
+
+### Fixed
+- Mirror synchronization now fails visibly when its credential is unavailable
+  instead of reporting a false successful no-op.
+- Pinned lint/type-check tooling and import-light CLI annotations make local and
+  CI quality gates deterministic across supported backend versions.
+
+---
+
+## [0.3.3] — 2026-09-01
+
+### Added
+- Native Apple Silicon/Metal MLX CI, TPU-oriented Pallas validation, Windows
+  process-tree cleanup regressions, safe optional-backend collection, and a
+  broader cross-framework numerical-parity suite.
+- Precision policy plumbing for every Pallas attention dot product and
+  TPU-legal NNX Pallas BlockSpecs for forward and backward kernels.
+
+### Changed
+- Low-precision YAT score paths accumulate overflow-prone intermediates and
+  operator-local cotangents safely while preserving genuine NaNs and public
+  float16/bfloat16 output contracts.
+- Learnable epsilon initialization uses stable inverse softplus with validated,
+  dtype-aware storage across dense and convolution families.
+- Fully masked attention rows, broadcast masks, normalization, output
+  projection, and incremental decoding semantics are aligned across backends.
+
+### Fixed
+- Grouped and transposed convolution parity, Keras `channels_first` execution
+  on TensorFlow CPU, shared-kernel-bank lifecycle behavior, and serialization.
+- MLX fused epsilon gradients and transposed-convolution `SAME` behavior,
+  including compiled/lazy and native Metal coverage.
+- NNX attention custom-VJP gradients, cache transactionality and overflow,
+  DropConnect RNG behavior, grouped patch norms, and transpose-kernel layouts.
+- Release publishing now runs only for version tags and validates artifacts in
+  TestPyPI before publishing to PyPI.
+
+---
+
 ## [0.3.2] — 2026-06-09
 
 ### Added

--- a/tests/test_documentation_policy.py
+++ b/tests/test_documentation_policy.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 OPTIONAL_DEPENDENCIES = PYPROJECT["project"]["optional-dependencies"]
 NNX_README = (ROOT / "src/nmn/nnx/README.md").read_text(encoding="utf-8")
+CHANGELOG = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
 
 
 def _minimum_version(extra: str, package: str) -> str:
@@ -64,3 +65,21 @@ def test_agent_docs_link_to_release_sources_instead_of_hard_coding_version():
         assert "Current release:" not in content
         assert "https://pypi.org/project/nmn/" in content
         assert "https://github.com/azettaai/nmn/releases" in content
+
+
+def test_changelog_has_unreleased_and_descending_dated_releases():
+    headers = re.findall(
+        r"^## \[([^\]]+)\](?: — (\d{4}-\d{2}-\d{2}))?$",
+        CHANGELOG,
+        re.MULTILINE,
+    )
+    assert headers and headers[0] == ("Unreleased", "")
+
+    releases = headers[1:]
+    versions = [version for version, _date in releases]
+    assert len(versions) == len(set(versions))
+    assert all(re.fullmatch(r"\d+\.\d+\.\d+", version) for version in versions)
+    assert all(date for _version, date in releases)
+
+    version_tuples = [tuple(map(int, version.split("."))) for version in versions]
+    assert version_tuples == sorted(version_tuples, reverse=True)

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -85,13 +85,20 @@ def test_mypy_checks_the_package_from_one_drift_resistant_config():
     workflow = (WORKFLOWS / "test.yml").read_text()
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())
     config = project["tool"]["mypy"]
-    package_files = sorted((ROOT / "src" / "nmn").rglob("*.py"))
+    package_files = sorted(
+        path
+        for path in (ROOT / "src" / "nmn").rglob("*.py")
+        if path.name != "_version.py"
+    )
 
     assert config["files"] == ["src/nmn"]
     assert config["follow_imports"] == "skip"
     assert "exclude" not in config
     assert "mypy==2.3.1" in project["project"]["optional-dependencies"]["dev"]
-    assert len(package_files) >= 99
+    # hatch-vcs materializes the ignored ``_version.py`` during builds. Count
+    # only committed package sources so this invariant is identical in a clean
+    # checkout and an already-built developer tree.
+    assert len(package_files) >= 98
     assert workflow.count("mypy --no-error-summary") == 1
     mypy_job = workflow.split("  mypy:", 1)[1]
     assert 'pip install -e ".[dev]" "numpy<2.3"' in mypy_job


### PR DESCRIPTION
Implements dacli task 048-prepare-and-publish-nmn-v0-3-4.

Refs #117

### Acceptance
- [x] Add accurate 0.3.3 and 0.3.4 changelog entries derived from landed changes; do not claim unverified behavior.
- [x] Build sdist and wheel from the release-preparation commit and smoke-test the installed wheel.
- [ ] Release policy tests and required CI pass on the preparation PR.
- [ ] Merge the preparation PR to master and verify the exact commit on origin/master.
- [ ] Create and push annotated tag v0.3.4 from that exact commit.
- [ ] Verify the tag workflow publishes successfully to TestPyPI and PyPI.
- [ ] Create/verify the GitHub Release with generated notes and link it from the issue.
