### PR TITLE
055: Restore the broken public mirror and sync v0.3.4

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,55 +1,61 @@
-name: Mirror to mlnomadpy/nmn
+name: Sync public mirror
 
-# Keeps the original repository github.com/mlnomadpy/nmn in sync with the
-# canonical github.com/azettaai/nmn. On every push to master (and on version
-# tags) this fast-forwards the mirror's master and pushes all tags.
-#
-# Setup (one-time): create a Personal Access Token with `contents:write` (repo)
-# scope on mlnomadpy/nmn and add it to this repo's secrets as `MIRROR_PAT`
-# (Settings → Secrets and variables → Actions). A missing secret is a failed
-# synchronization and must remain visible in Actions.
+# This file is intentionally identical in the canonical and mirror repositories.
+# It executes only in mlnomadpy/nmn, where the ephemeral GITHUB_TOKEN has write
+# access to that repository and no access to azettaai/nmn. The canonical source
+# is fetched anonymously and the mirror refuses divergent history or tag edits.
 
 on:
-  push:
-    branches:
-      - master
-    tags:
-      - 'v*.*.*'
+  schedule:
+    - cron: '17 * * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: mirror-mlnomadpy
+  group: sync-public-mirror
   cancel-in-progress: false
 
 jobs:
-  mirror:
-    name: Push master + tags to mlnomadpy/nmn
+  sync:
+    name: Fast-forward master and tags from azettaai/nmn
+    if: github.repository == 'mlnomadpy/nmn'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # full history + tags for a clean fast-forward
+          fetch-depth: 0
 
-      - name: Mirror to mlnomadpy/nmn
-        env:
-          MIRROR_PAT: ${{ secrets.MIRROR_PAT }}
+      - name: Fetch and verify canonical history
         run: |
-          if [ -z "${MIRROR_PAT}" ]; then
-            echo "::error::MIRROR_PAT is not set; the public mirror was not updated."
+          git remote add canonical https://github.com/azettaai/nmn.git
+          git fetch --prune canonical master --tags
+          mirror_head="$(git rev-parse refs/remotes/origin/master)"
+          canonical_head="$(git rev-parse refs/remotes/canonical/master)"
+          if ! git merge-base --is-ancestor "${mirror_head}" "${canonical_head}"; then
+            echo "Mirror master has diverged from canonical master." >&2
             exit 1
           fi
-          remote="https://x-access-token:${MIRROR_PAT}@github.com/mlnomadpy/nmn.git"
-          # Sync master (fast-forward only; the mirror should never diverge).
-          git push "${remote}" "HEAD:refs/heads/master"
-          # Sync all version tags.
-          git push "${remote}" --tags
-          expected_head="$(git rev-parse HEAD)"
-          mirrored_head="$(git ls-remote "${remote}" refs/heads/master | awk '{print $1}')"
-          if [ "${mirrored_head}" != "${expected_head}" ]; then
-            echo "::error::Mirror verification failed: expected ${expected_head}, got ${mirrored_head:-missing}."
-            exit 1
-          fi
+
+      - name: Update mirror with repository-scoped authentication
+        run: |
+          git push origin refs/remotes/canonical/master:refs/heads/master
+          git push origin --tags
+
+      - name: Verify remote master and tags
+        run: |
+          canonical_head="$(git rev-parse refs/remotes/canonical/master)"
+          mirrored_head="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
+          test -n "${mirrored_head}"
+          test "${mirrored_head}" = "${canonical_head}"
+
+          while IFS= read -r tag_ref; do
+            canonical_tag="$(git rev-parse "${tag_ref}")"
+            mirrored_tag="$(git ls-remote origin "${tag_ref}" | awk '{print $1}')"
+            test -n "${mirrored_tag}"
+            test "${mirrored_tag}" = "${canonical_tag}"
+          done < <(git for-each-ref --format='%(refname)' refs/tags)

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -223,14 +223,20 @@ def test_sdist_excludes_the_local_dacli_evidence_ledger():
     assert "/.dacli" in sdist["exclude"]
 
 
-def test_mirror_fails_and_verifies_when_sync_is_unavailable():
+def test_mirror_uses_repository_scoped_self_sync_and_verifies_every_ref():
     workflow = (WORKFLOWS / "mirror.yml").read_text()
 
-    assert 'if [ -z "${MIRROR_PAT}" ]; then' in workflow
-    assert "exit 0" not in workflow
-    assert "exit 1" in workflow
+    assert "github.repository == 'mlnomadpy/nmn'" in workflow
+    assert "contents: write" in workflow
+    assert "MIRROR_PAT" not in workflow
+    assert "https://github.com/azettaai/nmn.git" in workflow
+    assert "git merge-base --is-ancestor" in workflow
+    assert "git push origin refs/remotes/canonical/master:refs/heads/master" in workflow
+    assert "git push origin --tags" in workflow
     assert "git ls-remote" in workflow
     assert "mirrored_head" in workflow
+    assert "mirrored_tag" in workflow
+    assert "continue-on-error" not in workflow
 
 
 def test_website_is_built_on_pull_requests_with_node24():


### PR DESCRIPTION
Implements dacli task 055-restore-the-broken-public-mirror-and-sync-v0-3-4.

Refs #120

### Acceptance
- [x] Configure a least-privilege credential or documented replacement authentication mechanism that can write to `mlnomadpy/nmn`.
- [ ] A manual mirror workflow run completes successfully.
- [ ] Mirror `master` exactly matches canonical `master`.
- [ ] Mirror contains the annotated `v0.3.4` tag at the canonical release commit.
- [x] The workflow continues to fail visibly when authentication or verification is unavailable.
