### PR TITLE
081: Prevent NNX tied kernel-bank expansion from corrupting optimizer state

### DIFF
--- a/src/nmn/nnx/README.md
+++ b/src/nmn/nnx/README.md
@@ -242,28 +242,37 @@ Share kernel parameters across multiple layers to **reduce model size** and **en
 
 **Key concepts:**
 - **Kernel Bank**: Shared parameter store managed at class level
-- **Auto-expansion**: Automatically grows when larger layer needs more features
+- **Fixed capacity**: The first consumer fixes the bank size; set
+  `kernel_bank_size` there to the largest size any consumer will need
 - **First-k slicing**: Each layer extracts the first k filters it needs
 - **Namespace isolation**: Multiple independent banks via `kernel_bank_id`
+- **Compatible signatures**: A shared convolution bank requires the same
+  `kernel_bank_id`, spatial `kernel_size`, input channels per group, group count,
+  parameter dtype, initializer, and `positive_init` setting. A shared dense
+  bank requires the same `kernel_bank_id`, input feature count, parameter
+  dtype, initializer, and `positive_init` setting. Changing one of these
+  fields intentionally creates a separate bank.
 
 ```python
 from nmn.nnx.layers.conv import YatConv
 
 rngs = nnx.Rngs(0)
 
-# Create multiple layers sharing same kernel bank
+# Create parallel consumers with compatible input/kernel/group signatures.
+# These are not a sequential stack: every consumer accepts 32 input channels.
 layer1 = YatConv(
-    in_features=3,
+    in_features=32,
     out_features=32,  # First 32 filters
     kernel_size=(3, 3),
     tie_kernel_bank=True,
+    kernel_bank_size=128,  # Fixed capacity declared before state/optimizer creation
     kernel_bank_id='resnet-conv',  # Bank namespace
     rngs=rngs
 )
 
 layer2 = YatConv(
     in_features=32,
-    out_features=64,  # Auto-expands to 64
+    out_features=64,  # Uses the first 64 filters
     kernel_size=(3, 3),
     tie_kernel_bank=True,
     kernel_bank_id='resnet-conv',
@@ -271,17 +280,17 @@ layer2 = YatConv(
 )
 
 layer3 = YatConv(
-    in_features=64,
-    out_features=128,  # Auto-expands to 128
+    in_features=32,
+    out_features=128,  # Uses the full preallocated bank
     kernel_size=(3, 3),
     tie_kernel_bank=True,
     kernel_bank_id='resnet-conv',
     rngs=rngs
 )
 
-# Console output:
-# Auto-expanding kernel bank 'resnet-conv': 32 -> 64 filters
-# Auto-expanding kernel bank 'resnet-conv': 64 -> 128 filters
+# A later consumer requesting more than 128 filters raises ValueError without
+# mutating the shared parameter, gradients, or optimizer state.
+assert layer1.kernel is layer2.kernel is layer3.kernel
 ```
 
 **For YatNMN:**
@@ -298,12 +307,14 @@ head1 = YatNMN(
 )
 
 head2 = YatNMN(
-    in_features=256,
+    in_features=512,  # Must match head1 to share its kernel bank
     out_features=128,
     tie_kernel_bank=True,
     kernel_bank_id='classifier',  # Shares with head1
     rngs=rngs
 )
+
+assert head1.kernel is head2.kernel
 ```
 
 **Multiple independent banks:**
@@ -335,16 +346,15 @@ classifier = YatNMN(
 **Parameter reduction example:**
 
 ```
-ResNet-50 without tying:
-- Stage 1: 32 filters
-- Stage 2: 64 filters
-- Stage 3: 128 filters
-- Stage 4: 256 filters
-Total unique: 480 filters
+Four compatible parallel 3x3 convolutions, each with 64 input channels and
+32, 64, 128, and 256 output filters:
 
