### PR TITLE
050: Remediate and track Docusaurus dependency advisories

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -36,6 +36,10 @@ jobs:
         working-directory: website/docusaurus
         run: npm ci
 
+      - name: Enforce reviewed dependency advisories
+        working-directory: website/docusaurus
+        run: npm run audit:ci
+
       - name: Prepare static website assets
         run: bash website/prepare-docusaurus-static.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   smoke tests for every declared backend minimum.
 - Restored PyTorch 1.11 masked-attention compatibility and corrected the MLX
   lower bound to 0.18.1, the first published release in the 0.18 series.
+- Patched the website's `serialize-javascript` and `uuid` dependency paths and
+  added a fail-closed audit gate for new high/critical advisories, retaining an
+  exact reviewed allowance only for two upstream `image-size` no-fix findings.
 
 ---
 

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -299,4 +299,6 @@ def test_website_dependency_audit_has_exact_reviewed_allowlist():
     }
     assert "critical > 0" in script
     assert "Unreviewed high advisories" in script
+    assert "report.error" in script
+    assert "did not return a vulnerability report" in script
     assert "reviewed repository images" in rationale

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -274,3 +274,29 @@ def test_website_manifest_and_lockfile_use_coherent_versions():
         )
         assert locked_requirement == version
         assert locked_packages[f"node_modules/{package}"]["version"] == version
+
+
+def test_website_dependency_audit_has_exact_reviewed_allowlist():
+    manifest = json.loads((DOCUSAURUS / "package.json").read_text())
+    lockfile = json.loads((DOCUSAURUS / "package-lock.json").read_text())
+    workflow = (WORKFLOWS / "website.yml").read_text()
+    script = (ROOT / "website" / "audit-dependencies.mjs").read_text()
+    rationale = (ROOT / "website" / "DEPENDENCY_SECURITY.md").read_text()
+
+    assert manifest["scripts"]["audit:ci"] == "node ../audit-dependencies.mjs"
+    assert manifest["overrides"] == {
+        "serialize-javascript": "7.1.1",
+        "uuid": "11.1.1",
+    }
+    assert (
+        lockfile["packages"]["node_modules/serialize-javascript"]["version"] == "7.1.1"
+    )
+    assert lockfile["packages"]["node_modules/uuid"]["version"] == "11.1.1"
+    assert "npm run audit:ci" in workflow
+    assert set(re.findall(r"'(GHSA-[\w-]+)'", script)) == {
+        "GHSA-w3rx-r6r6-pgpr",
+        "GHSA-5p2g-fcmc-qvqq",
+    }
+    assert "critical > 0" in script
+    assert "Unreviewed high advisories" in script
+    assert "reviewed repository images" in rationale

--- a/website/DEPENDENCY_SECURITY.md
+++ b/website/DEPENDENCY_SECURITY.md
@@ -1,0 +1,31 @@
+# Website dependency security
+
+The documentation site is built from reviewed files in this repository. CI
+runs `npm run audit:ci` after every clean install and rejects critical findings
+or any high-severity advisory that is not listed in the audit script.
+
+## Applied remediations
+
+- `serialize-javascript` is overridden to 7.1.1, removing the RCE and CPU
+  exhaustion advisories inherited through Docusaurus's webpack plugins.
+- `uuid` is overridden to 11.1.1, the first patched release for the buffer
+  bounds advisory inherited through `sockjs`.
+
+Both overrides are exercised by the production Docusaurus build. Dependabot
+continues to update the npm lockfile weekly.
+
+## Reviewed residual advisories
+
+Docusaurus 3.10.2 currently resolves `image-size` 2.0.2, which is also the latest
+published release. No patched version exists for these build-time parser denial
+of service advisories:
+
+- `GHSA-w3rx-r6r6-pgpr` — ICNS parser infinite loop;
+- `GHSA-5p2g-fcmc-qvqq` — JXL/HEIF parser infinite loops.
+
+Exposure is limited because the production build processes only versioned,
+reviewed repository images and MDX; it does not accept user uploads or fetch
+untrusted images. This is a containment measure, not a suppression. The audit
+script requires the exact two-advisory allowlist: a new high finding fails CI,
+and a patched upstream release also fails CI until the obsolete allowance is
+removed.

