### PR TITLE
060: Ship a portable NMN agent skill for all supported frameworks

### DIFF
--- a/.claude/skills/nmn/SKILL.md
+++ b/.claude/skills/nmn/SKILL.md
@@ -1,126 +1,140 @@
 ---
 name: nmn
-description: >-
-  Use when writing, reviewing, or debugging code that uses the `nmn`
-  (Neural-Matter Network) Python library — activation-free YAT / ⵟ neural
-  layers and attention that learn non-linearity geometrically. Trigger when a
-  file imports `nmn` or `from nmn.<framework> import ...`; when the user
-  mentions "Neural Matter Network", "YAT layer/attention", `YatNMN`, `YatConv`,
-  `MultiHeadYatAttention`, `RotaryYatAttention`, the MAY/RAY performer feature
-  maps, or lazy YatNMN training; or when choosing/using nmn across PyTorch,
-  Flax NNX, Flax Linen, Keras, TensorFlow, or MLX. Covers per-framework imports
-  and the `units`/`features`/`in_features` constructor differences, the
-  SLAY/MAY/RAY performer maps, lazy mode, and the `nmn` CLI.
+description: Use when writing, porting, reviewing, debugging, training, exporting, or benchmarking code with the nmn Neural Matter Network Python package. Trigger on `import nmn`, `nmn.torch`, `nmn.nnx`, `nmn.linen`, `nmn.keras`, `nmn.tf`, `nmn.mlx`, YatNMN/YatDense, YAT convolution or embedding, MultiHeadYatAttention, RotaryYatAttention, SLAY/MAY/RAY/GOAT attention, Pallas YAT kernels, tied kernel banks, learnable epsilon, lazy or mixed-precision NMN training. Provides verified per-framework constructors, tensor layouts, masking semantics, serialization, accelerator guidance, and tests for PyTorch, Flax NNX, Flax Linen, Keras 3, TensorFlow, and MLX.
 ---
 
-# Using the `nmn` (Neural-Matter Network) library
+# Use NMN
 
-`nmn` ships **YAT (ⵟ) layers** — activation-free neural layers whose response is
-`(⟨w,x⟩ + b)² / (‖w − x‖² + ε)`, a ratio of *similarity* to *distance*. The same
-math is implemented, numerically equivalent (< 1e-6 fp32), across **six
-frameworks**. Each framework is an independent optional install.
+Treat the installed package and repository source as authoritative. NMN ships
+the YAT family across six independent backends; similar class names do not imply
+identical constructor names, layouts, state APIs, or export formats.
 
-## Step 0 — check the environment first
+## Start with discovery
 
-Before writing code, confirm which backend is installed:
+Run these before writing backend-specific code:
 
 ```bash
-nmn doctor            # which of the 6 backends import + versions
-nmn guide <framework> # a self-contained quickstart (torch/nnx/linen/keras/tf/mlx)
-nmn features          # MAY/RAY performer maps + lazy YatNMN usage
+nmn version
+nmn doctor
+nmn frameworks
+nmn guide <torch|nnx|linen|keras|tf|mlx>
+nmn features
 ```
 
-`import nmn` is import-light; a framework is only pulled in when you import its
-subpackage. If a backend is missing: `pip install nmn[<framework>]`
-(`torch`, `nnx`, `linen`, `keras`, `tf`, `mlx`).
+If working from a checkout, inspect `src/nmn/<backend>/__init__.py` and the real
+class signature. Do not infer one backend's kwargs from another.
 
-## Pick the framework, then use the EXACT import + constructor
+Install exactly the backend needed:
 
-The single most common mistake is the wrong `YatNMN` constructor kwarg — it
-differs per framework. Use this table verbatim:
+```bash
+python -m pip install "nmn[torch]"
+python -m pip install "nmn[nnx]"
+python -m pip install "nmn[linen]"
+python -m pip install "nmn[keras]"
+python -m pip install "nmn[tf]"
+python -m pip install "nmn[mlx]"
+```
 
-| Framework | Import | `YatNMN` constructor |
+`nmn[all]` excludes MLX because MLX requires Apple Silicon. Importing `nmn`
+itself is framework-light; importing a backend requires that backend's extra.
+
+## Select the backend reference
+
+Read only the reference relevant to the task:
+
+- [PyTorch](references/pytorch.md): eager/compile, tied banks, `param_dtype`.
+- [Flax NNX](references/flax-nnx.md): NNX state, JIT, decode, performers,
+  precision modes, and Pallas TPU/GPU attention.
+- [Flax Linen](references/flax-linen.md): `init`/`apply`, Optax freezing,
+  grouped convolution, softmax/L1 attention.
+- [Keras 3](references/keras.md): backend selection, serialization, shared
+  convolution banks, and channels-first portability.
+- [TensorFlow](references/tensorflow.md): native TF modules, `tf.function`,
+  grouped convolution, and SavedModel signatures.
+- [MLX](references/mlx.md): Apple GPU, eager/fused paths, compile, decode, and
+  transpose-SAME semantics.
+
+For behavior shared by all backends, read
+[the cross-framework contract](references/shared-contract.md).
+
+## Constructor map
+
+Use the exact dense constructor for the selected backend:
+
+| Backend | Import | Construction |
 | --- | --- | --- |
