### PR TITLE
051: Repair developer workflow, documentation, and template drift

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,6 +30,7 @@ body:
         - Flax Linen (nmn.linen)
         - Keras (nmn.keras)
         - TensorFlow (nmn.tf)
+        - MLX (nmn.mlx)
         - Cross-framework / consistency
         - Build / packaging
         - Documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -36,6 +36,7 @@ body:
         - Flax Linen (nmn.linen)
         - Keras (nmn.keras)
         - TensorFlow (nmn.tf)
+        - MLX (nmn.mlx)
         - All frameworks
         - Build / packaging
         - Documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,7 @@ Thanks for sending a pull request! Please make sure you've read CONTRIBUTING.md 
 - [ ] Flax Linen (`nmn.linen`)
 - [ ] Keras (`nmn.keras`)
 - [ ] TensorFlow (`nmn.tf`)
+- [ ] MLX (`nmn.mlx`)
 - [ ] All / cross-framework
 
 ## Test plan

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,20 +12,20 @@ repos:
         exclude: ^website/
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3
         files: ^(src|tests)/.*\.py$
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 9.0.1
     hooks:
       - id: isort
         files: ^(src|tests)/.*\.py$
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         # Configuration (max-line-length, ignores, per-file-ignores) lives in setup.cfg.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-No changes yet.
+### Changed
+- Repaired the contributor workflow so clean dev installs can build packages,
+  local pytest always resolves the checkout, Make and CI share package-wide
+  type checking, and documentation/templates match the six supported backends.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,7 @@ pip install -e ".[dev,nnx]"       # Flax NNX (JAX)
 pip install -e ".[dev,linen]"     # Flax Linen (JAX)
 pip install -e ".[dev,keras]"     # Keras
 pip install -e ".[dev,tf]"        # TensorFlow
+pip install -e ".[dev,mlx]"       # MLX (Apple Silicon)
 
 # Everything (heavy; recommended for cross-framework consistency work)
 pip install -e ".[test]"
@@ -94,7 +95,6 @@ nmn info          # banner with the six frameworks and their pip extras
 ### 5. (Optional) install the pre-commit hooks
 
 ```bash
-pip install pre-commit
 pre-commit install
 ```
 
@@ -116,7 +116,7 @@ make test-torch     # one backend's tests (also: -nnx, -linen, -keras, -tf, -mlx
 make lint           # flake8 errors (E9,F63,F7,F82) + advisory style pass
 make format         # auto-format with black + isort
 make format-check   # check formatting without writing
-make typecheck      # mypy on the torch and nnx backends
+make typecheck      # mypy on the full nmn package
 
 make build          # build sdist + wheel
 make docs           # where to find the documentation
@@ -136,7 +136,7 @@ Each of the six framework backends — `nmn.torch`, `nmn.nnx`, `nmn.linen`, `nmn
 | `nmn[torch]` | torch, torchvision | `nmn.torch` |
 | `nmn[nnx]` | jax, jaxlib, flax | `nmn.nnx` |
 | `nmn[linen]` | jax, jaxlib, flax | `nmn.linen` |
-| `nmn[keras]` | tensorflow | `nmn.keras` |
+| `nmn[keras]` | keras | `nmn.keras` (select a Keras backend separately) |
 | `nmn[tf]` | tensorflow | `nmn.tf` |
 | `nmn[mlx]` | mlx (Apple Silicon) | `nmn.mlx` |
 
@@ -195,11 +195,11 @@ open htmlcov/index.html
 # Skip slow tests
 pytest tests/ -m "not slow"
 
-# Only one framework's marker
-pytest tests/ -m torch
 ```
 
-Custom markers are declared in [`pyproject.toml`](pyproject.toml): `slow`, `integration`, `torch`, `jax`, `tf`.
+The `slow` marker is declared in [`pyproject.toml`](pyproject.toml). Select a
+backend by its test directory rather than by a marker; optional backends that
+are unavailable are skipped safely.
 
 ### Writing tests
 
@@ -217,7 +217,7 @@ Style is enforced by **black**, **isort**, **flake8**, and **mypy**. black/isort
 make format        # black + isort (writes changes)
 make format-check  # black + isort in --check mode
 make lint          # flake8 errors (must pass) + advisory style pass
-make typecheck     # mypy on the torch and nnx backends
+make typecheck     # mypy on the full nmn package
 ```
 
 The equivalent raw commands:
@@ -231,12 +231,12 @@ isort src/ tests/
 flake8 src/nmn --select=E9,F63,F7,F82       # errors only (must pass)
 flake8 src/nmn --max-line-length=127        # style (informational)
 
-# Type check (informational for now, tightening over time)
-mypy src/nmn/torch --ignore-missing-imports
-mypy src/nmn/nnx   --ignore-missing-imports
+# Type check (uses the package-wide configuration in pyproject.toml)
+mypy --no-error-summary
 ```
 
-CI fails only on **flake8 errors** (`E9,F63,F7,F82`) and test failures. Black/isort/mypy are advisory but please run them locally before pushing.
+CI blocks on test failures, **flake8 errors** (`E9,F63,F7,F82`), Black,
+isort, and package-wide MyPy. Run the matching `make` targets before pushing.
 
 ### Conventions
 
@@ -273,7 +273,7 @@ Layers should reach **all 6 frameworks** before being considered complete. The r
 3. **Run tests + linters** locally.
 4. **Update CHANGELOG.md** under `## [Unreleased]` if the change is user-visible.
 5. **Open a PR** against `master`. Fill in the PR template — describe what changed, why, and how it was tested.
