### PR TITLE
048: Prepare and publish NMN v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ No changes yet.
   extra with the official JAX TPU/CUDA wheels and metadata-aligned minimums.
 
 ### Fixed
+- Source distributions explicitly exclude the local `.dacli` orchestration and
+  evidence ledger, including run transcripts and task worktrees.
 - Mirror synchronization now fails visibly when its credential is unavailable
   instead of reporting a false successful no-op.
 - Pinned lint/type-check tooling and import-light CLI annotations make local and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,9 @@ version-file = "src/nmn/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nmn"]
+
+[tool.hatch.build.targets.sdist]
+# dacli is the local orchestration/evidence ledger. It is excluded through
+# .git/info/exclude rather than the shared .gitignore, so declare the release
+# boundary explicitly instead of relying on developer-local Git state.
+exclude = ["/.dacli"]

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -106,6 +106,13 @@ def test_mypy_checks_the_package_from_one_drift_resistant_config():
     assert "src/nmn/nnx/" not in mypy_job
 
 
+def test_sdist_excludes_the_local_dacli_evidence_ledger():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    sdist = project["tool"]["hatch"]["build"]["targets"]["sdist"]
+
+    assert "/.dacli" in sdist["exclude"]
+
+
 def test_mirror_fails_and_verifies_when_sync_is_unavailable():
     workflow = (WORKFLOWS / "mirror.yml").read_text()
 


### PR DESCRIPTION
Implements dacli task 048-prepare-and-publish-nmn-v0-3-4.

Refs #117

### Acceptance
- [x] Add accurate 0.3.3 and 0.3.4 changelog entries derived from landed changes; do not claim unverified behavior.
- [x] Build sdist and wheel from the release-preparation commit and smoke-test the installed wheel.
- [x] Release policy tests and required CI pass on the preparation PR.
- [x] Merge the preparation PR to master and verify the exact commit on origin/master.
- [ ] Create and push annotated tag v0.3.4 from that exact commit.
- [ ] Verify the tag workflow publishes successfully to TestPyPI and PyPI.
- [ ] Create/verify the GitHub Release with generated notes and link it from the issue.