-| PyTorch | `from nmn.torch import YatNMN` | `YatNMN(in_features, out_features)` |
-| Flax NNX | `from nmn.nnx import YatNMN` | `YatNMN(in_features, out_features, rngs=nnx.Rngs(0))` |
-| Flax Linen | `from nmn.linen import YatNMN` | `YatNMN(features=N)` — call `YatNMN(features=N)(x)` |
-| Keras | `from nmn.keras import YatNMN` | `YatNMN(units)` — **`units`, not `features`** |
-| TensorFlow | `from nmn.tf import YatNMN` | `YatNMN(features)` |
-| MLX | `from nmn.mlx import YatNMN` | `YatNMN(features)` |
+| PyTorch | `from nmn.torch import YatNMN` | `YatNMN(in_features=128, out_features=64)` |
+| Flax NNX | `from nmn.nnx import YatNMN` | `YatNMN(128, 64, rngs=nnx.Rngs(0))` |
+| Flax Linen | `from nmn.linen import YatNMN` | `YatNMN(features=64)` then `init`/`apply` |
+| Keras 3 | `from nmn.keras import YatNMN` | `YatNMN(units=64)` |
+| TensorFlow | `from nmn.tf import YatNMN` | `YatNMN(features=64)`; input width is lazy |
+| MLX | `from nmn.mlx import YatNMN` | `YatNMN(features=64)`; input width is lazy |
 
-Minimal MLP (Flax NNX):
+Common aliases are intentionally incomplete: Keras/TF/MLX export `YatDense`;
+NNX exports dimension-generic `YatConv` and `YatConvTranspose` plus aliases;
+Linen attention is `MultiHeadAttention`; Torch/Keras/TF/MLX use
+`MultiHeadYatAttention`.
 
-```python
-from flax import nnx
-from nmn.nnx import YatNMN
+## Core semantics
 
-class MLP(nnx.Module):
-    def __init__(self, rngs):
-        self.fc1 = YatNMN(in_features=784, out_features=256, rngs=rngs)
-        self.fc2 = YatNMN(in_features=256, out_features=10, rngs=rngs)
-    def __call__(self, x):
-        return self.fc2(self.fc1(x))   # no activation between layers — YAT is non-linear
+For an input vector `x` and output kernel vector `w`, YAT computes a learned
+scale of
+
+```text
+((dot(x, w) + bias) ** 2) / (squared_distance(x, w) + epsilon)
 ```
 
-Common knobs (same names across frameworks): `use_bias`, `use_alpha` /
-`constant_alpha`, `epsilon`, `learnable_epsilon`. Conv variants exist too:
-`YatConv{1,2,3}D` / `YatConvTranspose{1,2,3}D` (torch/keras/tf/linen) and
-`YatConv` (nnx).
+The ratio is already nonlinear. Do not automatically insert ReLU/GELU after a
+YAT layer. `constant_alpha=True` means the backend's documented constant;
+a numeric `constant_alpha` uses that value. `lazy=True` / `freeze_kernel=True`
+freezes only the kernel; bias, alpha, and learnable epsilon remain trainable.
 
-## Attention
+`epsilon` must be finite and strictly positive. When `learnable_epsilon=True`,
+the public effective epsilon is `softplus(epsilon_param)`. Keep optimizer and
+checkpoint code aware that low-precision layers may retain epsilon state in
+FP32 to avoid underflow or overflow.
 
-- `MultiHeadYatAttention(embed_dim, num_heads, ...)` — Keras / TensorFlow / MLX.
-- Flax NNX: `from nmn.nnx import MultiHeadAttention` → `MultiHeadAttention(num_heads, in_features, rngs=...)` (also exported as `MultiHeadYatAttention`).
-- Flax Linen: `MultiHeadAttention(num_heads, qkv_features=..., out_features=...)` — **no `in_features`**.
-- NNX RoPE + O(n) performer: `RotaryYatAttention(embed_dim, num_heads, use_performer=True, performer_kind="slay"|"maclaurin"|"radial", performer_num_features=256, rngs=...)`. There is **no `key_dim`** kwarg anywhere, and RotaryYatAttention takes `embed_dim` (not `in_features`) and `performer_num_features` (not `num_features`).
+## Attention and masks
 
-## Linear-attention feature maps: SLAY / MAY / RAY
+Functional attention tensors use `[..., query_length, heads, head_dim]` for Q
+and `[..., key_length, heads, head_dim]` for K/V. Modules generally accept
+batch-major `[batch, sequence, embedding]` inputs.
 
-Approximate the spherical-YAT kernel `κ(s) = (s+b)²/((2+ε)−2s)` so attention runs
-in **O(n)**. Available across frameworks as `create_*_projection` /
-`*_features` / `*_yat_attention` (canonical kwargs `bias=`, `epsilon=`):
+Boolean masks use `True` for allowed positions and may be broadcast from common
+`[Q,K]`, `[B,Q,K]`, or `[B,H,Q,K]` forms. A fully masked query row produces
+exactly zero attention weights and exactly zero module output, including after
+an output projection with bias. Do not replace this with a uniform row or NaNs.
 
-- **SLAY** (anchor) — bias-free (`b = 0`) only.
-- **MAY** (Random Maclaurin) — bias-aware; near-exact for the deployment regime `b > 0`, where it beats SLAY.
-- **RAY** (radial) — bias-aware secondary route.
+Use SLAY for the bias-free spherical-anchor regime. Use MAY (`maclaurin`) or
+RAY (`radial`) when the kernel bias matters. Their features are sign-indefinite;
+stabilize only the final denominator, never the features themselves.
 
-```python
-from nmn.nnx import create_maclaurin_projection, maclaurin_yat_attention
-# epsilon here is the YAT ε. MAY is near-exact when ε ≈ the median squared
-# distance (~O(1) on the unit sphere), not a tiny stabilizer like 1e-5.
-p = create_maclaurin_projection(key, head_dim=64, num_features=256, bias=1.0, epsilon=0.5)
-out = maclaurin_yat_attention(q, k, v, p)   # q,k,v: [batch, seq, heads, head_dim]
-```
+## Numeric policy
 
-MAY/RAY features are **sign-indefinite** — never add an epsilon to the features
-(it biases the estimator); only stabilize the division denominator.
+NMN promotes vulnerable low-precision score reductions where necessary,
+preserves the requested public output dtype, saturates finite values that do not
+fit that dtype, and preserves genuine NaNs. Compare low-precision behavior to a
+synchronized FP32 reference for outputs and all trainable/input gradients.
 
-## Lazy training mode (freeze the kernel)
+A mathematically out-of-range gradient accumulated from multiple independent
+uses of the same FP16 leaf cannot be represented in FP16. Prefer FP32 parameter
+storage, autocast/loss scaling, or BF16 where appropriate; do not claim arbitrary
+FP16 leaf accumulation remains exact.
 
-`YatNMN(..., lazy=True)` (alias `freeze_kernel=True`) freezes **only the kernel**
-feature directions; **`bias`, `alpha`, and `epsilon` stay trainable**. Uses each
-backend's idiomatic mechanism (NNX `FrozenParam`, torch `requires_grad=False`,
-mlx `freeze`, Keras/TF `trainable=False`, linen `stop_gradient`). Default is
-`lazy=False` (unchanged).
+## Verification workflow
 
-## Gotchas
-
-- Backends are **independent optional installs** — run `nmn doctor`; don't assume torch/tf/jax/mlx is present.
-- `YatNMN` kwarg differs per framework (table above) — Keras is `units`, NOT `features`.
-- No `key_dim` on any attention class; `MultiHeadYatAttention` needs `embed_dim` + `num_heads`.
-- Don't insert activation functions between YAT layers — the non-linearity is built in.
-- There is **no RNN module** (`nmn.nnx.rnn` does not exist); any such import is wrong.
-- Squashers are at the package root: `from nmn.nnx import softermax, softer_sigmoid, soft_tanh`.
-
-## Verify
-
-Run the whole suite (backend tests auto-skip when a framework is absent), or
-target one backend's directory:
+Test the narrow backend first, then shared parity and the full available suite:
 
 ```bash