-6. **CI must pass** (tests + flake8 errors). Style checks are advisory but help reviewers.
+6. **CI must pass** (tests, formatting, lint, and package-wide type checks).
 7. **One reviewer approval** is required for merge. A maintainer will merge.
 
 PRs that touch more than one framework should ideally be split, unless the change is intrinsically cross-framework (e.g. a renaming for parity).

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ help: ## Show this help (default target)
 	@echo "  lint           flake8 errors (E9,F63,F7,F82) + advisory style pass"
 	@echo "  format         Auto-format with black + isort"
 	@echo "  format-check   Check formatting without writing (black/isort --check)"
-	@echo "  typecheck      mypy on the torch and nnx backends"
+	@echo "  typecheck      mypy on the full nmn package"
 	@echo ""
 	@echo "Build & docs"
 	@echo "  build          Build the sdist + wheel (python -m build)"
@@ -103,9 +103,8 @@ format-check: ## Check formatting without modifying files
 	$(PYTHON) -m black --check --diff $(SRC) $(TEST)
 	$(PYTHON) -m isort --check-only --diff $(SRC) $(TEST)
 
-typecheck: ## mypy on the torch and nnx backends
-	$(PYTHON) -m mypy $(SRC)/torch --ignore-missing-imports
-	$(PYTHON) -m mypy $(SRC)/nnx --ignore-missing-imports
+typecheck: ## mypy on the full nmn package using pyproject.toml
+	$(PYTHON) -m mypy --no-error-summary
 
 # ---------------------------------------------------------------------------
 # Build & docs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ NMN follows semantic versioning. Security fixes are applied to the latest minor 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2.x   | :white_check_mark: |
-| < 0.2   | :x:                |
+| 0.3.x   | :white_check_mark: |
+| < 0.3   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,12 @@ nmn = "nmn.cli:main"
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
-    "black>=23.0.0",
-    "flake8>=6.0.0",
-    "isort>=5.12.0",
+    "build>=1.2.2",
+    "black==26.5.1",
+    "flake8==7.3.0",
+    "isort==9.0.1",
     "mypy==2.3.1",
+    "pre-commit>=4.0.0",
     "hatch-vcs>=0.3.0",
     "tomli>=1.1.0; python_version < '3.11'",
 ]
@@ -89,16 +91,13 @@ skip_glob = ["build/*", "dist/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = ["--verbose", "--tb=short", "--strict-markers"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
-    "torch: marks tests requiring PyTorch",
-    "jax: marks tests requiring JAX/Flax",
-    "tf: marks tests requiring TensorFlow",
 ]
 
 [tool.mypy]

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -4,6 +4,8 @@ import json
 import re
 from pathlib import Path
 
+import nmn
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10
@@ -79,6 +81,47 @@ def test_lint_toolchain_is_reproducible_and_skips_generated_version_file():
     assert '"black==26.5.1"' in workflow
     assert '"isort==9.0.1"' in workflow
     assert "extend-exclude = 'src/nmn/_version\\.py'" in project
+
+
+def test_local_checkout_precedes_any_installed_nmn_package():
+    package_path = Path(nmn.__file__).resolve()
+
+    assert package_path.is_relative_to(ROOT / "src")
+
+
+def test_developer_commands_and_tool_versions_match_ci():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    makefile = (ROOT / "Makefile").read_text()
+    precommit = (ROOT / ".pre-commit-config.yaml").read_text()
+    dev = set(project["project"]["optional-dependencies"]["dev"])
+
+    assert "build>=1.2.2" in dev
+    assert {"black==26.5.1", "isort==9.0.1", "flake8==7.3.0"} <= dev
+    assert "$(PYTHON) -m mypy --no-error-summary" in makefile
+    assert "rev: 26.5.1" in precommit
+    assert "rev: 9.0.1" in precommit
+    assert "rev: 7.3.0" in precommit
+
+
+def test_only_documented_pytest_markers_are_declared():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    assert project["tool"]["pytest"]["ini_options"]["markers"] == [
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')"
+    ]
+
+
+def test_contribution_templates_cover_every_backend():
+    expected = {"nmn.torch", "nmn.nnx", "nmn.linen", "nmn.keras", "nmn.tf", "nmn.mlx"}
+    templates = [
+        ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md",
+        ROOT / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml",
+        ROOT / ".github" / "ISSUE_TEMPLATE" / "feature_request.yml",
+    ]
+
+    for template in templates:
+        contents = template.read_text()
+        assert all(backend in contents for backend in expected), template
 
 
 def test_mypy_checks_the_package_from_one_drift_resistant_config():


### PR DESCRIPTION
Implements dacli task 051-repair-developer-workflow-documentation-and-template-drift.

Refs #124

### Acceptance
- [x] `make install && make build` works in a clean environment.
- [x] `make typecheck` invokes the same package-wide MyPy configuration as CI.
- [x] Pytest reliably imports `src/nmn` when run from a checkout, with a regression test against stale installed-package shadowing.
- [x] Security and contribution documentation matches v0.3.x, optional extras, and blocking CI behavior.
- [x] Either apply the documented backend/integration markers consistently or remove the unused marker-based instructions/configuration.
- [x] Add MLX to contribution and issue templates.
- [x] Align pre-commit tool versions with CI or centralize the versions.
