### PR TITLE
078: Route Torch normalized YAT attention through low-precision-safe score computation

### DIFF
--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -21,7 +21,6 @@ Note: Constant alpha (e.g. sqrt(2)) is handled by the calling module
 
 from __future__ import annotations
 
-import math
 from typing import Optional, Tuple
 
 import torch
@@ -238,46 +237,19 @@ def yat_attention_normalized(
     Returns:
         Output of shape (batch, q_len, num_heads, v_dim)
     """
-    head_dim = query.shape[-1]
-
-    # Normalize to unit vectors
-    query_n, key_n = normalize_qk(query, key, epsilon)
-
-    # Dot product: q·k → (B, H, Q, K)
-    dot_product = torch.einsum("bqhd,bkhd->bhqk", query_n, key_n)
-
-    # Simplified: (q·k)² / ((2(1 - q·k) + ε) * √d)
-    # Clamp distance: bf16 rounding can make q·k > 1 after normalization
-    dim_scale = head_dim**0.5
-    squared_dot = dot_product.square()
-    distance_sq = (2.0 - 2.0 * dot_product).clamp(min=0.0)
-
-    attn_weights = squared_dot / ((distance_sq + epsilon) * dim_scale)
-
-    # Alpha scaling (before softmax)
-    # Either learnable alpha (simple multiply) or direct constant scale, never both
-    if alpha is not None:
-        attn_weights = attn_weights * alpha
-    elif scale is not None:
-        attn_weights = attn_weights * scale
-
-    # Mask
-    if mask is not None:
-        mask = torch.broadcast_to(mask.to(dtype=torch.bool), attn_weights.shape)
-        row_has_key = mask.any(dim=-1, keepdim=True)
-        attn_weights = attn_weights.masked_fill(~mask, float("-inf"))
-        attn_weights = torch.where(
-            row_has_key, attn_weights, torch.zeros_like(attn_weights)
-        )
-
-    # Softmax
-    attn_weights = F.softmax(attn_weights, dim=-1)
-    if mask is not None:
-        attn_weights = torch.where(mask, attn_weights, torch.zeros_like(attn_weights))
-
-    # Dropout
-    if dropout_p > 0.0 and training:
-        attn_weights = F.dropout(attn_weights, p=dropout_p, training=True)
-
-    # Weighted sum
-    return torch.einsum("bhqk,bkhd->bqhd", attn_weights, value)
+    # Keep this public optimized alias on the same guarded score path as
+    # ``yat_attention(..., spherical=True)``.  In particular, fp16/bfloat16
+    # normalization and score formation must accumulate in fp32 before the
+    # bounded attention weights return to the caller dtype.
+    return yat_attention(
+        query,
+        key,
+        value,
+        mask=mask,
+        dropout_p=dropout_p,
+        training=training,
+        epsilon=epsilon,
+        alpha=alpha,
+        scale=scale,
+        spherical=True,
+    )

--- a/tests/test_torch/test_attention.py
+++ b/tests/test_torch/test_attention.py
@@ -14,6 +14,79 @@ from nmn.torch.attention.yat_attention import (
 
 
 class TestAttentionFunctions:
+    @pytest.mark.parametrize(
+        ("dtype", "rtol", "atol"),
+        [
+            pytest.param(torch.float16, 5e-3, 5e-4, id="float16"),
+            pytest.param(torch.bfloat16, 2e-2, 3e-3, id="bfloat16"),
+        ],
+    )
+    @pytest.mark.parametrize("compiled", [False, True], ids=["eager", "compiled"])
+    def test_normalized_low_precision_matches_fp32_output_and_gradients(
+        self, dtype, rtol, atol, compiled
+    ):
+        if compiled and not hasattr(torch, "compile"):
+            pytest.skip("torch.compile requires PyTorch 2")
+
+        # Build the reference from values quantized to the caller dtype so this
+        # measures arithmetic precision rather than input representation error.
+        query_data = torch.tensor(
+            [[[[300.0, 300.0, 300.0, 300.0]], [[300.0, -300.0, 200.0, -200.0]]]],
+            dtype=dtype,
+        )
+        key_data = torch.tensor(
+            [
+                [
+                    [[300.0, 300.0, 300.0, -300.0]],
+                    [[300.0, -300.0, -300.0, 300.0]],
+                    [[-300.0, 250.0, 200.0, 100.0]],
+                ]
+            ],
+            dtype=dtype,
+        )
+        value_data = torch.tensor(
+            [[[[1.0, -1.0]], [[3.0, 2.0]], [[-2.0, 4.0]]]], dtype=dtype
+        )
+        mask = torch.tensor([[[[False, False, False], [True, True, False]]]])
+        cotangent = torch.tensor([[[[0.5, -0.25]], [[1.5, 0.75]]]])
+
+        def evaluate(compute_dtype, use_compile, normalized):
+            query = query_data.to(compute_dtype).detach().requires_grad_()
+            key = key_data.to(compute_dtype).detach().requires_grad_()
+            value = value_data.to(compute_dtype).detach().requires_grad_()
+            alpha = torch.tensor(1.25, dtype=dtype).to(compute_dtype).requires_grad_()
+
+            def apply(q, k, v, a):
+                if normalized:
+                    return yat_attention_normalized(
+                        q, k, v, mask=mask, training=False, alpha=a
+                    )
+                return yat_attention(
+                    q, k, v, mask=mask, training=False, alpha=a, spherical=True
+                )
+
+            if use_compile:
+                apply = torch.compile(apply, backend="eager")
+            output = apply(query, key, value, alpha)
+            gradients = torch.autograd.grad(
+                (output.float() * cotangent).sum(), (query, key, value, alpha)
+            )
+            return output, gradients
+
+        reference_output, reference_gradients = evaluate(torch.float32, False, False)
+        output, gradients = evaluate(dtype, compiled, True)
+
+        assert output.dtype == dtype
+        assert torch.equal(output[:, 0], torch.zeros_like(output[:, 0]))
+        assert all(torch.isfinite(gradient).all() for gradient in gradients)
+        torch.testing.assert_close(
+            output.float(), reference_output, rtol=rtol, atol=atol
+        )
+        for gradient, reference_gradient in zip(gradients, reference_gradients):
+            torch.testing.assert_close(
+                gradient.float(), reference_gradient, rtol=rtol, atol=atol
+            )
+
     def test_negative_scale_cannot_make_masked_key_win_softmax(self):
         q = torch.ones(1, 1, 1, 4)
         k = torch.ones(1, 2, 1, 4)


### PR DESCRIPTION
Implements dacli task 078-route-torch-normalized-yat-attention-through-low-precision-safe-score.

Refs #143

### Acceptance
- [x] Normalized attention delegates to the guarded score path or implements identical fp32 accumulation and saturating output conversion.
- [x] fp16 and bfloat16 output plus q<withheld-local-path> gradients match synchronized fp32 references within documented tolerances.
- [x] Tests cover masks, fully masked rows, eager execution, and `torch.compile`.