-python -m pytest -q                 # full suite
-python -m pytest tests/test_torch -q # one backend
+python -m pytest -q tests/test_<backend>
+python -m pytest -q tests/integration
+python -m pytest -q
 ```
 
-For deeper, self-contained per-framework quickstarts, prefer `nmn guide <framework>`
-over guessing — it prints verified, runnable snippets.
+Missing optional backends should skip cleanly. Validate on the real accelerator
+for accelerator-specific paths: Pallas on TPU/GPU and fused MLX on Apple Metal.
+CPU interpretation proves algebra, not native lowering.
+
+When porting between backends, synchronize every parameter explicitly and test
+forward values plus input/kernel/bias/alpha/epsilon gradients. Compare semantics,
+not initializer randomness or framework-default layouts.

--- a/.claude/skills/nmn/SKILL.md
+++ b/.claude/skills/nmn/SKILL.md
@@ -89,21 +89,26 @@ YAT layer. `constant_alpha=True` means the backend's documented constant;
 a numeric `constant_alpha` uses that value. `lazy=True` / `freeze_kernel=True`
 freezes only the kernel; bias, alpha, and learnable epsilon remain trainable.
 
-`epsilon` must be finite and strictly positive. When `learnable_epsilon=True`,
-the public effective epsilon is `softplus(epsilon_param)`. Keep optimizer and
-checkpoint code aware that low-precision layers may retain epsilon state in
-FP32 to avoid underflow or overflow.
+Pass a finite, strictly positive `epsilon`; treat this as a caller precondition
+because validation is not yet uniform across every backend. When
+`learnable_epsilon=True`, the public effective epsilon is
+`softplus(epsilon_param)`. Keep optimizer and checkpoint code aware that
+low-precision layers may retain epsilon state in FP32 to avoid underflow or
+overflow.
 
 ## Attention and masks
 
-Functional attention tensors use `[..., query_length, heads, head_dim]` for Q
-and `[..., key_length, heads, head_dim]` for K/V. Modules generally accept
-batch-major `[batch, sequence, embedding]` inputs.
+The portable functional-attention layout is `[batch, query_length, heads,
+head_dim]` for Q and `[batch, key_length, heads, head_dim]` for K/V. Some JAX
+functions, including Pallas attention, document extra leading batch dimensions;
+do not assume that extension in Torch, TensorFlow, or MLX. Modules generally
+accept batch-major `[batch, sequence, embedding]` inputs.
 
 Boolean masks use `True` for allowed positions and may be broadcast from common
-`[Q,K]`, `[B,Q,K]`, or `[B,H,Q,K]` forms. A fully masked query row produces
-exactly zero attention weights and exactly zero module output, including after
-an output projection with bias. Do not replace this with a uniform row or NaNs.
+`[Q,K]`, `[H,Q,K]`, `[B,1,Q,K]`, or `[B,H,Q,K]` forms. A rank-3 mask aligns to
+heads, not batches. A fully masked query row produces exactly zero attention
+weights and exactly zero module output, including after an output projection
+with bias. Do not replace this with a uniform row or NaNs.
 
 Use SLAY for the bias-free spherical-anchor regime. Use MAY (`maclaurin`) or
 RAY (`radial`) when the kernel bias matters. Their features are sign-indefinite;

--- a/.claude/skills/nmn/agents/openai.yaml
+++ b/.claude/skills/nmn/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "NMN Framework Guide"
+  short_description: "Use NMN correctly across six ML frameworks"
+  default_prompt: "Use $nmn to implement this model with the correct backend API and verify numerical behavior."

--- a/.claude/skills/nmn/references/flax-linen.md
+++ b/.claude/skills/nmn/references/flax-linen.md
@@ -1,0 +1,56 @@
+# Flax Linen
+
+Install with `python -m pip install "nmn[linen]"`. Linen modules use immutable
+variables and `init`/`apply`.
+
+```python
+import jax
+import jax.numpy as jnp
+from nmn.linen import YatNMN
+
+layer = YatNMN(features=64, learnable_epsilon=True)
+x = jnp.ones((8, 128))
+variables = layer.init(jax.random.key(0), x)
+y = layer.apply(variables, x)
+```
+
+Convolution uses channels-last and tuple geometry:
+
+```python
+from nmn.linen import YatConv2D
+
+conv = YatConv2D(features=32, kernel_size=(3, 3), padding="SAME",
+                feature_group_count=1)
+variables = conv.init(jax.random.key(1), jnp.ones((4, 64, 64, 3)))
+```
+
+Grouped convolution requires input and output features divisible by
+`feature_group_count`. Patch norms are group-local; preserve contiguous
+group-to-output mapping when writing references or ports.
+
+## Attention
+
+```python
+from nmn.linen import MultiHeadAttention
+
+attn = MultiHeadAttention(num_heads=8, qkv_features=128,
+                          normalization="softmax")
+variables = attn.init(jax.random.key(2), jnp.ones((2, 32, 128)))
+y = attn.apply(variables, jnp.ones((2, 32, 128)), deterministic=True)
+```
+
+Use `normalization="l1"` for direct normalization of non-negative YAT scores.
+Constant and learnable alpha both scale scores before normalization. Masks
+broadcast and fully masked rows produce exact-zero module outputs.
+
+## Training and precision
+
+`lazy=True` applies `stop_gradient` to the kernel. Also use an Optax mask (for
+example `multi_transform` with `set_to_zero`) if the kernel must be absent from
+optimizer state. Low-precision QR/orthogonal initialization is performed safely
+and score reductions preserve FP16/BF16 output policy. Learned epsilon may use
+wider state; do not cast the whole variables tree blindly when that would erase
+its representability.
+
+Use `jax.jit`, `grad`, `jvp`, `jacfwd`, and batched transforms normally; the
+safe precision boundary is transform-compatible.

--- a/.claude/skills/nmn/references/flax-nnx.md
+++ b/.claude/skills/nmn/references/flax-nnx.md
@@ -1,0 +1,81 @@
+# Flax NNX
+
+Install with `python -m pip install "nmn[nnx]"`. Every module constructor needs
+`rngs=nnx.Rngs(...)`.
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from nmn.nnx import YatNMN
+
+model = YatNMN(128, 64, learnable_epsilon=True, rngs=nnx.Rngs(0))
+x = jnp.ones((8, 128))
+y = model(x)
+params = nnx.state(model, nnx.Param)
+```
+
+NNX uses channels-last, dimension-generic `YatConv` / `YatConvTranspose`; the
+dimension is inferred from `kernel_size`.
+
+```python
+from nmn.nnx import YatConv
+
+conv = YatConv(3, 32, kernel_size=(3, 3), padding="SAME", rngs=nnx.Rngs(1))
+y = conv(jnp.ones((4, 64, 64, 3)))
+```
+
+`lazy=True` stores the kernel as `FrozenParam`, excluding it from ordinary
+`nnx.Param` optimizer state. Tied banks are incompatible with lazy mode.
+
+## Attention and decode
+
+```python
+from nmn.nnx import MultiHeadAttention, RotaryYatAttention
+
+mha = MultiHeadAttention(num_heads=8, in_features=128, rngs=nnx.Rngs(2))
+y = mha(jnp.ones((2, 32, 128)), deterministic=True)
+
+rope = RotaryYatAttention(
+    embed_dim=128,
+    num_heads=8,
+    use_performer=True,
+    performer_kind="maclaurin",
+    performer_num_features=256,
+    rngs=nnx.Rngs(3),
+)
+```
+
+Incremental `decode=True` uses mutable cache state and RoPE offsets. Initialize
+cache capacity deliberately; overflow and invalid masks fail before committing
+cache or RNG state. Performer modes accept key-padding masks and reject general
+query-dependent masks.
+
+## Precision modes
+
+`compute_mode="fp32"` is the stable default. For TPU BF16 storage, prefer
+`compute_mode="mixed"`; it requests FP32 accumulation without full operand
+copies. `compute_mode="bf16"` is experimental and should use a suitable
+`distance_floor`. All modes are covered by standard/fused parity tests.
+
+## Pallas attention
+
+Import the Pallas function from the attention submodule:
+
+```python
+from nmn.nnx.layers.attention import pallas_yat_l1_attention
+
+out = pallas_yat_l1_attention(
+    q, k, v,
+    causal=True,
+    block_q=128,
+    block_k=128,
+    precision=jax.lax.Precision.HIGHEST,
+)
+```
+
+Q/K/V use `[..., sequence, heads, features]`; Q and KV lengths and value/head
+dimensions may differ as documented. On TPU, use tile sizes legal for Mosaic
+(multi-tile sequence blocks are multiples of 8) and validate native lowering.
+`interpret=True` is a CPU algebra test only. `Precision.HIGHEST` prevents TPU
+matrix-unit rounding of FP32 dots when parity matters.

