### PR TITLE
079: Disambiguate Keras sequence masks when batch size equals query length

### DIFF
--- a/.claude/skills/nmn/references/keras.md
+++ b/.claude/skills/nmn/references/keras.md
@@ -44,9 +44,13 @@ attn = MultiHeadYatAttention(embed_dim=128, num_heads=8)
 y = attn(x, attention_mask=mask, training=True)
 ```
 
-`mask` and `attention_mask` are accepted aliases; do not pass conflicting
-values. Fully masked query rows yield exact zeros even when output projection
-bias is enabled.
+A rank-2 `mask` is always a Keras query sequence mask shaped `[batch,
+query_length]`; in self-attention it also masks the corresponding keys. Use
+`attention_mask` for pairwise masks, including rank-2 `[query_length,
+key_length]` masks. Legacy rank-3 and rank-4 pairwise masks passed through
+`mask` remain supported. The two masks are combined when both are supplied.
+Fully masked query rows yield exact zeros even when output projection bias is
+enabled.
 
 ## Dtype and serialization
 

--- a/docs/guides/keras.md
+++ b/docs/guides/keras.md
@@ -131,6 +131,15 @@ print(y.shape)  # (4, 16, 512)
 
 Drop in as a replacement for `keras.layers.MultiHeadAttention`.
 
+The `mask` argument has one unambiguous meaning: a rank-2 Keras query sequence
+mask shaped `(batch, query_length)`, where `True` marks a valid token. For
+self-attention the same sequence mask also masks keys; for cross-attention it
+masks queries only. This contract does not change when `batch == query_length`.
+Pass pairwise masks—including rank-2 `(query_length, key_length)` masks—through
+`attention_mask`. For backward compatibility, rank-3 and rank-4 pairwise masks
+passed through `mask` remain supported. When both arguments are present, the
+layer combines them.
+
 ---
 
 ## 6. Saving & loading

--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -325,10 +325,13 @@ class MultiHeadYatAttention(Layer):
             query: (batch, q_len, embed_dim)
             key: (batch, kv_len, embed_dim). Defaults to query.
             value: (batch, kv_len, embed_dim). Defaults to key.
-            mask: Keras sequence mask or a broadcastable attention mask.
-            attention_mask: Explicit broadcastable attention mask. Prefer this
-                argument when a rank-2 ``(q_len, kv_len)`` mask could be
-                confused with a Keras ``(batch, seq_len)`` sequence mask.
+            mask: Rank-2 Keras query sequence mask with shape
+                ``(batch, q_len)``. In self-attention it masks both query and
+                key positions; in cross-attention it masks query positions.
+                For backward compatibility, rank-3 and rank-4 masks retain
+                their legacy meaning as broadcastable pairwise masks.
+            attention_mask: Explicit pairwise or broadcastable attention mask,
+                including rank-2 ``(q_len, kv_len)`` masks.
             training: Whether in training mode.
 
         Returns:
@@ -367,25 +370,21 @@ class MultiHeadYatAttention(Layer):
         sequence_mask = None
         if mask is not None:
             mask_rank = len(mask.shape)
-            query_keras_mask = getattr(query, "_keras_mask", None)
-            static_batch = query.shape[0]
-            static_q_len = query.shape[1]
-            first_dim = mask.shape[0] if mask_rank == 2 else None
-            looks_like_sequence_mask = mask_rank == 2 and (
-                query_keras_mask is not None
-                or first_dim is None
-                or (
-                    static_batch is not None
-                    and first_dim == static_batch
-                    and first_dim != static_q_len
-                )
-            )
-            if looks_like_sequence_mask:
+            if mask_rank == 2:
                 sequence_mask = ops.cast(mask, "bool")
-            elif attention_mask is None:
-                attention_mask = mask
+            elif mask_rank >= 3:
+                attention_mask = (
+                    mask
+                    if attention_mask is None
+                    else ops.logical_and(attention_mask, mask)
+                )
             else:
-                attention_mask = ops.logical_and(attention_mask, mask)
+                raise ValueError(
+                    "`mask` must be either a rank-2 Keras sequence mask with "
+                    "shape (batch, query_length) or a legacy rank-3/rank-4 "
+                    "pairwise mask; pass rank-2 pairwise masks through "
+                    "`attention_mask`."
+                )
 
         if attention_mask is not None:
             effective_mask = ops.broadcast_to(

--- a/tests/test_keras/test_attention.py
+++ b/tests/test_keras/test_attention.py
@@ -14,6 +14,50 @@ from nmn.keras.attention import (
 )
 
 to_numpy = keras.ops.convert_to_numpy
+BACKEND = keras.backend.backend()
+
+
+def _compiled_output_and_input_gradient(
+    layer, query, context, mask, *, explicit_attention_mask=False
+):
+    def call_layer(query_value):
+        mask_kwargs = (
+            {"attention_mask": mask} if explicit_attention_mask else {"mask": mask}
+        )
+        if context is None:
+            return layer(query_value, **mask_kwargs)
+        return layer(query_value, key=context, value=context, **mask_kwargs)
+
+    if BACKEND == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        output = jax.jit(call_layer)(query)
+        gradient = jax.jit(jax.grad(lambda value: jnp.sum(call_layer(value))))(query)
+        return output, gradient
+
+    if BACKEND == "torch":
+        import torch
+
+        query = query.detach().clone().requires_grad_(True)
+        apply = torch.compile(call_layer, backend="eager")
+        output = apply(query)
+        return output, torch.autograd.grad(output.sum(), query)[0]
+
+    if BACKEND == "tensorflow":
+        import tensorflow as tf
+
+        @tf.function
+        def apply(query_value):
+            with tf.GradientTape() as tape:
+                tape.watch(query_value)
+                output = call_layer(query_value)
+                loss = tf.reduce_sum(output)
+            return output, tape.gradient(loss, query_value)
+
+        return apply(query)
+
+    raise pytest.skip.Exception("requires the JAX, Torch, or TensorFlow Keras backend")
 
 
 class TestAttentionFunctions:
@@ -89,6 +133,118 @@ class TestMultiHeadYatAttention:
         output = layer(inputs, attention_mask=attention_mask)
 
         assert output.shape == (2, 3, 4)
+
+    @pytest.mark.parametrize("cross_attention", [False, True])
+    def test_sequence_mask_is_unambiguous_when_batch_equals_query_length(
+        self, cross_attention
+    ):
+        layer = MultiHeadYatAttention(embed_dim=4, num_heads=2)
+        query = keras.ops.convert_to_tensor(
+            np.arange(16, dtype=np.float32).reshape(2, 2, 4) / 16.0
+        )
+        context = (
+            keras.ops.convert_to_tensor(
+                np.arange(24, dtype=np.float32).reshape(2, 3, 4) / 24.0
+            )
+            if cross_attention
+            else None
+        )
+        sequence_mask = keras.ops.convert_to_tensor(
+            [[True, False], [True, True]], dtype="bool"
+        )
+        if context is None:
+            layer(query)
+        else:
+            layer(query, key=context, value=context)
+        layer.out_bias.assign(np.full(layer.out_bias.shape, 3.0, dtype=np.float32))
+
+        output, gradient = _compiled_output_and_input_gradient(
+            layer, query, context, sequence_mask
+        )
+
+        np.testing.assert_array_equal(to_numpy(output)[0, 1], np.zeros(4))
+        assert np.all(np.isfinite(to_numpy(output)))
+        assert np.all(np.isfinite(to_numpy(gradient)))
+
+    @pytest.mark.parametrize("cross_attention", [False, True])
+    def test_symbolic_sequence_mask_supports_dynamic_lengths(self, cross_attention):
+        query = keras.Input(shape=(None, 4))
+        sequence_mask = keras.Input(shape=(None,), dtype="bool")
+        layer = MultiHeadYatAttention(embed_dim=4, num_heads=2)
+        if cross_attention:
+            context = keras.Input(shape=(None, 4))
+            output = layer(query, key=context, value=context, mask=sequence_mask)
+            model = keras.Model((query, context, sequence_mask), output)
+            inputs = (
+                np.ones((2, 2, 4), dtype=np.float32),
+                np.ones((2, 3, 4), dtype=np.float32),
+                np.array([[True, False], [True, True]]),
+            )
+        else:
+            output = layer(query, mask=sequence_mask)
+            model = keras.Model((query, sequence_mask), output)
+            inputs = (
+                np.ones((2, 2, 4), dtype=np.float32),
+                np.array([[True, False], [True, True]]),
+            )
+
+        result = to_numpy(model(inputs))
+        np.testing.assert_array_equal(result[0, 1], np.zeros(4))
+
+    @pytest.mark.parametrize("mask_rank", [3, 4])
+    def test_legacy_pairwise_mask_matches_attention_mask(self, mask_rank):
+        layer = MultiHeadYatAttention(embed_dim=4, num_heads=2)
+        inputs = keras.ops.convert_to_tensor(
+            np.arange(24, dtype=np.float32).reshape(2, 3, 4) / 24.0
+        )
+        pairwise_mask = np.ones(
+            (1, 3, 3) if mask_rank == 3 else (2, 1, 3, 3), dtype=bool
+        )
+        pairwise_mask[..., 1, :] = False
+        layer(inputs)
+
+        legacy_output, legacy_gradient = _compiled_output_and_input_gradient(
+            layer, inputs, None, pairwise_mask
+        )
+        explicit_output, explicit_gradient = _compiled_output_and_input_gradient(
+            layer,
+            inputs,
+            None,
+            pairwise_mask,
+            explicit_attention_mask=True,
+        )
+
+        np.testing.assert_allclose(
+            to_numpy(legacy_output), to_numpy(explicit_output), atol=1e-6
+        )
+        np.testing.assert_allclose(
+            to_numpy(legacy_gradient), to_numpy(explicit_gradient), atol=1e-6
+        )
+        np.testing.assert_array_equal(to_numpy(legacy_output)[:, 1], 0.0)
+
+    def test_legacy_pairwise_mask_combines_with_attention_mask(self):
+        layer = MultiHeadYatAttention(embed_dim=4, num_heads=2)
+        inputs = np.arange(24, dtype=np.float32).reshape(2, 3, 4) / 24.0
+        legacy_mask = np.ones((2, 1, 3, 3), dtype=bool)
+        legacy_mask[:, :, 1, :] = False
+        explicit_mask = np.tril(np.ones((3, 3), dtype=bool))
+
+        combined_output = layer(inputs, mask=legacy_mask, attention_mask=explicit_mask)
+        expected_output = layer(
+            inputs,
+            attention_mask=np.logical_and(legacy_mask, explicit_mask),
+        )
+
+        np.testing.assert_allclose(
+            to_numpy(combined_output), to_numpy(expected_output), atol=1e-6
+        )
+
+    def test_rank_one_mask_is_rejected(self):
+        layer = MultiHeadYatAttention(embed_dim=4, num_heads=2)
+        inputs = np.ones((1, 2, 4), dtype=np.float32)
+
+        with pytest.raises(ValueError, match="rank-2"):
+            layer(inputs, mask=np.ones((2,), dtype=bool))
 
     def test_self_attention(self):
         attn = MultiHeadYatAttention(embed_dim=32, num_heads=4)

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -121,9 +121,9 @@ def test_attention_layer_zeroes_fully_masked_rows_after_projection(
     mask_np[..., 0, :] = False
     mask = tensor(mask_np, dtype="bool")
     output = (
-        layer(query, key=context, value=context, mask=mask)
+        layer(query, key=context, value=context, attention_mask=mask)
         if cross_attention
-        else layer(query, mask=mask)
+        else layer(query, attention_mask=mask)
     )
     np.testing.assert_array_equal(to_numpy(output)[:, 0], 0.0)
     assert np.all(np.isfinite(to_numpy(output)))


### PR DESCRIPTION
Implements dacli task 079-disambiguate-keras-sequence-masks-when-batch-size-equals-query-length.

Refs #142

### Acceptance
- [x] The Keras `mask` argument has an unambiguous documented sequence-mask contract even when `B == Q`.
- [x] Pairwise rank-2 masks are accepted only through `attention_mask`, or ambiguity raises a clear error.
- [ ] Tests cover JAX, Torch, and TensorFlow Keras backends, self/cross attention, dynamic shapes, biased output projection, gradients, and compiled execution.