-With weight tying:
-- Single shared bank: 256 filters (final size)
-Reduction: 480 -> 256 (46.7% fewer parameters)
+- Untied kernels: 3 * 3 * 64 * (32 + 64 + 128 + 256) = 276,480 elements
+- One preallocated 256-filter bank: 3 * 3 * 64 * 256 = 147,456 elements
+- Kernel-parameter reduction: 46.7%
+
+This calculation excludes each consumer's independent bias/alpha/epsilon
+state. Sequential stages with different input widths require separate banks.
 ```
 
 ### Constant Alpha Scaling
@@ -514,12 +524,11 @@ class EfficientYATResNet(nnx.Module):
             padding='SAME',
             weight_normalized=True,      # 10-15% speedup
             constant_alpha=True,         # Use sqrt(2)
-            tie_kernel_bank=True,        # Share weights
-            kernel_bank_id='conv-bank',
             rngs=rngs
         )
         
-        # Stage 2: 64 filters (bank auto-expands)
+        # Stage 2: 64 filters. Its input width differs from stage 1, so it
+        # intentionally uses an independent kernel.
         self.conv2 = YatConv(
             in_features=32,
             out_features=64,
@@ -528,12 +537,11 @@ class EfficientYATResNet(nnx.Module):
             padding='SAME',
             weight_normalized=True,
             constant_alpha=True,
-            tie_kernel_bank=True,
-            kernel_bank_id='conv-bank',
             rngs=rngs
         )
         
-        # Stage 3: 128 filters (bank auto-expands)
+        # Stage 3: 128 filters. Sequential stages with different input widths
+        # cannot share a tied kernel bank.
         self.conv3 = YatConv(
             in_features=64,
             out_features=128,
@@ -542,8 +550,6 @@ class EfficientYATResNet(nnx.Module):
             padding='SAME',
             weight_normalized=True,
             constant_alpha=True,
-            tie_kernel_bank=True,
-            kernel_bank_id='conv-bank',
             rngs=rngs
         )
         
@@ -553,8 +559,6 @@ class EfficientYATResNet(nnx.Module):
             out_features=num_classes,
             weight_normalized=True,
             constant_alpha=True,
-            tie_kernel_bank=True,
-            kernel_bank_id='head-bank',
             rngs=rngs
         )
     
@@ -627,16 +631,12 @@ class OptimizedYATNet(nnx.Module):
             3, 64, (3, 3), padding='SAME',
             weight_normalized=True,
             constant_alpha=True,
-            tie_kernel_bank=True,
-            kernel_bank_id='conv',
             rngs=rngs
         )
         self.conv2 = YatConv(
             64, 128, (3, 3), strides=(2, 2), padding='SAME',
             weight_normalized=True,
             constant_alpha=True,
-            tie_kernel_bank=True,
-            kernel_bank_id='conv',
             rngs=rngs
         )
         self.head = YatNMN(
@@ -814,14 +814,17 @@ layer = YatConv(64, 128, (3, 3), constant_alpha=True, rngs=rngs)
 
 ### 3. **Apply Weight Tying for Large Models**
 ```python