--- a/.claude/skills/nmn/references/keras.md
+++ b/.claude/skills/nmn/references/keras.md
@@ -1,0 +1,60 @@
+# Keras 3
+
+Install Keras plus one backend, and set the backend before importing Keras:
+
+```bash
+python -m pip install "nmn[keras]" jax
+export KERAS_BACKEND=jax        # or tensorflow / torch
+```
+
+```python
+import keras
+from nmn.keras import YatNMN
+
+model = keras.Sequential([
+    keras.Input((128,)),
+    YatNMN(units=64, learnable_epsilon=True),
+    YatNMN(units=10),
+])
+model.compile(optimizer="adam", loss="mse")
+```
+
+Keras uses `units`, not `features` or `out_features`. `YatDense` is an alias.
+Do not add an activation merely to make the layer nonlinear.
+
+## Convolution
+
+`YatConv1D/2D/3D` and transpose variants follow Keras channels-last defaults
+and accept `data_format`. On the TensorFlow CPU backend, channels-first public
+inputs are internally converted to channels-last for the complete YAT path and
+converted back, including grouped/dilated/causal and transpose output-padding
+cases.
+
+Shared convolution banks use `tie_kernel_bank=True` with a compatible
+`kernel_bank_id`/capacity or an explicit bank object. Registry compatibility
+includes backend and dtype policy. Clone/save/load should preserve one tracked
+shared variable without duplicate optimizer slots.
+
+## Attention
+
+```python
+from nmn.keras import MultiHeadYatAttention
+
+attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+y = attn(x, attention_mask=mask, training=True)
+```
+
+`mask` and `attention_mask` are accepted aliases; do not pass conflicting
+values. Fully masked query rows yield exact zeros even when output projection
+bias is enabled.
+
+## Dtype and serialization
+
+Use Keras dtype policies (`float32`, `mixed_float16`, etc.). Vulnerable YAT
+reductions use a safe FP32 boundary and cast/saturate back while preserving
+NaNs. On JAX, declared float64 learned-epsilon state requires x64 enabled;
+otherwise construction rejects rather than silently storing FP32/inf.
+
+Round-trip with `model.save("model.keras")` and
+`keras.models.load_model(...)`; NMN layers are registered serializables. With
+the TensorFlow backend, use `model.export(...)` for SavedModel.

