### PR TITLE
056: Fix new qs denial-of-service advisory and keep audit policy synchronized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Patched the website's `serialize-javascript` and `uuid` dependency paths and
   added a fail-closed audit gate for new high/critical advisories, retaining an
   exact reviewed allowance only for two upstream `image-size` no-fix findings.
+- Updated `qs` to 6.16.0 to resolve its request-buffer denial-of-service
+  advisory without expanding the website audit allowlist.
 
 ---
 

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -309,12 +309,14 @@ def test_website_dependency_audit_has_exact_reviewed_allowlist():
 
     assert manifest["scripts"]["audit:ci"] == "node ../audit-dependencies.mjs"
     assert manifest["overrides"] == {
+        "qs": "6.16.0",
         "serialize-javascript": "7.1.1",
         "uuid": "11.1.1",
     }
     assert (
         lockfile["packages"]["node_modules/serialize-javascript"]["version"] == "7.1.1"
     )
+    assert lockfile["packages"]["node_modules/qs"]["version"] == "6.16.0"
     assert lockfile["packages"]["node_modules/uuid"]["version"] == "11.1.1"
     assert "npm run audit:ci" in workflow
     assert set(re.findall(r"'(GHSA-[\w-]+)'", script)) == {

--- a/website/DEPENDENCY_SECURITY.md
+++ b/website/DEPENDENCY_SECURITY.md
@@ -10,6 +10,8 @@ or any high-severity advisory that is not listed in the audit script.
   exhaustion advisories inherited through Docusaurus's webpack plugins.
 - `uuid` is overridden to 11.1.1, the first patched release for the buffer
   bounds advisory inherited through `sockjs`.
+- `qs` is overridden to 6.16.0, the first patched release for
+  `GHSA-4mjr-xmp4-gh2g`, inherited through the Docusaurus development server.
 
 Both overrides are exercised by the production Docusaurus build. Dependabot
 continues to update the npm lockfile weekly.

--- a/website/docusaurus/package-lock.json
+++ b/website/docusaurus/package-lock.json
@@ -15467,9 +15467,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/website/docusaurus/package.json
+++ b/website/docusaurus/package.json
@@ -30,6 +30,7 @@
     "@docusaurus/types": "3.10.2"
   },
   "overrides": {
+    "qs": "6.16.0",
     "serialize-javascript": "7.1.1",
     "uuid": "11.1.1"
   },


### PR DESCRIPTION
Implements dacli task 056-fix-new-qs-denial-of-service-advisory-and-keep-audit-policy-synchronized.

Refs #133

### Acceptance
- [ ] Resolve `qs` to `>=6.16.0` without weakening the exact advisory allowlist.
- [ ] `npm audit --json` reports only the two documented upstream `image-size` no-fix findings.
- [ ] `npm run audit:ci` and `npm run build` pass on Node 24.
- [ ] Add or strengthen regression coverage so a patchable advisory cannot be silently allowlisted.
- [ ] Update dependency-security documentation and changelog.
- [ ] Confirm Dependabot alert #3 closes after merge.
