### PR TITLE
fix(attention): centralize shape validation

### DIFF
--- a/src/nmn/_attention_shape.py
+++ b/src/nmn/_attention_shape.py
@@ -1,0 +1,72 @@
+"""Framework-neutral validation for functional attention tensor shapes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def validate_attention_inputs(
+    query: Any,
+    key: Any,
+    value: Any | None = None,
+    *,
+    exact_rank: int | None = None,
+) -> None:
+    """Validate ``[..., sequence, heads, depth]`` attention operands.
+
+    The helper deliberately inspects only ``ndim`` and ``shape`` so all
+    backends can share the same exception type, check ordering, and messages
+    without importing another tensor framework.
+    """
+    operands: tuple[tuple[str, Any], ...] = (("query", query), ("key", key))
+    if value is not None:
+        operands += (("value", value),)
+
+    ranks = {name: operand.ndim for name, operand in operands}
+    if exact_rank is None:
+        invalid = {name: rank for name, rank in ranks.items() if rank < 3}
+        if invalid:
+            details = ", ".join(f"{name}={rank}" for name, rank in ranks.items())
+            raise ValueError(
+                "attention inputs must have rank at least 3 "
+                f"([..., sequence, heads, depth]); got {details}"
+            )
+    elif any(rank != exact_rank for rank in ranks.values()):
+        details = ", ".join(f"{name}={rank}" for name, rank in ranks.items())
+        raise ValueError(
+            f"attention inputs must have rank {exact_rank} "
+            f"([batch, sequence, heads, depth]); got {details}"
+        )
+
+    if len(set(ranks.values())) != 1:
+        details = ", ".join(f"{name}={rank}" for name, rank in ranks.items())
+        raise ValueError(f"attention inputs must have the same rank; got {details}")
+
+    batch_shapes = {name: tuple(operand.shape[:-3]) for name, operand in operands}
+    if len(set(batch_shapes.values())) != 1:
+        details = ", ".join(f"{name}={shape}" for name, shape in batch_shapes.items())
+        raise ValueError(
+            f"attention input batch dimensions must match exactly; got {details}"
+        )
+
+    head_counts = {name: operand.shape[-2] for name, operand in operands}
+    if len(set(head_counts.values())) != 1:
+        details = ", ".join(f"{name}={count}" for name, count in head_counts.items())
+        raise ValueError(
+            f"attention inputs must have the same number of heads; got {details}"
+        )
+
+    if query.shape[-1] != key.shape[-1]:
+        raise ValueError(
+            "query and key head depth (head_dim) must match; "
+            f"got query={query.shape[-1]}, key={key.shape[-1]}"
+        )
+
+    if value is not None and key.shape[-3] != value.shape[-3]:
+        raise ValueError(
+            "key and value sequence lengths must match; "
+            f"got key={key.shape[-3]}, value={value.shape[-3]}"
+        )
+
+
+__all__ = ["validate_attention_inputs"]

--- a/src/nmn/linen/performer_yat.py
+++ b/src/nmn/linen/performer_yat.py
@@ -84,6 +84,8 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
+from nmn._attention_shape import validate_attention_inputs
+
 __all__ = [
     "spherical_kappa",
     "maclaurin_coeffs",
@@ -387,6 +389,7 @@ def linear_attention(
     Returns:
         ``(B, Q, H, dv)``.
     """
+    validate_attention_inputs(phi_q, phi_k, value, exact_rank=4)
     if causal:
         # kv[b, k, h, f, d] = phi_k[b, k, h, f] * value[b, k, h, d]
         kv = jnp.einsum("bkhf,bkhd->bkhfd", phi_k, value)