--- a/.claude/skills/nmn/references/mlx.md
+++ b/.claude/skills/nmn/references/mlx.md
@@ -1,0 +1,60 @@
+# MLX
+
+Install on Apple Silicon with `python -m pip install "nmn[mlx]"`.
+
+```python
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+from nmn.mlx import YatNMN
+
+model = YatNMN(features=64, learnable_epsilon=True)
+x = mx.ones((8, 128))
+loss_and_grad = nn.value_and_grad(model, lambda m, z: mx.sum(m(z)))
+loss, grads = loss_and_grad(model, x)
+optim.Adam(1e-3).update(model, grads)
+mx.eval(model.parameters(), loss)
+```
+
+MLX dense/conv modules build lazily from input width. `YatDense` aliases
+`YatNMN`. Use channels-last convolution layouts.
+
+## Fused score path
+
+```python
+from nmn.mlx import YatNMN, is_gpu_available
+
+layer = YatNMN(features=128, fused=is_gpu_available(),
+               learnable_epsilon=True)
+```
+
+The fused path dispatches a Metal kernel on a visible MLX GPU and falls back to
+the eager implementation when unsupported. Array epsilon remains in the custom
+VJP graph so gradients reach `epsilon_param`, including under `mx.compile` and
+lazy mode. Force/evaluate GPU tests when validating the fused branch; the
+repository's ordinary fixture may select CPU.
+
+## Convolution transpose
+
+For `padding="same"`, transpose output size is
+`input * stride + output_padding` per spatial axis. The implementation handles
+asymmetric high-side crop/pad for odd/even kernels, stride, and dilation. Test
+2D/3D mixed-axis output and input/kernel VJPs against an independent scatter
+reference on Metal.
+
+## Attention and decode
+
+`MultiHeadYatAttention` uses batch-major inputs. `RotaryYatAttention` adds RoPE
+and incremental `decode=True` cache updates. Decode positions advance from the
+cache index; invalid masks or overflow must not partially mutate cache.
+
+MLX also exports SLAY-style performer functions, MAY, RAY, and experimental
+GOAT attention. Choose the explicitly documented feature map; do not assume all
+mask forms work in linear-attention paths.
+
+## Runtime discipline
+
+Call `mx.eval` on outputs and gradients before comparing or timing. Test both
+eager and `mx.compile`. MLX can be installed on an unsupported/headless host yet
+abort during Metal initialization, so probe it in a subprocess when optional
+availability must not crash a parent test process.