-# 30-50% parameter reduction in ResNet-style architectures
-layers = [
-    YatConv(ch_in, ch_out, (3, 3), 
-            tie_kernel_bank=True, 
-            kernel_bank_id='shared',
-            rngs=rngs)
-    for ch_in, ch_out in [(3, 64), (64, 128), (128, 256)]
-]
+# Tied banks are useful for parallel consumers with compatible signatures.
+# Preallocate the largest required output width on the first consumer.
+narrow = YatConv(
+    64, 64, (3, 3), tie_kernel_bank=True,
+    kernel_bank_id='shared', kernel_bank_size=128, rngs=rngs,
+)
+wide = YatConv(
+    64, 128, (3, 3), tie_kernel_bank=True,
+    kernel_bank_id='shared', kernel_bank_size=128, rngs=rngs,
+)
+assert narrow.kernel is wide.kernel
 ```
 
 ### 4. **Use Appropriate Padding Mode**

--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -11,17 +11,12 @@ patch-wise between input patches and kernel weights.
 
 from __future__ import annotations
 
-import logging
 import threading
 import typing as tp
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax import lax
-
-logger = logging.getLogger(__name__)
-
 from flax import nnx
 from flax.nnx import rnglib
 from flax.nnx.module import Module
@@ -34,6 +29,7 @@ from flax.typing import (
     PrecisionLike,
     PromoteDtypeFn,
 )
+from jax import lax
 
 from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 from .utils import (
@@ -111,7 +107,8 @@ class YatConv(Module):
         tie_kernel_bank: If True, reuse a shared kernel bank across compatible
             YatConv instances and slice the first ``out_features`` filters.
         kernel_bank_size: Total number of filters in the shared bank. If None,
-            defaults to ``out_features`` for the creating instance.
+            defaults to ``out_features`` for the creating instance. Bank capacity
+            is immutable; declare the largest required size on the first consumer.
         kernel_bank_id: Optional bank namespace to control sharing groups.
         rngs: Random number generators.
     """
@@ -181,9 +178,14 @@ class YatConv(Module):
         self._kernel_slice = slice(None)
 
         if tie_kernel_bank:
-            # Auto-calculate bank size: use specified size or default to current layer's out_features
-            # Bank will auto-expand if a later layer needs more features
-            bank_out_features = kernel_bank_size or out_features
+            bank_out_features = (
+                out_features if kernel_bank_size is None else kernel_bank_size
+            )
+            if bank_out_features < out_features:
+                raise ValueError(
+                    "kernel_bank_size must be at least out_features, "
+                    f"got {bank_out_features} < {out_features}"
+                )
 
             bank_shape = kernel_size + (
                 in_features // feature_group_count,
@@ -202,7 +204,11 @@ class YatConv(Module):
             with YatConv._KERNEL_BANKS_LOCK:
                 shared_kernel = YatConv._KERNEL_BANKS.get(bank_key)
                 if shared_kernel is None:
-                    # First layer using this bank: create with auto-sized dimensions
+                    # The first consumer fixes capacity. Resizing a live Param can
+                    # invalidate gradients and optimizer moments that already hold
+                    # its original shape, and NNX state extraction is not observable
+                    # here. Requiring up-front capacity is therefore the only safe
+                    # class-global sharing contract.
                     kernel_key = rngs.params()
                     kernel_val = kernel_init(kernel_key, bank_shape, param_dtype)
                     if positive_init:
@@ -210,31 +216,16 @@ class YatConv(Module):
                     shared_kernel = nnx.Param(kernel_val)
                     YatConv._KERNEL_BANKS[bank_key] = shared_kernel
                 else:
-                    # Bank exists: auto-expand if needed
-                    existing_shape = shared_kernel.value.shape
+                    existing_shape = shared_kernel[...].shape
                     existing_bank_size = existing_shape[-1]
 
                     if bank_out_features > existing_bank_size:
-                        # Auto-expand bank to accommodate larger layer
-                        logger.info(
-                            "Auto-expanding kernel bank '%s': %d -> %d filters",
-                            kernel_bank_id,
-                            existing_bank_size,
-                            bank_out_features,
+                        raise ValueError(
+                            f"Kernel bank {kernel_bank_id!r} has fixed capacity "
+                            f"{existing_bank_size}; requested {bank_out_features}. "
+                            "Set kernel_bank_size to the maximum required capacity "
+                            "when constructing the first consumer."
                         )
-                        new_shape = existing_shape[:-1] + (bank_out_features,)
-                        old_kernel = shared_kernel.value
-                        # Pad with random initialization for new filters
-                        kernel_key = rngs.params()
-                        new_kernel_val = kernel_init(kernel_key, new_shape, param_dtype)
-                        if positive_init:
-                            new_kernel_val = jnp.abs(new_kernel_val)
-                        # Copy old values, new filters already initialized
-                        new_kernel_val = new_kernel_val.at[
-                            ..., :existing_bank_size
-                        ].set(old_kernel)
-                        shared_kernel.set_value(new_kernel_val)
-                    # elif bank_out_features < existing_bank_size: bank is larger, slice used below
 
             self.kernel = shared_kernel
             self._kernel_slice = slice(0, out_features)

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -122,7 +122,8 @@ class YatNMN(Module):
       tie_kernel_bank: if True, reuse a shared kernel bank across compatible
         YatNMN instances and slice the first ``out_features`` neurons.
       kernel_bank_size: total neurons in the shared bank. If None, defaults to
-        ``out_features`` for the creating instance.
+        ``out_features`` for the creating instance. Bank capacity is immutable;
+        declare the largest required size on the first consumer.
       kernel_bank_id: optional bank namespace to control sharing groups.
       rngs: rng key.
     """
@@ -199,9 +200,14 @@ class YatNMN(Module):
         self.kernel_shape = (in_features, out_features)
 
         if tie_kernel_bank:
-            # Auto-calculate bank size: use specified size or default to current layer's out_features
-            # Bank will auto-expand if a later layer needs more features
-            bank_out_features = kernel_bank_size or out_features
+            bank_out_features = (
+                out_features if kernel_bank_size is None else kernel_bank_size
+            )
+            if bank_out_features < out_features:
+                raise ValueError(
+                    "kernel_bank_size must be at least out_features, "
+                    f"got {bank_out_features} < {out_features}"
+                )
 
             bank_shape = (in_features, bank_out_features)
             bank_key = (
@@ -215,7 +221,11 @@ class YatNMN(Module):
             with YatNMN._KERNEL_BANKS_LOCK:
                 shared_kernel = YatNMN._KERNEL_BANKS.get(bank_key)
                 if shared_kernel is None:
-                    # First layer using this bank: create with auto-sized dimensions
+                    # The first consumer fixes capacity. Resizing a live Param can
+                    # invalidate gradients and optimizer moments that already hold
+                    # its original shape, and NNX state extraction is not observable
+                    # here. Requiring up-front capacity is therefore the only safe
+                    # class-global sharing contract.
                     kernel_key = rngs.params()
                     kernel_val = kernel_init(kernel_key, bank_shape, param_dtype)
                     if positive_init:
@@ -223,33 +233,16 @@ class YatNMN(Module):
                     shared_kernel = nnx.Param(kernel_val)
                     YatNMN._KERNEL_BANKS[bank_key] = shared_kernel
                 else:
-                    # Bank exists: auto-expand if needed
-                    existing_shape = shared_kernel.value.shape
+                    existing_shape = shared_kernel[...].shape
                     existing_bank_size = existing_shape[-1]
 
                     if bank_out_features > existing_bank_size:
-                        # Auto-expand bank to accommodate larger layer
-                        import logging as _logging
-
-                        _logging.getLogger(__name__).info(
-                            "Auto-expanding kernel bank '%s': %d -> %d neurons",
-                            kernel_bank_id,
-                            existing_bank_size,
-                            bank_out_features,
+                        raise ValueError(
+                            f"Kernel bank {kernel_bank_id!r} has fixed capacity "
+                            f"{existing_bank_size}; requested {bank_out_features}. "
+                            "Set kernel_bank_size to the maximum required capacity "
+                            "when constructing the first consumer."
                         )
-                        new_shape = (in_features, bank_out_features)
-                        old_kernel = shared_kernel.value
-                        # Pad with random initialization for new neurons
-                        kernel_key = rngs.params()
-                        new_kernel_val = kernel_init(kernel_key, new_shape, param_dtype)
-                        if positive_init:
-                            new_kernel_val = jnp.abs(new_kernel_val)
-                        # Copy old values, new neurons already initialized
-                        new_kernel_val = new_kernel_val.at[:, :existing_bank_size].set(
-                            old_kernel
-                        )
-                        shared_kernel.set_value(new_kernel_val)
-                    # elif bank_out_features < existing_bank_size: bank is larger, slice used below
 
             self.kernel = shared_kernel
             self._kernel_slice = slice(0, out_features)

--- a/tests/test_nnx/test_variable_updates.py
+++ b/tests/test_nnx/test_variable_updates.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import re
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
+import optax
 import pytest
-from flax import nnx
+from flax import nnx, serialization
 
 from nmn.nnx import Embed, YatConv, YatNMN
 
@@ -53,57 +55,123 @@ def test_weight_normalization_uses_same_shape_variable_update(kind):
     np.testing.assert_allclose(norms, np.ones_like(norms), rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.parametrize("kind", ["dense", "conv"])
-def test_shared_bank_shape_expansion_uses_replacement_update(kind):
-    bank_id = f"issue-111-{kind}"
+def _bank_layer(kind, out_features, bank_id, *, bank_size=None, seed=0):
     if kind == "dense":
-        narrow = YatNMN(
+        return YatNMN(
             2,
-            2,
+            out_features,
             tie_kernel_bank=True,
+            kernel_bank_size=bank_size,
             kernel_bank_id=bank_id,
-            rngs=nnx.Rngs(0),
+            rngs=nnx.Rngs(seed),
         )
-        old_values = np.asarray(narrow.kernel[...]).copy()
-        wide = _without_deprecated_setter_warning(
-            lambda: YatNMN(
-                2,
-                4,
-                tie_kernel_bank=True,
-                kernel_bank_id=bank_id,
-                rngs=nnx.Rngs(1),
-            )
-        )
-        inputs = jnp.ones((3, 2), dtype=jnp.float32)
-    else:
-        narrow = YatConv(
-            2,
-            2,
-            1,
-            tie_kernel_bank=True,
-            kernel_bank_id=bank_id,
-            rngs=nnx.Rngs(0),
-        )
-        old_values = np.asarray(narrow.kernel[...]).copy()
-        wide = _without_deprecated_setter_warning(
-            lambda: YatConv(
-                2,
-                4,
-                1,
-                tie_kernel_bank=True,
-                kernel_bank_id=bank_id,
-                rngs=nnx.Rngs(1),
-            )
-        )
-        inputs = jnp.ones((3, 5, 2), dtype=jnp.float32)
+    return YatConv(
+        2,
+        out_features,
+        1,
+        tie_kernel_bank=True,
+        kernel_bank_size=bank_size,
+        kernel_bank_id=bank_id,
+        rngs=nnx.Rngs(seed),
+    )
+
+
+def _bank_inputs(kind):
+    shape = (3, 2) if kind == "dense" else (3, 5, 2)
+    return jnp.ones(shape, dtype=jnp.float32)
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv"])
+def test_shared_bank_capacity_is_fixed_and_can_be_preallocated(kind):
+    bank_id = f"issue-140-capacity-{kind}"
+    narrow = _bank_layer(kind, 2, bank_id, bank_size=4)
+    wide = _bank_layer(kind, 4, bank_id, seed=1)
 
     assert narrow.kernel is wide.kernel
     assert wide.kernel[...].shape[-1] == 4
-    np.testing.assert_array_equal(np.asarray(wide.kernel[..., :2]), old_values)
+    assert narrow(_bank_inputs(kind)).shape[-1] == 2
+    assert wide(_bank_inputs(kind)).shape[-1] == 4
 
-    grads = nnx.grad(lambda module, x: jnp.sum(module(x)))(wide, inputs)
-    assert grads.kernel[...].shape == wide.kernel[...].shape
-    assert np.isfinite(np.asarray(grads.kernel[...])).all()
+
+@pytest.mark.parametrize("kind", ["dense", "conv"])
+def test_shared_bank_rejects_expansion_without_mutating_live_state(kind):
+    bank_id = f"issue-140-optimizer-{kind}"
+    layer = _bank_layer(kind, 2, bank_id)
+    inputs = _bank_inputs(kind)
+    optimizer = nnx.Optimizer(layer, optax.adam(1e-3), wrt=nnx.Param)
+
+    def loss_fn(model):
+        return jnp.sum(model(inputs))
+
+    _, grads = nnx.value_and_grad(loss_fn)(layer)
+    optimizer.update(layer, grads)
+    kernel_before = np.asarray(layer.kernel[...]).copy()
+    grad_shape = grads.kernel[...].shape
+
+    with pytest.raises(ValueError, match="fixed capacity 2; requested 3"):
+        _bank_layer(kind, 3, bank_id, seed=1)
+
+    assert layer.kernel[...].shape == kernel_before.shape
+    assert grads.kernel[...].shape == grad_shape
+    np.testing.assert_array_equal(np.asarray(layer.kernel[...]), kernel_before)
+
+    # Existing optimizer moments remain compatible after the rejected request.
+    _, next_grads = nnx.value_and_grad(loss_fn)(layer)
+    optimizer.update(layer, next_grads)
+    assert layer.kernel[...].shape == kernel_before.shape
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv"])
+def test_shared_bank_rejection_is_jit_and_serialization_safe(kind):
+    bank_id = f"issue-140-jit-serialization-{kind}"
+    layer = _bank_layer(kind, 2, bank_id)
+    inputs = _bank_inputs(kind)
+    optimizer = nnx.Optimizer(layer, optax.adam(1e-3), wrt=nnx.Param)
+
+    @nnx.jit
+    def train_step(model, opt):
+        _, grads = nnx.value_and_grad(lambda m: jnp.sum(m(inputs)))(model)
+        opt.update(model, grads)
+
+    train_step(layer, optimizer)
+    state = nnx.state(layer)
+    pure_state = nnx.to_pure_dict(state)
+    encoded = serialization.to_bytes(pure_state)
+
+    with pytest.raises(ValueError, match="fixed capacity"):
+        _bank_layer(kind, 3, bank_id, seed=1)
+
+    restored = serialization.from_bytes(pure_state, encoded)
+    assert restored["kernel"].shape == layer.kernel[...].shape
+    train_step(layer, optimizer)
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv"])
+def test_shared_bank_rejects_concurrent_expansion_atomically(kind):
+    bank_id = f"issue-140-concurrent-{kind}"
+    layer = _bank_layer(kind, 2, bank_id)
+    kernel_before = np.asarray(layer.kernel[...]).copy()
+
+    def construct_wider(seed):
+        with pytest.raises(ValueError, match="fixed capacity"):
+            _bank_layer(kind, 3, bank_id, seed=seed)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        list(pool.map(construct_wider, range(1, 9)))
+
+    assert layer.kernel[...].shape[-1] == 2
+    np.testing.assert_array_equal(np.asarray(layer.kernel[...]), kernel_before)
+
+
+@pytest.mark.parametrize("kind", ["dense", "conv"])
+def test_kernel_bank_size_cannot_be_smaller_than_consumer(kind):
+    with pytest.raises(ValueError, match="must be at least out_features"):
+        _bank_layer(
+            kind,
+            3,
+            f"issue-140-invalid-capacity-{kind}",
+            bank_size=2,
+        )
 
 
 def test_no_direct_nnx_variable_value_assignments_remain():


### PR DESCRIPTION
Implements dacli task 081-prevent-nnx-tied-kernel-bank-expansion-from-corrupting-optimizer-state.

Refs #140

### Acceptance
- [x] Dense and convolution banks reject expansion after any consumer has run or optimizer/state has been created.
- [x] Constructing a wider later consumer never mutates an existing graph, parameter, gradient, or optimizer-state shape.
- [x] Existing optimizers continue updating after rejected expansion.
- [x] Tests cover eager, JIT, serialization, and concurrent construction.
