### PR TITLE
052: Close CI trigger gaps and harden workflow supply chain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,6 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment
 concurrency:
@@ -27,6 +25,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
       - name: Checkout repository
@@ -63,7 +62,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/minimum-versions.yml
+++ b/.github/workflows/minimum-versions.yml
@@ -1,0 +1,90 @@
+name: Minimum Backend Versions
+
+on:
+  pull_request:
+    paths:
+      - 'pyproject.toml'
+      - '.github/workflows/minimum-versions.yml'
+  schedule:
+    - cron: '23 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  torch:
+    name: PyTorch 1.11 minimum smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: pip
+      - name: Install declared lower bound
+        run: |
+          pip install numpy pytest
+          pip install -e . --no-deps
+          pip install 'torch==1.11.0+cpu' 'torchvision==0.12.0+cpu' --extra-index-url https://download.pytorch.org/whl/cpu
+          pip check
+      - name: Exercise representative public APIs
+        run: pytest tests/test_torch/test_yat_nmn.py tests/test_torch/test_attention.py -q
+
+  tensorflow:
+    name: TensorFlow 2.10 minimum smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: pip
+      - name: Install declared lower bound
+        run: |
+          pip install pytest 'tensorflow==2.10.0'
+          pip install -e . --no-deps
+          pip check
+      - name: Exercise representative public APIs
+        run: pytest tests/test_tf/test_basic.py tests/test_tf/test_attention.py -q
+
+  keras:
+    name: Keras 3.0 minimum smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      KERAS_BACKEND: torch
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          cache: pip
+      - name: Install declared lower bound
+        run: |
+          pip install numpy pytest 'keras==3.0.0'
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -e . --no-deps
+          pip check
+      - name: Exercise representative public APIs
+        run: pytest tests/test_keras/test_basic.py tests/test_keras/test_attention.py -q
+
+  mlx:
+    name: MLX 0.18 minimum smoke
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install declared lower bound
+        run: |
+          pip install numpy pytest 'mlx==0.18.0'
+          pip install -e . --no-deps
+          pip check
+      - name: Exercise representative public APIs on Apple Silicon
+        run: pytest tests/test_mlx/test_basic.py tests/test_mlx/test_attention.py -q

--- a/.github/workflows/minimum-versions.yml
+++ b/.github/workflows/minimum-versions.yml
@@ -44,7 +44,8 @@ jobs:
           cache: pip
       - name: Install declared lower bound
         run: |
-          pip install pytest 'tensorflow==2.10.0'
+          # TensorFlow 2.10 predates NumPy 2's binary ABI.
+          pip install pytest 'numpy<2' 'tensorflow==2.10.0'
           pip install -e . --no-deps
           pip check
       - name: Exercise representative public APIs

--- a/.github/workflows/minimum-versions.yml
+++ b/.github/workflows/minimum-versions.yml
@@ -72,7 +72,7 @@ jobs:
         run: pytest tests/test_keras/test_basic.py tests/test_keras/test_attention.py -q
 
   mlx:
-    name: MLX 0.18 minimum smoke
+    name: MLX 0.18.1 minimum smoke
     runs-on: macos-15
     timeout-minutes: 15
     steps:
@@ -83,7 +83,7 @@ jobs:
           cache: pip
       - name: Install declared lower bound
         run: |
-          pip install numpy pytest 'mlx==0.18.0'
+          pip install numpy pytest 'mlx==0.18.1'
           pip install -e . --no-deps
           pip check
       - name: Exercise representative public APIs on Apple Silicon

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -28,6 +28,7 @@ jobs:
   mirror:
     name: Push master + tags to mlnomadpy/nmn
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,12 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # required for OIDC trusted publishing
 
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -48,6 +48,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: testpypi
       url: https://test.pypi.org/p/nmn