--- a/.claude/skills/nmn/references/pytorch.md
+++ b/.claude/skills/nmn/references/pytorch.md
@@ -53,8 +53,9 @@ x = torch.randn(2, 32, 128)
 y = attn(x, mask=torch.ones(32, 32, dtype=torch.bool))
 ```
 
-Pass `key=` and `value=` for cross attention. `deterministic=False` enables
-training dropout. Fully masked query rows return exact-zero weights/output.
+Pass `key=` and `value=` for cross attention. With the module in training mode,
+`deterministic=False` permits dropout; `eval()` disables it. Fully masked query
+rows return exact-zero weights/output.
 
 ## Precision and transforms
 

--- a/.claude/skills/nmn/references/pytorch.md
+++ b/.claude/skills/nmn/references/pytorch.md
@@ -1,0 +1,67 @@
+# PyTorch
+
+Install with `python -m pip install "nmn[torch]"`.
+
+```python
+import torch
+from nmn.torch import YatNMN
+
+layer = YatNMN(
+    in_features=128,
+    out_features=64,
+    bias=True,
+    alpha=True,
+    epsilon=1e-5,
+    learnable_epsilon=True,
+    dtype=torch.float32,
+    param_dtype=torch.float32,
+)
+y = layer(torch.randn(8, 128))
+y.sum().backward()
+```
+
+PyTorch dense uses `bias=` and `alpha=`; convolution and attention use their
+own documented `use_alpha`-style options. Inspect signatures before sharing
+configuration dictionaries.
+
+## Convolution
+
+Use `YatConv1D/2D/3D` and transpose variants with native PyTorch NCL/NCHW/NCDHW
+layouts. Group counts must divide both input and output channels.
+
+```python
+from nmn.torch import YatConv2D
+
+conv = YatConv2D(3, 32, 3, padding="same", learnable_epsilon=True)
+y = conv(torch.randn(4, 3, 64, 64))
+```
+
+Tied dense/forward-convolution banks use `tie_kernel_bank=True`, a stable
+`kernel_bank_id`, and optional `kernel_bank_size`. Construct compatible
+consumers on the final target device/dtype. Capacity may expand only before the
+bank's first forward; tied modules deliberately reject post-construction
+`.to()`/`.half()` migration that would split shared identity. Untied modules
+migrate normally. Learned epsilon retains safe storage through dtype changes.
+
+## Attention
+
+```python
+from nmn.torch import MultiHeadYatAttention
+
+attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+x = torch.randn(2, 32, 128)
+y = attn(x, mask=torch.ones(32, 32, dtype=torch.bool))
+```
+
+Pass `key=` and `value=` for cross attention. `deterministic=False` enables
+training dropout. Fully masked query rows return exact-zero weights/output.
+
+## Precision and transforms
+
+`dtype` is compute/output policy; `param_dtype` is parameter storage. Prefer
+FP32 parameter storage with autocast for FP16 training. Safe casts support
+autograd and modern `torch.func` transforms while retaining compatibility with
+the declared minimum Torch version.
+
+Checkpoint with ordinary `state_dict`; shared-bank consumers must be recreated
+with compatible bank configuration before loading.

--- a/.claude/skills/nmn/references/shared-contract.md
+++ b/.claude/skills/nmn/references/shared-contract.md
@@ -1,0 +1,56 @@
+# Cross-framework contract
+
+## Public families
+
+Every backend provides dense YAT, 1D/2D/3D convolution and transpose
+convolution, embedding, attention, squashers, and MAY/RAY feature maps. Names
+and construction differ; use the backend reference rather than guessing.
+
+## State and training
+
+- `lazy=True` and `freeze_kernel=True` freeze only the kernel.
+- `learnable_epsilon=True` stores a raw parameter and evaluates its softplus.
+- `weight_normalized=True` uses normalized kernel geometry where supported.
+- DropConnect is stochastic only during training/non-deterministic calls. Use a
+  rate in `[0, 1)` and pass the framework's training/deterministic flag.
+- Tied banks share only compatible geometry, device, backend, and dtype policy.
+  Preallocate capacity when architecture width is known.
+
+## Data layouts
+
+- Dense operates on the final feature dimension.
+- JAX/Linen/NNX, Keras, TF, and MLX convolution examples are channels-last.
+- Native PyTorch convolution is channels-first.
+- Attention functional APIs use `[..., Q, H, D]`; attention modules use
+  `[B, S, E]` unless their backend reference says otherwise.
+
+## Masks
+
+- Boolean `True` means allowed/visible.
+- Broadcast masks to score shape rather than indexing fixed mask ranks.
+- Partially masked rows normalize over valid keys only.
+- Fully masked rows yield exact-zero weights and outputs with finite gradients.
+- Performer paths accept key-padding-style masks, not arbitrary query-dependent
+  masks, unless the selected function documents broader support.
+
+## Precision
+
+- Form YAT dots, squared norms, distances, and ratios using the backend's safe
+  compute path for FP16/BF16.
+- Preserve genuine NaNs. Saturation is for finite overflow, not corruption.
+- Keep learned epsilon representable and positive; use FP32 epsilon state for
+  low-precision training where implemented.
+- Verify forward and VJP parity against synchronized FP32 parameters. Use
+  realistic collision, large-distance, multi-output, and aggregate-reduction
+  cases—not only random small tensors.
+
+## Porting checklist
+
+1. Map constructor names and tensor layout.
+2. Build lazy layers before assigning weights.
+3. Transpose kernels explicitly between framework layouts.
+4. Match bias, alpha, epsilon, spherical/normalized mode, and score
+   normalization.
+5. Match mask convention and output projection.
+6. Compare output and every gradient with dtype-appropriate tolerances.
+7. Round-trip the native checkpoint/export format.

--- a/.claude/skills/nmn/references/shared-contract.md
+++ b/.claude/skills/nmn/references/shared-contract.md
@@ -11,8 +11,9 @@ and construction differ; use the backend reference rather than guessing.
 - `lazy=True` and `freeze_kernel=True` freeze only the kernel.
 - `learnable_epsilon=True` stores a raw parameter and evaluates its softplus.
 - `weight_normalized=True` uses normalized kernel geometry where supported.
-- DropConnect is stochastic only during training/non-deterministic calls. Use a
-  rate in `[0, 1)` and pass the framework's training/deterministic flag.
+- Where supported, DropConnect is stochastic only during
+  training/non-deterministic calls. Use a rate in `[0, 1)` and pass the
+  framework's training/deterministic flag.
 - Tied banks share only compatible geometry, device, backend, and dtype policy.
   Preallocate capacity when architecture width is known.
 
@@ -21,12 +22,16 @@ and construction differ; use the backend reference rather than guessing.
 - Dense operates on the final feature dimension.
 - JAX/Linen/NNX, Keras, TF, and MLX convolution examples are channels-last.
 - Native PyTorch convolution is channels-first.
-- Attention functional APIs use `[..., Q, H, D]`; attention modules use
-  `[B, S, E]` unless their backend reference says otherwise.
+- The portable attention functional layout is `[B, Q, H, D]`; only use extra
+  leading batch dimensions where the selected backend documents them.
+- Attention modules use `[B, S, E]` unless their backend reference says
+  otherwise.
 
 ## Masks
 
 - Boolean `True` means allowed/visible.
+- Portable broadcast forms are `[Q,K]`, `[H,Q,K]`, `[B,1,Q,K]`, and
+  `[B,H,Q,K]`; rank 3 aligns to heads rather than batches.
 - Broadcast masks to score shape rather than indexing fixed mask ranks.
 - Partially masked rows normalize over valid keys only.
 - Fully masked rows yield exact-zero weights and outputs with finite gradients.

--- a/.claude/skills/nmn/references/tensorflow.md
+++ b/.claude/skills/nmn/references/tensorflow.md
@@ -1,0 +1,60 @@
+# TensorFlow
+
+Install with `python -m pip install "nmn[tf]"`.
+
+```python
+import tensorflow as tf
+from nmn.tf import YatNMN
+
+layer = YatNMN(features=64, learnable_epsilon=True)
+x = tf.ones((8, 128))
+with tf.GradientTape() as tape:
+    tape.watch(x)
+    loss = tf.reduce_sum(layer(x))
+grads = tape.gradient(loss, [x] + layer.trainable_variables)
+```
+
+Native TF dense, embedding, and convolution modules build lazily from input
+shape. `YatDense` aliases `YatNMN`. Convolutions are channels-last; native TF
+does not expose Keras `data_format`. Grouped convolution uses explicit
+split/apply/concat so CPU forward and gradients remain portable.
+
+## Attention
+
+```python
+from nmn.tf import MultiHeadYatAttention
+
+attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
+y = attn(x, mask=tf.ones((32, 32), dtype=tf.bool), training=True)
+```
+
+Use batch-major `[B,S,E]` module inputs. Boolean `True` means allowed. Fully
+masked rows return exact-zero output after projection.
+
+## SavedModel
+
+NMN native modules expose explicit export methods with stable signatures:
+
+```python
+layer.export("saved_dense", tf.TensorSpec([None, 128], tf.float32))
+
+from nmn.tf import YatEmbed
+embed = YatEmbed(num_embeddings=32000, features=128)
+embed.export(
+    "saved_embed",
+    tf.TensorSpec([None, None], tf.int32),
+    attend_signature=tf.TensorSpec([None, 128], tf.float32),
+)
+```
+
+Convolution modules also accept one `input_signature`. Attention export accepts
+query plus optional key/value/mask signatures and creates self/cross serving
+paths as applicable. Load with `tf.saved_model.load` and invoke the named
+signature; overwrite behavior is explicit.
+
+## Precision
+
+FP16/BF16 score math promotes vulnerable reductions, saturates finite output
+overflow, and preserves NaNs. Learned epsilon uses representable positive state.
+Test eager and `tf.function`; note that some dilated convolution gradients are
+limited by TensorFlow CPU itself and may require accelerator validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,22 @@ Concise, accurate orientation for an agent working with the `nmn` package
 
 ## Install the agent skill
 
-This repo ships an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills)
-at [`.claude/skills/nmn/`](.claude/skills/nmn/SKILL.md). Install it so your coding
-agent auto-loads NMN expertise whenever you `import nmn` or work with YAT layers —
-no manual lookup:
+This repo ships a portable Agent Skill at
+[`.claude/skills/nmn/`](.claude/skills/nmn/SKILL.md). Give the entire `nmn`
+directory to an agent—not only `SKILL.md`—because its per-framework references
+and UI metadata are part of the skill. Install it so the agent auto-loads NMN
+expertise whenever you `import nmn` or work with YAT layers:
 
 ```bash