@@ -429,6 +432,7 @@ def maclaurin_yat_attention(
     Returns:
         ``(B, Q, H, dv)``.
     """
+    validate_attention_inputs(query, key, value, exact_rank=4)
     phi_q = maclaurin_features(query, params, normalize=True)
     phi_k = maclaurin_features(key, params, normalize=True)
     return linear_attention(phi_q, phi_k, value, causal=causal, eps_div=eps_div)
@@ -455,6 +459,7 @@ def radial_yat_attention(
     Returns:
         ``(B, Q, H, dv)``.
     """
+    validate_attention_inputs(query, key, value, exact_rank=4)
     phi_q = radial_features(query, params, normalize=True)
     phi_k = radial_features(key, params, normalize=True)
     return linear_attention(phi_q, phi_k, value, causal=causal, eps_div=eps_div)

--- a/src/nmn/nnx/layers/attention/dot_product.py
+++ b/src/nmn/nnx/layers/attention/dot_product.py
@@ -21,6 +21,8 @@ from flax.nnx.nn.dtypes import promote_dtype
 from flax.typing import Dtype, PrecisionLike
 from jax import Array, random
 
+from nmn._attention_shape import validate_attention_inputs
+
 from ._attention_core import finalize_attention_weights
 
 
@@ -65,10 +67,7 @@ def dot_product_attention_weights(
     query, key = promote_dtype((query, key), dtype=dtype)
     dtype = query.dtype
 
-    assert query.ndim == key.ndim, "q, k must have same rank."
-    assert query.shape[:-3] == key.shape[:-3], "q, k batch dims must match."
-    assert query.shape[-2] == key.shape[-2], "q, k num_heads must match."
-    assert query.shape[-1] == key.shape[-1], "q, k depths must match."
+    validate_attention_inputs(query, key)
 
     # Calculate scaled attention matrix
     depth = query.shape[-1]
@@ -136,14 +135,7 @@ def dot_product_attention(
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
 
-    assert key.ndim == query.ndim == value.ndim, "q, k, v must have same rank."
-    assert (
-        query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
-    ), "q, k, v batch dims must match."
-    assert (
-        query.shape[-2] == key.shape[-2] == value.shape[-2]
-    ), "q, k, v num_heads must match."
-    assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
+    validate_attention_inputs(query, key, value)
 
     # Compute attention weights
     attn_weights = dot_product_attention_weights(

--- a/src/nmn/nnx/layers/attention/fused_yat_attention.py
+++ b/src/nmn/nnx/layers/attention/fused_yat_attention.py
@@ -24,6 +24,8 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
+from nmn._attention_shape import validate_attention_inputs
+
 
 def fused_yat_l1_attention(
     query: Array,
@@ -65,6 +67,8 @@ def fused_yat_l1_attention(
     Returns:
         Output of shape [..., q_length, num_heads, v_dim].
     """
+    validate_attention_inputs(query, key, value)
+
     has_bias = bias is not None
     has_mask = mask is not None
     has_eps_grad = isinstance(epsilon, jnp.ndarray)
@@ -377,6 +381,8 @@ def fused_yat_l1_self_attention(
     Returns:
         Output of shape [..., seq_len, num_heads, v_dim].
     """
+    validate_attention_inputs(x, x, value)
+
     has_bias = bias is not None
     has_eps_grad = isinstance(epsilon, jnp.ndarray)
 

--- a/src/nmn/nnx/layers/attention/maclaurin_yat.py
+++ b/src/nmn/nnx/layers/attention/maclaurin_yat.py
@@ -77,6 +77,8 @@ from flax.nnx.nn.dtypes import promote_dtype
 from flax.typing import Dtype, PrecisionLike
 from jax import Array, lax, random
 
+from nmn._attention_shape import validate_attention_inputs
+
 
 def maclaurin_coeffs(b: float, epsilon: float, nmax: int) -> np.ndarray:
     """Maclaurin coefficients ``a_n`` of ``kappa(s) = (s+b)²/(C-2s)``.
@@ -328,6 +330,7 @@ def maclaurin_yat_attention(
         Output ``[..., q_length, num_heads, v_dim]``.
     """
     query, key, value = promote_dtype((query, key, value), dtype=None)
+    validate_attention_inputs(query, key, value)
 
     q_feat = maclaurin_features(query, params, normalize=True)
     k_feat = maclaurin_features(key, params, normalize=True)

--- a/src/nmn/nnx/layers/attention/pallas_yat_attention.py
+++ b/src/nmn/nnx/layers/attention/pallas_yat_attention.py
@@ -36,6 +36,8 @@ import jax.numpy as jnp
 from jax import lax
 from jax.experimental import pallas as pl
 
+from nmn._attention_shape import validate_attention_inputs
+
 
 def _dot(a, b, precision):
     """Pallas dot with an explicit caller-selected precision policy."""
@@ -339,16 +341,7 @@ def pallas_yat_l1_attention(
 
 
 def _validate_inputs(q, k, v, block_q, block_k, interpret):
-    if q.ndim < 3 or k.ndim < 3 or v.ndim < 3:
-        raise ValueError("q, k, and v must have shape [..., sequence, heads, features]")
-    if q.shape[:-3] != k.shape[:-3] or q.shape[:-3] != v.shape[:-3]:
-        raise ValueError("q, k, and v batch dimensions must match")
-    if q.shape[-1] != k.shape[-1]:
-        raise ValueError("q and k head_dim must match")
-    if q.shape[-2] != k.shape[-2] or q.shape[-2] != v.shape[-2]:
-        raise ValueError("q, k, and v number of heads must match")
-    if k.shape[-3] != v.shape[-3]:
-        raise ValueError("k and v sequence lengths must match")
+    validate_attention_inputs(q, k, v)
     if q.shape[-3] == 0 or k.shape[-3] == 0:
         raise ValueError("q and k sequence lengths must be non-zero")
     if block_q <= 0 or block_k <= 0:

--- a/src/nmn/nnx/layers/attention/radial_yat.py
+++ b/src/nmn/nnx/layers/attention/radial_yat.py
@@ -57,6 +57,8 @@ from flax.nnx.nn.dtypes import promote_dtype
 from flax.typing import Dtype, PrecisionLike
 from jax import Array, random
 
+from nmn._attention_shape import validate_attention_inputs
+
 from .maclaurin_yat import _linear_readout
 
 
@@ -215,6 +217,7 @@ def radial_yat_attention(
         Output ``[..., q_length, num_heads, v_dim]``.
     """
     query, key, value = promote_dtype((query, key, value), dtype=None)
+    validate_attention_inputs(query, key, value)
 
     q_feat = radial_features(query, params, normalize=True)
     k_feat = radial_features(key, params, normalize=True)

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -46,6 +46,7 @@ from flax.typing import (
 )
 from jax import Array, random
 
+from nmn._attention_shape import validate_attention_inputs
 from nmn.nnx.layers.squashers import softermax
 
 from .._numerics import fp32_if_low_precision, inverse_softplus
@@ -229,6 +230,8 @@ def rotary_yat_attention_weights(
     Returns:
         Attention weights of shape [..., num_heads, q_length, kv_length].
     """
+    validate_attention_inputs(query, key)
+
     # Apply RoPE to query and key
     if key_position_offset is None:
         key_position_offset = position_offset
@@ -296,6 +299,8 @@ def rotary_yat_attention(
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
 
+    validate_attention_inputs(query, key, value)
+
     # Compute attention weights with RoPE + YAT
     attn_weights = rotary_yat_attention_weights(
         query,
@@ -357,6 +362,8 @@ def rotary_yat_performer_attention(
     """
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
+
+    validate_attention_inputs(query, key, value)
 
     # Apply RoPE first
     if key_position_offset is None:

--- a/src/nmn/nnx/layers/attention/spherical_yat_performer.py
+++ b/src/nmn/nnx/layers/attention/spherical_yat_performer.py
@@ -64,6 +64,8 @@ from flax.nnx.nn.dtypes import promote_dtype
 from flax.typing import Dtype, PrecisionLike
 from jax import Array, lax, random
 
+from nmn._attention_shape import validate_attention_inputs
+
 
 def create_orthogonal_features(key, num_features, dim, dtype=jnp.float32):
     """Create orthogonal random features scaled by sqrt(dim)."""
@@ -314,6 +316,7 @@ def yat_tp_attention(
         Output [..., q_length, num_heads, v_dim].
     """
     query, key, value = promote_dtype((query, key, value), dtype=None)
+    validate_attention_inputs(query, key, value)
 
     q_feat = yat_tp_features(query, params, normalize=True, epsilon=epsilon)
     k_feat = yat_tp_features(key, params, normalize=True, epsilon=epsilon)

--- a/src/nmn/nnx/layers/attention/yat_attention.py
+++ b/src/nmn/nnx/layers/attention/yat_attention.py
@@ -39,6 +39,7 @@ from flax.nnx.nn.dtypes import promote_dtype
 from flax.typing import Dtype, PrecisionLike
 from jax import Array, random
 
+from nmn._attention_shape import validate_attention_inputs
 from nmn.nnx.layers._numerics import fp32_if_low_precision
 from nmn.nnx.layers.squashers import softermax
 
@@ -104,10 +105,7 @@ def yat_attention_weights(
     query, key = promote_dtype((query, key), dtype=dtype)
     dtype = query.dtype
 
-    assert query.ndim == key.ndim, "q, k must have same rank."
-    assert query.shape[:-3] == key.shape[:-3], "q, k batch dims must match."
-    assert query.shape[-2] == key.shape[-2], "q, k num_heads must match."
-    assert query.shape[-1] == key.shape[-1], "q, k depths must match."
+    validate_attention_inputs(query, key)
 
     head_dim = query.shape[-1]
 
@@ -219,14 +217,7 @@ def yat_attention(
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
 
-    assert key.ndim == query.ndim == value.ndim, "q, k, v must have same rank."
-    assert (
-        query.shape[:-3] == key.shape[:-3] == value.shape[:-3]
-    ), "q, k, v batch dims must match."
-    assert (
-        query.shape[-2] == key.shape[-2] == value.shape[-2]
-    ), "q, k, v num_heads must match."
-    assert key.shape[-3] == value.shape[-3], "k, v lengths must match."
+    validate_attention_inputs(query, key, value)
 
     # Compute attention weights using YAT formula
     attn_weights = yat_attention_weights(
@@ -337,6 +328,8 @@ def yat_attention_normalized(
     """
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
+
+    validate_attention_inputs(query, key, value)
 
     head_dim = query.shape[-1]
 
@@ -504,6 +497,8 @@ def yat_performer_attention(
     """
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
+
+    validate_attention_inputs(query, key, value)
 
     head_dim = query.shape[-1]
 

--- a/src/nmn/torch/attention/performer_yat.py
+++ b/src/nmn/torch/attention/performer_yat.py
@@ -58,6 +58,8 @@ import numpy as np
 import torch
 from torch import Tensor
 
+from nmn._attention_shape import validate_attention_inputs
+
 __all__ = [
     "maclaurin_coeffs",
     "create_maclaurin_projection",
@@ -231,6 +233,7 @@ def maclaurin_yat_attention(
     Returns:
         ``(B, Q, H, v_dim)``.
     """
+    validate_attention_inputs(query, key, value, exact_rank=4)
     q_feat = maclaurin_features(query, params, normalize=True)
     k_feat = maclaurin_features(key, params, normalize=True)
     return linear_attention_readout(
@@ -378,6 +381,7 @@ def radial_yat_attention(
 
     See :func:`maclaurin_yat_attention`; same signature, RAY feature map.
     """
+    validate_attention_inputs(query, key, value, exact_rank=4)
     q_feat = radial_features(query, params, normalize=True)
     k_feat = radial_features(key, params, normalize=True)
     return linear_attention_readout(
@@ -412,6 +416,7 @@ def linear_attention_readout(
     Returns:
         ``(B, Q, H, v_dim)``.
     """
+    validate_attention_inputs(q_feat, k_feat, value, exact_rank=4)
     if k_feat.dtype != q_feat.dtype:
         k_feat = k_feat.to(q_feat.dtype)
     if value.dtype != q_feat.dtype:

--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -27,6 +27,8 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 
+from nmn._attention_shape import validate_attention_inputs
+
 from .._precision import saturating_upcast
 
 
@@ -85,7 +87,7 @@ def yat_attention_weights(
     Returns:
         Attention weights of shape (batch, num_heads, q_len, kv_len)
     """
-    assert query.ndim == key.ndim == 4, "Expected (batch, seq, heads, dim)"
+    validate_attention_inputs(query, key, exact_rank=4)
     output_dtype = query.dtype
     if output_dtype in (torch.float16, torch.bfloat16):
         # dot^2 and the expanded squared distance both overflow/cancel readily
@@ -189,6 +191,8 @@ def yat_attention(
     Returns:
         Output of shape (batch, q_len, num_heads, v_dim)
     """
+    validate_attention_inputs(query, key, value, exact_rank=4)
+
     attn_weights = yat_attention_weights(
         query,
         key,

--- a/tests/integration/test_attention_shape_contract.py
+++ b/tests/integration/test_attention_shape_contract.py
@@ -1,0 +1,253 @@
+"""Cross-backend contract tests for functional attention input shapes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+INVALID_QKV_SHAPES = {
+    "rank": ((2, 3), (2, 7, 3, 4), (2, 7, 3, 6), "rank"),
+    "batch": ((2, 5, 3, 4), (1, 7, 3, 4), (2, 7, 3, 6), "batch dimensions"),
+    "heads": ((2, 5, 3, 4), (2, 7, 2, 4), (2, 7, 3, 6), "number of heads"),
+    "qk_depth": ((2, 5, 3, 4), (2, 7, 3, 5), (2, 7, 3, 6), "head depth"),
+    "kv_length": ((2, 5, 3, 4), (2, 7, 3, 4), (2, 6, 3, 6), "sequence lengths"),
+}
+
+
+def _backend(backend):
+    if backend == "torch":
+        torch = pytest.importorskip("torch")
+        from nmn.torch.attention import yat_attention, yat_attention_weights
+
+        return (
+            torch.ones,
+            yat_attention,
+            yat_attention_weights,
+            lambda fn: torch.compile(fn, backend="eager"),
+        )
+
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    if backend == "nnx":
+        from nmn.nnx import yat_attention, yat_attention_weights
+    else:
+        from nmn.linen import yat_attention, yat_attention_weights
+    return jnp.ones, yat_attention, yat_attention_weights, jax.jit
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize("case", INVALID_QKV_SHAPES)
+@pytest.mark.parametrize("backend", ["torch", "nnx", "linen"])
+def test_invalid_qkv_shape_matrix_raises_value_error(backend, case, compiled):
+    ones, attention, _, compile_fn = _backend(backend)
+    q_shape, k_shape, v_shape, message = INVALID_QKV_SHAPES[case]
+    apply = compile_fn(attention) if compiled else attention
+
+    with pytest.raises(ValueError, match=message):
+        apply(ones(q_shape), ones(k_shape), ones(v_shape))
+
+
+@pytest.mark.parametrize("backend", ["nnx", "linen"])
+def test_jax_attention_retains_multiple_leading_batch_dimensions(backend):
+    ones, attention, _, _ = _backend(backend)
+    output = attention(
+        ones((2, 3, 5, 2, 4)),
+        ones((2, 3, 7, 2, 4)),
+        ones((2, 3, 7, 2, 6)),
+    )
+    assert output.shape == (2, 3, 5, 2, 6)
+
+
+@pytest.mark.parametrize("backend", ["torch", "nnx", "linen"])
+def test_shape_validation_is_active_under_python_optimized_mode(backend):
+    # This integration file runs in the JAX-only CI job as well as developer
+    # environments that may have every optional backend installed.  Skip in
+    # the parent process so a deliberately isolated install does not turn the
+    # child import into a false validation failure.
+    _backend(backend)
+    module = "nmn.torch.attention" if backend == "torch" else f"nmn.{backend}"
+    array = "torch.ones" if backend == "torch" else "jnp.ones"
+    imports = "import torch" if backend == "torch" else "import jax.numpy as jnp"
+    probe = f"""
+{imports}
+from {module} import yat_attention
+try:
+    yat_attention(
+        {array}((2, 5, 3, 4)),
+        {array}((1, 7, 3, 4)),
+        {array}((2, 7, 3, 6)),
+    )
+except ValueError as exc:
+    print(type(exc).__name__ + ': ' + str(exc))
+else:
+    raise RuntimeError('invalid shapes were accepted')
+"""
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            filter(None, (str(Path.cwd() / "src"), os.environ.get("PYTHONPATH")))
+        ),
+    }
+    results = [
+        subprocess.run(
+            [sys.executable, *flags, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        for flags in ([], ["-O"])
+    ]
+    assert all(result.returncode == 0 for result in results), results
+    assert results[0].stdout == results[1].stdout
+    assert "ValueError: attention input batch dimensions" in results[0].stdout
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize("backend", ["torch", "nnx", "linen"])
+def test_attention_weights_reject_mismatched_qk_shapes(backend, compiled):
+    ones, _, weights, compile_fn = _backend(backend)
+    apply = compile_fn(weights) if compiled else weights
+
+    with pytest.raises(ValueError, match="head depth"):
+        apply(ones((2, 5, 3, 4)), ones((2, 7, 3, 5)))
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+def test_nnx_dot_product_attention_uses_shared_shape_contract(compiled):
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    from nmn.nnx import dot_product_attention
+
+    apply = jax.jit(dot_product_attention) if compiled else dot_product_attention
+    with pytest.raises(ValueError, match="sequence lengths"):
+        apply(
+            jnp.ones((2, 5, 3, 4)),
+            jnp.ones((2, 7, 3, 4)),
+            jnp.ones((2, 6, 3, 8)),
+        )
+
+
+ADVANCED_ROUTES = [
+    pytest.param("torch", "spherical", id="torch-spherical"),
+    pytest.param("torch", "may", id="torch-may"),
+    pytest.param("torch", "ray", id="torch-ray"),
+    pytest.param("torch", "linear-readout", id="torch-linear-readout"),
+    pytest.param("linen", "spherical", id="linen-spherical"),
+    pytest.param("linen", "may", id="linen-may"),
+    pytest.param("linen", "ray", id="linen-ray"),
+    pytest.param("linen", "linear-readout", id="linen-linear-readout"),
+    pytest.param("nnx", "spherical", id="nnx-spherical"),
+    pytest.param("nnx", "dot-product", id="nnx-dot-product"),
+    pytest.param("nnx", "dot-product-weights", id="nnx-dot-product-weights"),
+    pytest.param("nnx", "fused", id="nnx-fused"),
+    pytest.param("nnx", "fused-self", id="nnx-fused-self"),
+    pytest.param("nnx", "pallas", id="nnx-pallas"),
+    pytest.param("nnx", "may", id="nnx-may"),
+    pytest.param("nnx", "ray", id="nnx-ray"),
+    pytest.param("nnx", "slay", id="nnx-slay"),
+    pytest.param("nnx", "performer", id="nnx-performer"),
+    pytest.param("nnx", "rotary", id="nnx-rotary"),
+    pytest.param("nnx", "rotary-weights", id="nnx-rotary-weights"),
+    pytest.param("nnx", "rotary-performer", id="nnx-rotary-performer"),
+]
+
+
+def _advanced_route(backend, route):
+    if backend == "torch":
+        torch = pytest.importorskip("torch")
+        from nmn.torch.attention import (
+            linear_attention_readout,
+            maclaurin_yat_attention,
+            radial_yat_attention,
+            yat_attention_normalized,
+        )
+
+        routes = {
+            "spherical": yat_attention_normalized,
+            "may": lambda q, k, v: maclaurin_yat_attention(q, k, v, None),
+            "ray": lambda q, k, v: radial_yat_attention(q, k, v, None),
+            "linear-readout": linear_attention_readout,
+        }
+        return torch.ones, routes[route], lambda fn: torch.compile(fn, backend="eager")
+
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    if backend == "linen":
+        from nmn.linen import (
+            linear_attention,
+            maclaurin_yat_attention,
+            radial_yat_attention,
+            yat_attention_normalized,
+        )
+
+        routes = {
+            "spherical": yat_attention_normalized,
+            "may": lambda q, k, v: maclaurin_yat_attention(q, k, v, None),
+            "ray": lambda q, k, v: radial_yat_attention(q, k, v, None),
+            "linear-readout": linear_attention,
+        }
+        return jnp.ones, routes[route], jax.jit
+
+    from nmn.nnx.layers.attention import (
+        dot_product_attention,
+        dot_product_attention_weights,
+        fused_yat_l1_attention,
+        fused_yat_l1_self_attention,
+        maclaurin_yat_attention,
+        pallas_yat_l1_attention,
+        radial_yat_attention,
+        rotary_yat_attention,
+        rotary_yat_attention_weights,
+        rotary_yat_performer_attention,
+        yat_attention_normalized,
+        yat_performer_attention,
+        yat_tp_attention,
+    )
+
+    routes = {
+        "spherical": yat_attention_normalized,
+        "dot-product": dot_product_attention,
+        "dot-product-weights": lambda q, k, _v: dot_product_attention_weights(q, k),
+        "fused": fused_yat_l1_attention,
+        "fused-self": lambda q, _k, v: fused_yat_l1_self_attention(q, v),
+        "pallas": lambda q, k, v: pallas_yat_l1_attention(q, k, v, interpret=True),
+        "may": lambda q, k, v: maclaurin_yat_attention(q, k, v, None),
+        "ray": lambda q, k, v: radial_yat_attention(q, k, v, None),
+        "slay": lambda q, k, v: yat_tp_attention(q, k, v, None),
+        "performer": lambda q, k, v: yat_performer_attention(q, k, v, None),
+        "rotary": lambda q, k, v: rotary_yat_attention(q, k, v, None, None),
+        "rotary-weights": lambda q, k, _v: rotary_yat_attention_weights(
+            q, k, None, None
+        ),
+        "rotary-performer": lambda q, k, v: rotary_yat_performer_attention(
+            q, k, v, None, None, None
+        ),
+    }
+    return jnp.ones, routes[route], jax.jit
+
+
+@pytest.mark.parametrize("compiled", [False, True])
+@pytest.mark.parametrize(("backend", "route"), ADVANCED_ROUTES)
+def test_advanced_public_routes_use_shared_shape_contract(backend, route, compiled):
+    ones, apply, compile_fn = _advanced_route(backend, route)
+    if (
+        compiled
+        and backend == "torch"
+        and not hasattr(pytest.importorskip("torch"), "compile")
+    ):
+        pytest.skip("torch.compile requires PyTorch 2")
+    if compiled:
+        apply = compile_fn(apply)
+
+    query = ones((2, 5, 3, 4))
+    key = ones((2, 7, 3, 5))
+    value_shape = (2, 4, 3, 6) if route == "fused-self" else (2, 7, 3, 6)
+    message = "sequence lengths" if route == "fused-self" else "head depth"
+
+    with pytest.raises(ValueError, match=message):
+        apply(query, key, ones(value_shape))


### PR DESCRIPTION
## Summary
- add an import-light shared attention shape validator with stable ValueError diagnostics
- apply it across Torch, NNX, Linen, fused, Pallas, rotary, and linear-attention entry points
- preserve Torch rank-4 and JAX arbitrary-leading-batch contracts under eager, compiled, and python -O execution
- add table-driven coverage for 21 advanced public routes and optional-backend-safe subprocess tests

## Verification
- 85 shape-contract integration tests passed
- 64 passed / 21 expected skips in a JAX-only environment
- 285 existing attention and performer tests passed
- post-rebase Torch overlap: 131 tests passed

Fixes #145