@@ -59,7 +63,7 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI (trusted publisher / OIDC)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -69,6 +73,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [build, publish-to-testpypi]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/p/nmn
@@ -80,6 +88,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI (trusted publisher / OIDC)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,18 +3,8 @@ name: Test Suite
 on:
   push:
     branches: [ main, master, develop ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - '.github/workflows/test.yml'
   pull_request:
     branches: [ main, master, develop ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - '.github/workflows/test.yml'
   workflow_dispatch:
 
 # Cancel an in-flight run when a new commit lands on the same ref. The
@@ -111,7 +101,7 @@ jobs:
         JAX_PLATFORM_NAME: cpu
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       if: matrix.dependencies == 'minimum'
       with:
         files: ./coverage.xml
@@ -182,7 +172,7 @@ jobs:
         -k "optional_backend_probe_windows_job_kills_descendants"
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       with:
         files: ./coverage.xml
@@ -236,7 +226,7 @@ jobs:
         pytest tests/test_keras/ tests/test_tf/ -v --cov=nmn --cov-report=xml
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       with:
         files: ./coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Repaired the contributor workflow so clean dev installs can build packages,
   local pytest always resolves the checkout, Make and CI share package-wide
   type checking, and documentation/templates match the six supported backends.
+- Hardened CI/CD with immutable third-party Action pins, job-scoped OIDC,
+  bounded release/deploy jobs, unskippable policy checks, and scheduled runtime
+  smoke tests for every declared backend minimum.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Hardened CI/CD with immutable third-party Action pins, job-scoped OIDC,
   bounded release/deploy jobs, unskippable policy checks, and scheduled runtime
   smoke tests for every declared backend minimum.
+- Restored PyTorch 1.11 masked-attention compatibility and corrected the MLX
+  lower bound to 0.18.1, the first published release in the 0.18 series.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ torch = ["torch>=1.11.0", "torchvision>=0.12.0"]
 keras = ["keras>=3.0.0"]
 tf = ["tensorflow>=2.10.0"]
 linen = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
-mlx = ["mlx>=0.18.0"]
+mlx = ["mlx>=0.18.1"]
 all = ["nmn[nnx,torch,keras,tf,linen]"]
 test = [
     "nmn[dev,all]",

--- a/src/nmn/torch/attention/multi_head.py
+++ b/src/nmn/torch/attention/multi_head.py
@@ -254,7 +254,8 @@ class MultiHeadYatAttention(nn.Module):
         # A projection bias must not reintroduce a value for a query whose
         # every key is masked in every head.
         if effective_mask is not None:
-            query_has_key = effective_mask.any(dim=(-3, -1))
+            # Torch 1.11 accepts only one reduction dimension at a time.
+            query_has_key = effective_mask.any(dim=-1).any(dim=-2)
             x = torch.where(query_has_key.unsqueeze(-1), x, torch.zeros_like(x))
 
         return x

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,3 +37,22 @@ owns its errors consistently across the supported backend-version matrix.
 Tests for unavailable optional backends are skipped before importing that
 backend. Keep new optional-backend imports inside their backend tree or guarded
 with `pytest.importorskip`.
+
+## Dependency and accelerator policy
+
+Every pull request runs the latest supported CPU suites for JAX/Flax, PyTorch,
+TensorFlow, and all three Keras backends. The declared lower bounds for Torch,
+TensorFlow, Keras, and MLX receive a weekly representative runtime smoke test;
+JAX/Flax's lower bound runs its full suite on every pull request because it is
+the reference implementation. Dependabot keeps both mutable dependency ranges
+and the immutable GitHub Action commit pins current.
+
+Continuous accelerator coverage is intentionally explicit:
+
+- MLX runs its full suite, fused Metal kernel gradients, and transpose-kernel
+  parity on a real Apple Silicon GPU for every pull request;
+- PyTorch, TensorFlow, Keras, and ordinary JAX tests run on CPU;
+- Pallas kernels run their independent numerical oracle and BlockSpec legality
+  checks in CPU interpret mode;
+- native TPU Mosaic and CUDA execution remain external validation gates and
+  are not represented as continuously tested in compatibility claims.

--- a/tests/test_torch/test_attention.py
+++ b/tests/test_torch/test_attention.py
@@ -24,6 +24,9 @@ class TestAttentionFunctions:
 
     @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
     @pytest.mark.parametrize("spherical", [False, True])
+    @pytest.mark.skipif(
+        not hasattr(torch, "compile"), reason="torch.compile requires PyTorch 2"
+    )
     def test_fully_masked_rows_are_zero_with_finite_compiled_gradients(
         self, spherical, dtype
     ):
@@ -130,6 +133,9 @@ class TestAttentionFunctions:
 class TestMultiHeadYatAttention:
     @pytest.mark.parametrize("mask_rank", [2, 4])
     @pytest.mark.parametrize("cross_attention", [False, True])
+    @pytest.mark.skipif(
+        not hasattr(torch, "compile"), reason="torch.compile requires PyTorch 2"
+    )
     def test_fully_masked_rows_stay_zero_after_biased_output_projection(
         self, cross_attention, mask_rank
     ):

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -15,6 +15,7 @@ WORKFLOWS = Path(__file__).parents[1] / ".github" / "workflows"
 DOCUSAURUS = WORKFLOWS.parents[1] / "website" / "docusaurus"
 ROOT = WORKFLOWS.parents[1]
 CHECKOUT_REF = re.compile(r"actions/checkout@([^\s'\"#]+)")
+ACTION_REF = re.compile(r"uses:\s+([^\s@]+)@([^\s#]+)")
 
 
 def test_publish_uploads_only_version_tags():
@@ -44,11 +45,77 @@ def test_ci_actions_use_node24_compatible_releases():
     assert "actions/download-artifact@v4" not in workflows
 
 
+def test_third_party_actions_are_immutable_and_dependabot_updates_them():
+    workflow_paths = [*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")]
+    action_refs = [
+        (owner, ref)
+        for path in workflow_paths
+        for owner, ref in ACTION_REF.findall(path.read_text())
+        if not owner.startswith("actions/")
+    ]
+
+    assert action_refs
+    assert all(re.fullmatch(r"[0-9a-f]{40}", ref) for _, ref in action_refs)
+    assert {owner for owner, _ in action_refs} == {
+        "codecov/codecov-action",
+        "pypa/gh-action-pypi-publish",
+    }
+    dependabot = (ROOT / ".github" / "dependabot.yml").read_text()
+    assert 'package-ecosystem: "github-actions"' in dependabot
+
+
 def test_codecov_uses_current_files_input():
     workflow = (WORKFLOWS / "test.yml").read_text()
 
     assert "        file: ./coverage.xml" not in workflow
     assert workflow.count("        files: ./coverage.xml") == 3
+
+
+def test_policy_ci_runs_for_every_pull_request_and_push():
+    workflow = (WORKFLOWS / "test.yml").read_text()
+    trigger = workflow.split("concurrency:", 1)[0]
+
+    assert "pull_request:" in trigger
+    assert "push:" in trigger
+    assert "paths:" not in trigger
+
+
+def test_release_and_deployment_permissions_are_job_scoped_and_bounded():
+    publish = (WORKFLOWS / "publish.yml").read_text()
+    deploy = (WORKFLOWS / "deploy.yml").read_text()
+    mirror = (WORKFLOWS / "mirror.yml").read_text()
+
+    publish_global = publish.split("jobs:", 1)[0]
+    deploy_global = deploy.split("jobs:", 1)[0]
+    publish_build = publish.split("  build:", 1)[1].split("  publish-to-testpypi:", 1)[
+        0
+    ]
+    deploy_build = deploy.split("  build:", 1)[1].split("  deploy:", 1)[0]
+
+    assert "id-token: write" not in publish_global
+    assert "id-token: write" not in publish_build
+    assert publish.count("id-token: write") == 2
+    assert "id-token: write" not in deploy_global
+    assert "id-token: write" not in deploy_build
+    assert deploy.count("id-token: write") == 1
+    assert publish.count("timeout-minutes:") == 3
+    assert deploy.count("timeout-minutes:") == 2
+    assert mirror.count("timeout-minutes:") == 1
+
+
+def test_minimum_backend_policy_is_scheduled_and_matches_metadata():
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    workflow = (WORKFLOWS / "minimum-versions.yml").read_text()
+    docs = (ROOT / "tests" / "README.md").read_text()
+    extras = project["project"]["optional-dependencies"]
+
+    assert "schedule:" in workflow and "workflow_dispatch:" in workflow
+    assert "torch==1.11.0+cpu" in workflow and "torch>=1.11.0" in extras["torch"]
+    assert "tensorflow==2.10.0" in workflow and "tensorflow>=2.10.0" in extras["tf"]
+    assert "keras==3.0.0" in workflow and "keras>=3.0.0" in extras["keras"]
+    assert "mlx==0.18.0" in workflow and "mlx>=0.18.0" in extras["mlx"]
+    assert "native TPU Mosaic and CUDA" in docs
+    assert "real Apple Silicon GPU" in docs
 
 
 def test_jax_ci_covers_minimum_and_latest_dependency_sets():

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -113,7 +113,7 @@ def test_minimum_backend_policy_is_scheduled_and_matches_metadata():
     assert "torch==1.11.0+cpu" in workflow and "torch>=1.11.0" in extras["torch"]
     assert "tensorflow==2.10.0" in workflow and "tensorflow>=2.10.0" in extras["tf"]
     assert "keras==3.0.0" in workflow and "keras>=3.0.0" in extras["keras"]
-    assert "mlx==0.18.0" in workflow and "mlx>=0.18.0" in extras["mlx"]
+    assert "mlx==0.18.1" in workflow and "mlx>=0.18.1" in extras["mlx"]
     assert "native TPU Mosaic and CUDA" in docs
     assert "real Apple Silicon GPU" in docs
 


### PR DESCRIPTION
Implements dacli task 052-close-ci-trigger-gaps-and-harden-workflow-supply-chain.

Refs #123

### Acceptance
- [x] Trigger policy/quality CI for every workflow and packaging/developer-policy file it validates.
- [x] Add explicit job timeouts to publish, mirror, and deployment workflows.
- [x] Scope OIDC permission only to jobs that publish or deploy.
- [x] Pin third-party Actions to immutable commits, with update automation retained.
- [x] Document and test a sustainable minimum-version policy for Torch, TensorFlow, Keras, and MLX, or raise unsupported lower bounds.
- [x] Document continuous accelerator coverage and clearly identify TPU/CUDA gaps.
- [x] Add workflow-policy tests for the new invariants.