-# user-level (applies to all your projects)
+# Codex user-level (applies to all your projects)
+mkdir -p ~/.codex/skills
+cp -r .claude/skills/nmn ~/.codex/skills/nmn
+
+# Claude Code user-level (applies to all your projects)
+mkdir -p ~/.claude/skills
 cp -r .claude/skills/nmn ~/.claude/skills/nmn
 
-# or project-level (commit it with your repo)
+# Claude Code project-level (commit it with your repo)
 mkdir -p .claude/skills && cp -r /path/to/nmn/.claude/skills/nmn .claude/skills/nmn
 ```
 

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SKILL = ROOT / ".claude" / "skills" / "nmn" / "SKILL.md"
+
+
+def test_nmn_skill_has_portable_frontmatter_and_existing_references():
+    text = SKILL.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    frontmatter = text.split("---\n", 2)[1]
+    keys = {
+        line.split(":", 1)[0]
+        for line in frontmatter.splitlines()
+        if line and not line.startswith(" ")
+    }
+    assert keys == {"name", "description"}
+    assert "name: nmn" in frontmatter
+
+    references = re.findall(r"\]\((references/[^)]+\.md)\)", text)
+    assert len(references) == 7
+    assert len(references) == len(set(references))
+    for relative in references:
+        assert (SKILL.parent / relative).is_file(), relative
+
+
+def test_nmn_skill_covers_every_backend_and_constructor_gotcha():
+    text = SKILL.read_text(encoding="utf-8")
+    references = {
+        "torch": "pytorch.md",
+        "nnx": "flax-nnx.md",
+        "linen": "flax-linen.md",
+        "keras": "keras.md",
+        "tf": "tensorflow.md",
+        "mlx": "mlx.md",
+    }
+    for backend in ("torch", "nnx", "linen", "keras", "tf", "mlx"):
+        assert f"nmn[{backend}]" in text
+        assert f"references/{references[backend]}" in text
+    for spelling in (
+        "in_features=128, out_features=64",
+        "YatNMN(128, 64, rngs=nnx.Rngs(0))",
+        "YatNMN(features=64)",
+        "YatNMN(units=64)",
+    ):
+        assert spelling in text
+
+
+def test_agent_handoff_copies_the_complete_skill_bundle():
+    instructions = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert "entire `nmn`" in instructions
+    assert "~/.codex/skills/nmn" in instructions
+    assert "~/.claude/skills/nmn" in instructions
+
+
+def test_nmn_skill_locks_current_numeric_and_mask_contracts():
+    text = SKILL.read_text(encoding="utf-8")
+    shared = (SKILL.parent / "references" / "shared-contract.md").read_text(
+        encoding="utf-8"
+    )
+    combined = text + shared
+    for contract in (
+        "fully masked",
+        "exact-zero",
+        "FP16",
+        "BF16",
+        "preserves genuine NaNs",
+        "learnable_epsilon=True",
+        "freezes only the kernel",
+    ):
+        assert contract in combined

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-
 ROOT = Path(__file__).parents[1]
 SKILL = ROOT / ".claude" / "skills" / "nmn" / "SKILL.md"
 

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -56,6 +57,55 @@ def test_agent_handoff_copies_the_complete_skill_bundle():
     assert "~/.claude/skills/nmn" in instructions
 
 
+def _yat_nmn_constructor_fields(relative_path: str) -> set[str]:
+    tree = ast.parse((ROOT / relative_path).read_text(encoding="utf-8"))
+    yat_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "YatNMN"
+    )
+    initializer = next(
+        (
+            node
+            for node in yat_class.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        ),
+        None,
+    )
+    if initializer is not None:
+        arguments = (
+            initializer.args.posonlyargs
+            + initializer.args.args
+            + initializer.args.kwonlyargs
+        )
+        return {argument.arg for argument in arguments} - {"self"}
+    return {
+        node.target.id
+        for node in yat_class.body
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+    }
+
+
+def test_documented_dense_constructor_names_match_source():
+    constructors = {
+        "src/nmn/torch/nmn/yat_nmn.py": {"in_features", "out_features"},
+        "src/nmn/nnx/layers/nmn.py": {"in_features", "out_features", "rngs"},
+        "src/nmn/linen/nmn.py": {"features"},
+        "src/nmn/keras/nmn.py": {"units"},
+        "src/nmn/tf/nmn.py": {"features"},
+        "src/nmn/mlx/nmn.py": {"features"},
+    }
+
+    for source, documented_fields in constructors.items():
+        assert documented_fields <= _yat_nmn_constructor_fields(source)
+
+    for backend in ("torch", "nnx", "linen", "keras", "tf", "mlx"):
+        exports = (ROOT / "src" / "nmn" / backend / "__init__.py").read_text(
+            encoding="utf-8"
+        )
+        assert "YatNMN" in exports
+
+
 def test_nmn_skill_locks_current_numeric_and_mask_contracts():
     text = SKILL.read_text(encoding="utf-8")
     shared = (SKILL.parent / "references" / "shared-contract.md").read_text(
@@ -72,3 +122,17 @@ def test_nmn_skill_locks_current_numeric_and_mask_contracts():
         "freezes only the kernel",
     ):
         assert contract in combined
+
+    assert "[B, Q, H, D]" in shared
+    assert "[B,1,Q,K]" in shared
+    assert "[H,Q,K]" in shared
+    assert "rank 3 aligns to heads" in shared
+    assert "caller precondition" in text
+    assert "Some JAX" in text
+
+    for overclaim in (
+        "[B,Q,K]",
+        "Attention functional APIs use `[..., Q, H, D]`",
+        "`epsilon` must be finite and strictly positive",
+    ):
+        assert overclaim not in combined


### PR DESCRIPTION
Implements dacli task 060-ship-<withheld-agent-identity>.

Refs #138

### Acceptance
- [ ] Provide a valid portable `nmn` skill with concise routing instructions.
- [ ] Add focused references for all six supported frameworks and the shared numerical/masking contract.
- [ ] Include Codex-compatible UI metadata and installation guidance for Codex and Claude Code.
- [ ] Add dependency-light regression tests for frontmatter, references, backend constructors, and current precision/mask guarantees.
- [ ] Keep the CLI discovery workflow documented and passing.