--- a/website/audit-dependencies.mjs
+++ b/website/audit-dependencies.mjs
@@ -24,6 +24,16 @@ try {
   process.exit(1);
 }
 
+if (
+  report.error ||
+  typeof report.vulnerabilities !== 'object' ||
+  typeof report.metadata?.vulnerabilities !== 'object'
+) {
+  const detail = report.error?.detail || report.error?.summary || report.message;
+  console.error(`npm audit did not return a vulnerability report: ${detail || 'unknown error'}`);
+  process.exit(1);
+}
+
 const activeHighAdvisories = new Set();
 for (const vulnerability of Object.values(report.vulnerabilities ?? {})) {
   for (const advisory of vulnerability.via ?? []) {

--- a/website/audit-dependencies.mjs
+++ b/website/audit-dependencies.mjs
@@ -1,0 +1,58 @@
+import {spawnSync} from 'node:child_process';
+
+const acceptedHighAdvisories = new Set([
+  'GHSA-5p2g-fcmc-qvqq',
+  'GHSA-w3rx-r6r6-pgpr',
+]);
+
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const result = spawnSync(npm, ['audit', '--omit=dev', '--json'], {
+  cwd: process.cwd(),
+  encoding: 'utf8',
+});
+
+if (result.error || ![0, 1].includes(result.status)) {
+  console.error(result.stderr || result.error || 'npm audit failed unexpectedly');
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(result.stdout);
+} catch (error) {
+  console.error(`npm audit did not return valid JSON: ${error.message}`);
+  process.exit(1);
+}
+
+const activeHighAdvisories = new Set();
+for (const vulnerability of Object.values(report.vulnerabilities ?? {})) {
+  for (const advisory of vulnerability.via ?? []) {
+    if (typeof advisory !== 'object' || advisory === null) continue;
+    if (!['high', 'critical'].includes(advisory.severity)) continue;
+    const match = advisory.url?.match(/GHSA-[\w-]+$/);
+    activeHighAdvisories.add(match?.[0] ?? advisory.url ?? advisory.title);
+  }
+}
+
+const unreviewed = [...activeHighAdvisories].filter(
+  advisory => !acceptedHighAdvisories.has(advisory),
+);
+const stale = [...acceptedHighAdvisories].filter(
+  advisory => !activeHighAdvisories.has(advisory),
+);
+const critical = report.metadata?.vulnerabilities?.critical ?? 0;
+
+if (critical > 0 || unreviewed.length > 0 || stale.length > 0) {
+  if (critical > 0) console.error(`npm audit reports ${critical} critical findings`);
+  if (unreviewed.length > 0) {
+    console.error(`Unreviewed high advisories: ${unreviewed.join(', ')}`);
+  }
+  if (stale.length > 0) {
+    console.error(`Remove resolved advisories from the allowlist: ${stale.join(', ')}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Dependency audit passed with ${activeHighAdvisories.size} explicitly reviewed high advisories.`,
+);

--- a/website/docusaurus/package-lock.json
+++ b/website/docusaurus/package-lock.json
@@ -15514,15 +15514,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -16543,12 +16534,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.1.tgz",
+      "integrity": "sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -18026,13 +18017,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/docusaurus/package.json
+++ b/website/docusaurus/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "audit:ci": "node ../audit-dependencies.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -27,6 +28,10 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.2",
     "@docusaurus/types": "3.10.2"
+  },
+  "overrides": {
+    "serialize-javascript": "7.1.1",
+    "uuid": "11.1.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Implements dacli task 050-remediate-and-track-docusaurus-dependency-advisories.

Refs #125

### Acceptance
- [x] Apply every non-breaking lockfile remediation currently available, including `uuid`.
- [x] Determine whether patched Docusaurus/transitive releases or safe overrides resolve each high advisory.
- [x] Document residual no-fix advisories and why repository-only trusted build inputs limit exposure.
- [x] Add a CI audit policy that fails on newly introduced high/critical advisories without making accepted no-fix advisories permanently red.
- [x] Re-run the Docusaurus production build after dependency changes.
