### PR TITLE
054: Make coverage uploads observable and enforce coverage policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,9 @@ jobs:
     name: Test JAX/Flax (${{ matrix.dependencies }}, py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -106,13 +109,17 @@ jobs:
       with:
         files: ./coverage.xml
         flags: jax
-        token: ${{ secrets.CODECOV_TOKEN }}
-      continue-on-error: true
+        use_oidc: true
+        fail_ci_if_error: true
+        disable_search: true
 
   test-torch:
     name: Test PyTorch (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -177,13 +184,17 @@ jobs:
       with:
         files: ./coverage.xml
         flags: torch
-        token: ${{ secrets.CODECOV_TOKEN }}
-      continue-on-error: true
+        use_oidc: true
+        fail_ci_if_error: true
+        disable_search: true
 
   test-keras:
     name: Test Keras/TF (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -231,8 +242,9 @@ jobs:
       with:
         files: ./coverage.xml
         flags: keras
-        token: ${{ secrets.CODECOV_TOKEN }}
-      continue-on-error: true
+        use_oidc: true
+        fail_ci_if_error: true
+        disable_search: true
 
   test-keras-multibackend:
     name: Test Keras (${{ matrix.backend }} backend)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,19 @@ jobs:
       env:
         JAX_PLATFORM_NAME: cpu
 
+    - name: Stage JAX coverage data
+      if: matrix.dependencies == 'minimum'
+      run: cp .coverage .coverage.jax
+
+    - name: Preserve JAX coverage for the local policy gate
+      uses: actions/upload-artifact@v7
+      if: matrix.dependencies == 'minimum'
+      with:
+        name: coverage-jax
+        path: .coverage.jax
+        include-hidden-files: true
+        if-no-files-found: error
+
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       if: matrix.dependencies == 'minimum'
@@ -172,11 +185,24 @@ jobs:
     - name: Run PyTorch tests
       run: pytest tests/test_torch/ -v --cov=nmn --cov-report=xml
 
+    - name: Stage PyTorch coverage data
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      run: cp .coverage .coverage.torch
+
     - name: Verify Windows optional-backend probe cleanup
       if: runner.os == 'Windows'
       run: >-
         python -m pytest tests/test_cli.py -v
         -k "optional_backend_probe_windows_job_kills_descendants"
+
+    - name: Preserve PyTorch coverage for the local policy gate
+      uses: actions/upload-artifact@v7
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      with:
+        name: coverage-torch
+        path: .coverage.torch
+        include-hidden-files: true
+        if-no-files-found: error
 
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
@@ -236,6 +262,19 @@ jobs:
       run: |
         pytest tests/test_keras/ tests/test_tf/ -v --cov=nmn --cov-report=xml
 
+    - name: Stage Keras/TF coverage data
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      run: cp .coverage .coverage.keras
+
+    - name: Preserve Keras/TF coverage for the local policy gate
+      uses: actions/upload-artifact@v7
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+      with:
+        name: coverage-keras
+        path: .coverage.keras
+        include-hidden-files: true
+        if-no-files-found: error
+
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
@@ -245,6 +284,57 @@ jobs:
         use_oidc: true
         fail_ci_if_error: true
         disable_search: true
+
+  coverage-policy:
+    name: Enforce combined and changed-line coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [test-jax, test-torch, test-keras]
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install coverage policy tools
+      run: python -m pip install "coverage[toml]" diff-cover
+
+    - name: Download JAX coverage
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-jax
+        path: coverage-data
+
+    - name: Download PyTorch coverage
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-torch
+        path: coverage-data
+
+    - name: Download Keras/TF coverage
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-keras
+        path: coverage-data
+
+    - name: Enforce 70% combined project coverage
+      run: |
+        coverage combine coverage-data
+        coverage xml -o combined-coverage.xml
+        coverage report --fail-under=70
+
+    - name: Enforce 80% changed-line coverage
+      if: github.event_name == 'pull_request'
+      run: >-
+        diff-cover combined-coverage.xml
+        --compare-branch=origin/${{ github.base_ref }}
+        --fail-under=80
 
   test-keras-multibackend:
     name: Test Keras (${{ matrix.backend }} backend)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   advisory without expanding the website audit allowlist.
 - Made coverage uploads authenticated through OIDC and failure-blocking, with
   explicit project and patch coverage policies for the combined backend flags.
+- Added a repository-owned coverage gate that combines JAX, PyTorch, and
+  Keras/TensorFlow data, enforcing 70% project and 80% changed-line coverage
+  even when an external reporting integration is unavailable.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   exact reviewed allowance only for two upstream `image-size` no-fix findings.
 - Updated `qs` to 6.16.0 to resolve its request-buffer denial-of-service
   advisory without expanding the website audit allowlist.
+- Made coverage uploads authenticated through OIDC and failure-blocking, with
+  explicit project and patch coverage policies for the combined backend flags.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://pypi.org/project/nmn/"><img src="https://img.shields.io/pypi/v/nmn.svg?style=flat-square&color=blue" alt="PyPI version"></a>
   <a href="https://pepy.tech/project/nmn"><img src="https://static.pepy.tech/badge/nmn?style=flat-square" alt="Downloads"></a>
   <a href="https://github.com/azettaai/nmn/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/azettaai/nmn/test.yml?style=flat-square&label=tests" alt="Tests"></a>
-  <a href="https://codecov.io/gh/azettaai/nmn"><img src="https://img.shields.io/codecov/c/github/azettaai/nmn?style=flat-square" alt="Coverage"></a>
+  <a href="https://codecov.io/gh/azettaai/nmn"><img src="https://img.shields.io/codecov/c/github/azettaai/nmn?branch=master&style=flat-square" alt="Coverage"></a>
   <a href="https://pypi.org/project/nmn/"><img src="https://img.shields.io/pypi/pyversions/nmn?style=flat-square" alt="Python"></a>
   <a href="https://pypi.org/project/nmn/"><img src="https://img.shields.io/pypi/l/nmn?style=flat-square&color=green" alt="License"></a>
 </p>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+coverage:
+  precision: 2
+  round: down
+  range: 50..100
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+
+flag_management:
+  default_rules:
+    carryforward: true
+
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  require_changes: true
+
+github_checks:
+  annotations: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ strict_equality = true
 
 [tool.coverage.run]
 source = ["src/nmn"]
-omit = ["*/tests/*", "*/examples/*", "*/__pycache__/*"]
+omit = ["*/tests/*", "*/examples/*", "*/__pycache__/*", "*/_version.py"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -107,6 +107,29 @@ def test_codecov_uploads_are_oidc_authenticated_and_failure_blocking():
     assert "carryforward: true" in policy
 
 
+def test_local_coverage_policy_is_fail_closed_and_combines_backend_data():
+    workflow = (WORKFLOWS / "test.yml").read_text()
+    project = (ROOT / "pyproject.toml").read_text()
+
+    assert workflow.count("uses: actions/upload-artifact@v7") == 3
+    assert workflow.count("uses: actions/download-artifact@v8") == 3
+    assert workflow.count("include-hidden-files: true") == 3
+    assert workflow.count("if-no-files-found: error") == 3
+    assert "cp .coverage .coverage.jax" in workflow
+    assert "cp .coverage .coverage.torch" in workflow
+    assert "cp .coverage .coverage.keras" in workflow
+    assert "needs: [test-jax, test-torch, test-keras]" in workflow
+    assert "coverage combine coverage-data" in workflow
+    assert "coverage report --fail-under=70" in workflow
+    assert "--compare-branch=origin/${{ github.base_ref }}" in workflow
+    assert "--fail-under=80" in workflow
+    assert '"*/_version.py"' in project
+    coverage_job = workflow.split("  coverage-policy:", 1)[1].split(
+        "\n  test-keras-multibackend:", 1
+    )[0]
+    assert "continue-on-error" not in coverage_job
+
+
 def test_policy_ci_runs_for_every_pull_request_and_push():
     workflow = (WORKFLOWS / "test.yml").read_text()
     trigger = workflow.split("concurrency:", 1)[0]

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -89,6 +89,24 @@ def test_codecov_uses_current_files_input():
     assert workflow.count("        files: ./coverage.xml") == 3
 
 
+def test_codecov_uploads_are_oidc_authenticated_and_failure_blocking():
+    workflow = (WORKFLOWS / "test.yml").read_text()
+    readme = (ROOT / "README.md").read_text()
+    policy = (ROOT / "codecov.yml").read_text()
+
+    assert workflow.count("        use_oidc: true") == 3
+    assert workflow.count("        fail_ci_if_error: true") == 3
+    assert workflow.count("        disable_search: true") == 3
+    assert workflow.count("      id-token: write") == 3
+    assert "CODECOV_TOKEN" not in workflow
+    for upload in workflow.split("- name: Upload coverage")[1:]:
+        assert "continue-on-error" not in upload.split("\n\n", 1)[0]
+    assert "branch=master" in readme
+    assert "target: auto" in policy
+    assert "target: 80%" in policy
+    assert "carryforward: true" in policy
+
+
 def test_policy_ci_runs_for_every_pull_request_and_push():
     workflow = (WORKFLOWS / "test.yml").read_text()
     trigger = workflow.split("concurrency:", 1)[0]


### PR DESCRIPTION
Implements dacli task 054-make-coverage-uploads-observable-and-enforce-coverage-policy.

Refs #121

### Acceptance
- [x] Configure authenticated Codecov upload using OIDC or a valid repository secret.
- [x] Set uploads to fail visibly when the coverage report cannot be uploaded.
- [x] The public coverage badge reports a numeric value for `master`.
- [x] Add a checked Codecov configuration with explicit project/patch policy or an equivalent local coverage floor.
- [x] Add workflow-policy regression tests covering authentication and failure behavior.
