### PR TITLE
053: Protect master, release tags, and repository security settings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           fetch-depth: 0  # full history so hatch-vcs can read tags
 
+      - name: Verify release tag is contained in master
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          git fetch --no-tags origin master
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/master
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,27 @@ You should receive an acknowledgment within **72 hours**. We will follow up with
 - Once a fix is released, we will publicly disclose the vulnerability via a GitHub Security Advisory and a release note in [`CHANGELOG.md`](CHANGELOG.md).
 - We aim for **90 days** from report to public disclosure as a maximum; faster if a patch is straightforward.
 
+## Repository and Release Integrity
+
+The following GitHub repository settings are part of NMN's release security
+boundary and must remain enabled:
+
+- the `master` branch ruleset requires pull requests and the repository's lint,
+  type-check, base-install, and representative backend test checks;
+- deletion and non-fast-forward updates are blocked for `master`;
+- version tags matching `v*.*.*` cannot be deleted or updated;
+- secret scanning, secret-scanning push protection, and Dependabot security
+  updates are enabled;
+- merged pull-request branches are deleted automatically; and
+- the `pypi` environment retains its required reviewer and trusted-publisher
+  configuration.
+
+The publication workflow provides a second release boundary: a version tag is
+accepted only when its commit is contained in `origin/master`, artifacts are
+built once, TestPyPI publication succeeds, and the protected `pypi` environment
+approves the final OIDC publication. Repository administrators should audit
+these settings after ownership, plan, or workflow changes.
+
 ## Scope
 
 In scope:

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -25,10 +25,8 @@ def test_publish_uploads_only_version_tags():
     assert "branches:" not in trigger_block
     assert "- 'v*.*.*'" in trigger_block
     assert "if: startsWith(github.ref, 'refs/tags/v')" in workflow
-    assert 'git fetch --no-tags origin master' in workflow
-    assert (
-        'git merge-base --is-ancestor "$GITHUB_SHA" origin/master' in workflow
-    )
+    assert "git fetch --no-tags origin master" in workflow
+    assert 'git merge-base --is-ancestor "$GITHUB_SHA" origin/master' in workflow
 
 
 def test_release_integrity_controls_are_documented():

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -25,6 +25,24 @@ def test_publish_uploads_only_version_tags():
     assert "branches:" not in trigger_block
     assert "- 'v*.*.*'" in trigger_block
     assert "if: startsWith(github.ref, 'refs/tags/v')" in workflow
+    assert 'git fetch --no-tags origin master' in workflow
+    assert 'git merge-base --is-ancestor "$GITHUB_SHA" origin/master' in workflow
+
+
+def test_release_integrity_controls_are_documented():
+    security = (ROOT / "SECURITY.md").read_text()
+    security = " ".join(security.split())
+
+    for control in (
+        "`master` branch ruleset",
+        "version tags matching `v*.*.*`",
+        "secret-scanning push protection",
+        "Dependabot security updates",
+        "deleted automatically",
+        "contained in `origin/master`",
+        "protected `pypi` environment",
+    ):
+        assert control in security
 
 
 def test_ci_actions_use_node24_compatible_releases():

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -26,7 +26,9 @@ def test_publish_uploads_only_version_tags():
     assert "- 'v*.*.*'" in trigger_block
     assert "if: startsWith(github.ref, 'refs/tags/v')" in workflow
     assert 'git fetch --no-tags origin master' in workflow
-    assert 'git merge-base --is-ancestor "$GITHUB_SHA" origin/master' in workflow
+    assert (
+        'git merge-base --is-ancestor "$GITHUB_SHA" origin/master' in workflow
+    )
 
 
 def test_release_integrity_controls_are_documented():


### PR DESCRIPTION
Implements dacli task 053-protect-master-release-tags-and-repository-security-settings.

Refs #122

### Acceptance
- [ ] Enable an enforced default-branch ruleset requiring pull requests and the repository's required test<withheld-local-path> checks.
- [ ] Prevent force pushes and branch deletion on `master`.
- [ ] Protect release tags matching `v*.*.*` or enforce an equivalent release rule.
- [ ] Enable secret scanning, push protection, and Dependabot security updates where supported.
- [ ] Enable automatic deletion of merged branches.
- [x] Document which repository settings are required for release integrity.
