### PR TITLE
Fix lifecycle-safe Torch and NNX kernel banks

### DIFF
--- a/src/nmn/_kernel_bank.py
+++ b/src/nmn/_kernel_bank.py
@@ -1,0 +1,74 @@
+"""Shared helpers for lifecycle-safe kernel-bank signatures."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+
+def _freeze(value: Any) -> object:
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return value
+    if isinstance(value, tuple):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, list):
+        return ("list", tuple(_freeze(item) for item in value))
+    if isinstance(value, dict):
+        return (
+            "dict",
+            tuple(sorted((str(key), _freeze(item)) for key, item in value.items())),
+        )
+    if isinstance(value, type):
+        return ("type", value.__module__, value.__qualname__)
+    if isinstance(value, functools.partial):
+        return (
+            "partial",
+            initializer_signature(value.func),
+            _freeze(value.args),
+            _freeze(value.keywords),
+        )
+    if callable(value):
+        return initializer_signature(value)
+    attributes = getattr(value, "__dict__", None)
+    if attributes:
+        return (
+            "object",
+            type(value).__module__,
+            type(value).__qualname__,
+            _freeze(attributes),
+        )
+    return ("value", type(value).__module__, type(value).__qualname__, str(value))
+
+
+def initializer_signature(initializer: Callable[..., object]) -> tuple[object, ...]:
+    """Return a pickle-stable signature for a parameter initializer."""
+    module = getattr(initializer, "__module__", type(initializer).__module__)
+    qualname = getattr(initializer, "__qualname__", type(initializer).__qualname__)
+    defaults = _freeze(getattr(initializer, "__defaults__", None))
+    keyword_defaults = _freeze(getattr(initializer, "__kwdefaults__", None))
+    closure = getattr(initializer, "__closure__", None)
+    closure_values = (
+        tuple(_freeze(cell.cell_contents) for cell in closure) if closure else ()
+    )
+    code = getattr(initializer, "__code__", None)
+    instance_state = (
+        _freeze(vars(initializer))
+        if code is None and hasattr(initializer, "__dict__")
+        else None
+    )
+    local_code = (
+        (code.co_code, _freeze(code.co_consts))
+        if code is not None and ("<locals>" in qualname or qualname == "<lambda>")
+        else None
+    )
+    return (
+        "initializer",
+        module,
+        qualname,
+        defaults,
+        keyword_defaults,
+        closure_values,
+        local_code,
+        instance_state,
+    )

--- a/src/nmn/nnx/README.md
+++ b/src/nmn/nnx/README.md
@@ -241,7 +241,7 @@ linear = YatNMN(
 Share kernel parameters across multiple layers to **reduce model size** and **encourage feature reuse**.
 
 **Key concepts:**
-- **Kernel Bank**: Shared parameter store managed at class level
+- **Kernel Bank**: Explicit model-owned shared parameter store
 - **Fixed capacity**: The first consumer fixes the bank size; set
   `kernel_bank_size` there to the largest size any consumer will need
 - **First-k slicing**: Each layer extracts the first k filters it needs
@@ -254,9 +254,10 @@ Share kernel parameters across multiple layers to **reduce model size** and **en
   fields intentionally creates a separate bank.
 
 ```python
-from nmn.nnx.layers.conv import YatConv
+from nmn.nnx import KernelBank, YatConv
 
 rngs = nnx.Rngs(0)
+conv_bank = KernelBank()
 
 # Create parallel consumers with compatible input/kernel/group signatures.
 # These are not a sequential stack: every consumer accepts 32 input channels.
@@ -267,6 +268,7 @@ layer1 = YatConv(
     tie_kernel_bank=True,
     kernel_bank_size=128,  # Fixed capacity declared before state/optimizer creation
     kernel_bank_id='resnet-conv',  # Bank namespace
+    kernel_bank=conv_bank,
     rngs=rngs
 )
 
@@ -276,6 +278,7 @@ layer2 = YatConv(
     kernel_size=(3, 3),
     tie_kernel_bank=True,
     kernel_bank_id='resnet-conv',
+    kernel_bank=conv_bank,
     rngs=rngs
 )
 
@@ -285,6 +288,7 @@ layer3 = YatConv(
     kernel_size=(3, 3),
     tie_kernel_bank=True,
     kernel_bank_id='resnet-conv',
+    kernel_bank=conv_bank,
     rngs=rngs
 )
 
@@ -293,16 +297,26 @@ layer3 = YatConv(
 assert layer1.kernel is layer2.kernel is layer3.kernel
 ```
 
+Keep the `KernelBank` on the containing model and pass it to every intended
+consumer. Separate owners isolate models even when `kernel_bank_id` strings
+match. Omitting `kernel_bank=` retains legacy ID-based sharing through a weak
+compatibility registry, which releases an entry after its last layer dies.
+Live legacy consumers with matching IDs still share; use separate explicit
+owners whenever independently loaded models must be isolated.
+
 **For YatNMN:**
 
 ```python
-from nmn.nnx import YatNMN
+from nmn.nnx import KernelBank, YatNMN
+
+head_bank = KernelBank()
 
 head1 = YatNMN(
     in_features=512,
     out_features=256,
     tie_kernel_bank=True,
     kernel_bank_id='classifier',
+    kernel_bank=head_bank,
     rngs=rngs
 )
 
@@ -311,6 +325,7 @@ head2 = YatNMN(
     out_features=128,
     tie_kernel_bank=True,
     kernel_bank_id='classifier',  # Shares with head1
+    kernel_bank=head_bank,
     rngs=rngs
 )
 

--- a/src/nmn/nnx/__init__.py
+++ b/src/nmn/nnx/__init__.py
@@ -77,6 +77,7 @@ from nmn.nnx.layers import (  # Layers; Utilities
     CONV_DEFAULT_CONSTANT_ALPHA,
     Embed,
     FrozenParam,
+    KernelBank,
     MultiHeadAttention,
     RotaryYatAttention,
     YatConv,
@@ -163,6 +164,7 @@ __all__ = [
     # -------------------------------------------------------------------------
     "YatNMN",
     "FrozenParam",
+    "KernelBank",
     "Embed",
     "YatEmbed",  # alias of Embed for cross-framework consistency
     # -------------------------------------------------------------------------

--- a/src/nmn/nnx/kernel_bank.py
+++ b/src/nmn/nnx/kernel_bank.py
@@ -1,0 +1,52 @@
+"""Lifecycle-safe ownership for tied Flax NNX YAT kernel banks."""
+
+from __future__ import annotations
+
+import threading
+
+from flax import nnx
+
+__all__ = ["KernelBank"]
+
+_KERNEL_BANK_LOCK = threading.RLock()
+
+
+class _BankParam(nnx.Param):
+    """A normal NNX parameter that can be held by a weak legacy registry."""
+
+    __slots__ = ("__weakref__",)
+
+
+class _BankEntry(nnx.Module):
+    def __init__(self, key: tuple[object, ...], parameter: nnx.Param) -> None:
+        self.key = key
+        self.parameter = parameter
+
+
+class KernelBank(nnx.Module):
+    """Own parameters shared by explicitly associated NNX YAT layers.
+
+    Pass the same instance as ``kernel_bank=`` to layers that should share a
+    tied kernel. Separate instances isolate models even when their
+    ``kernel_bank_id`` values are equal.
+    """
+
+    def __init__(self) -> None:
+        self._entries = nnx.List()
+
+    @property
+    def _lock(self):
+        return _KERNEL_BANK_LOCK
+
+    def __len__(self) -> int:
+        """Return the number of live banks owned by this context."""
+        return len(self._entries)
+
+    def _get(self, key: tuple[object, ...]) -> nnx.Param | None:
+        for entry in self._entries:
+            if entry.key == key:
+                return entry.parameter
+        return None
+
+    def _set(self, key: tuple[object, ...], parameter: nnx.Param) -> None:
+        self._entries.append(_BankEntry(key, parameter))

--- a/src/nmn/nnx/layers/__init__.py
+++ b/src/nmn/nnx/layers/__init__.py
@@ -18,6 +18,7 @@ This module contains all YAT (You Are There) layer implementations and related c
 # Rotary YAT Attention (RoPE + YAT)
 # YAT Attention Functions
 # Multi-Head Attention Module
+from nmn.nnx.kernel_bank import KernelBank
 from nmn.nnx.layers.attention import (
     DEFAULT_CONSTANT_ALPHA as ATTENTION_DEFAULT_CONSTANT_ALPHA,
 )
@@ -97,6 +98,7 @@ __all__ = [
     # Core Layers
     # -------------------------------------------------------------------------
     "YatNMN",
+    "KernelBank",
     "FrozenParam",
     "Embed",
     # -------------------------------------------------------------------------

--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import threading
 import typing as tp
+import weakref
 
 import jax
 import jax.numpy as jnp
@@ -31,6 +32,9 @@ from flax.typing import (
 )
 from jax import lax
 
+from nmn._kernel_bank import initializer_signature
+
+from ...kernel_bank import KernelBank, _BankParam
 from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 from .utils import (
     DEFAULT_CONSTANT_ALPHA,
@@ -110,11 +114,15 @@ class YatConv(Module):
             defaults to ``out_features`` for the creating instance. Bank capacity
             is immutable; declare the largest required size on the first consumer.
         kernel_bank_id: Optional bank namespace to control sharing groups.
+        kernel_bank: Optional explicit owner for shared banks. Reuse one object
+            within a model; separate objects isolate model lifecycles.
         rngs: Random number generators.
     """
 
     __data__ = ("kernel", "bias", "alpha", "epsilon_param", "mask", "dropconnect_key")
-    _KERNEL_BANKS: dict[tuple[tp.Any, ...], nnx.Param] = {}
+    _KERNEL_BANKS: weakref.WeakValueDictionary[tuple[tp.Any, ...], _BankParam] = (
+        weakref.WeakValueDictionary()
+    )
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -152,12 +160,12 @@ class YatConv(Module):
         tie_kernel_bank: bool = False,
         kernel_bank_size: tp.Optional[int] = None,
         kernel_bank_id: str = "default",
+        kernel_bank: tp.Optional[KernelBank] = None,
         rngs: rnglib.Rngs,
     ):
         if not 0.0 <= drop_rate < 1.0:
             raise ValueError(
-                "drop_rate must be in the half-open interval [0, 1), "
-                f"got {drop_rate}"
+                f"drop_rate must be in the half-open interval [0, 1), got {drop_rate}"
             )
         if feature_group_count <= 0:
             raise ValueError("feature_group_count must be positive")
@@ -192,17 +200,27 @@ class YatConv(Module):
                 bank_out_features,
             )
             bank_key = (
+                "conv",
                 kernel_bank_id,
                 kernel_size,
                 in_features // feature_group_count,
                 feature_group_count,
                 param_dtype,
-                kernel_init,
+                initializer_signature(kernel_init),
                 positive_init,
             )
 
-            with YatConv._KERNEL_BANKS_LOCK:
-                shared_kernel = YatConv._KERNEL_BANKS.get(bank_key)
+            lock = (
+                kernel_bank._lock
+                if kernel_bank is not None
+                else YatConv._KERNEL_BANKS_LOCK
+            )
+            with lock:
+                shared_kernel = (
+                    kernel_bank._get(bank_key)
+                    if kernel_bank is not None
+                    else YatConv._KERNEL_BANKS.get(bank_key)
+                )
                 if shared_kernel is None:
                     # The first consumer fixes capacity. Resizing a live Param can
                     # invalidate gradients and optimizer moments that already hold
@@ -213,8 +231,11 @@ class YatConv(Module):
                     kernel_val = kernel_init(kernel_key, bank_shape, param_dtype)
                     if positive_init:
                         kernel_val = jnp.abs(kernel_val)
-                    shared_kernel = nnx.Param(kernel_val)
-                    YatConv._KERNEL_BANKS[bank_key] = shared_kernel
+                    shared_kernel = _BankParam(kernel_val)
+                    if kernel_bank is not None:
+                        kernel_bank._set(bank_key, shared_kernel)
+                    else:
+                        YatConv._KERNEL_BANKS[bank_key] = shared_kernel
                 else:
                     existing_shape = shared_kernel[...].shape
                     existing_bank_size = existing_shape[-1]
@@ -235,6 +256,9 @@ class YatConv(Module):
             if positive_init:
                 kernel_val = jnp.abs(kernel_val)
             self.kernel = nnx.Param(kernel_val)
+        # Assign after ``kernel`` so NNX keeps the backward-compatible state path
+        # and records the bank's copy as a graph reference to the same variable.
+        self.kernel_bank = kernel_bank
 
         self.bias: nnx.Param[jax.Array] | None
         self._constant_bias_value: tp.Optional[float] = None

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -4,6 +4,7 @@ import functools
 import math
 import threading
 import typing as tp
+import weakref
 
 import jax
 import jax.numpy as jnp
@@ -20,6 +21,9 @@ from flax.typing import (
 )
 from jax import lax
 
+from nmn._kernel_bank import initializer_signature
+
+from ..kernel_bank import KernelBank, _BankParam
 from ._numerics import fp32_if_low_precision, inverse_softplus
 
 Array: tp.TypeAlias = jax.Array
@@ -125,11 +129,15 @@ class YatNMN(Module):
         ``out_features`` for the creating instance. Bank capacity is immutable;
         declare the largest required size on the first consumer.
       kernel_bank_id: optional bank namespace to control sharing groups.
+      kernel_bank: optional explicit owner for shared banks. Reuse one object
+        within a model; separate objects isolate model lifecycles.
       rngs: rng key.
     """
 
     __data__ = ("kernel", "bias", "alpha", "epsilon_param", "dropconnect_key")
-    _KERNEL_BANKS: dict[tuple[tp.Any, ...], nnx.Param] = {}
+    _KERNEL_BANKS: weakref.WeakValueDictionary[tuple[tp.Any, ...], _BankParam] = (
+        weakref.WeakValueDictionary()
+    )
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     # Default constant alpha value (sqrt(2))
@@ -167,6 +175,7 @@ class YatNMN(Module):
         tie_kernel_bank: bool = False,
         kernel_bank_size: tp.Optional[int] = None,
         kernel_bank_id: str = "default",
+        kernel_bank: tp.Optional[KernelBank] = None,
         lazy: bool = False,
         freeze_kernel: tp.Optional[bool] = None,
         rngs: rnglib.Rngs,
@@ -174,8 +183,7 @@ class YatNMN(Module):
 
         if not 0.0 <= drop_rate < 1.0:
             raise ValueError(
-                "drop_rate must be in the half-open interval [0, 1), "
-                f"got {drop_rate}"
+                f"drop_rate must be in the half-open interval [0, 1), got {drop_rate}"
             )
 
         # ── Lazy mode (issue #37): freeze ONLY the kernel ───────────────────────
@@ -211,15 +219,25 @@ class YatNMN(Module):
 
             bank_shape = (in_features, bank_out_features)
             bank_key = (
+                "dense",
                 kernel_bank_id,
                 in_features,
                 param_dtype,
-                kernel_init,
+                initializer_signature(kernel_init),
                 positive_init,
             )
 
-            with YatNMN._KERNEL_BANKS_LOCK:
-                shared_kernel = YatNMN._KERNEL_BANKS.get(bank_key)
+            lock = (
+                kernel_bank._lock
+                if kernel_bank is not None
+                else YatNMN._KERNEL_BANKS_LOCK
+            )
+            with lock:
+                shared_kernel = (
+                    kernel_bank._get(bank_key)
+                    if kernel_bank is not None
+                    else YatNMN._KERNEL_BANKS.get(bank_key)
+                )
                 if shared_kernel is None:
                     # The first consumer fixes capacity. Resizing a live Param can
                     # invalidate gradients and optimizer moments that already hold
@@ -230,8 +248,11 @@ class YatNMN(Module):
                     kernel_val = kernel_init(kernel_key, bank_shape, param_dtype)
                     if positive_init:
                         kernel_val = jnp.abs(kernel_val)
-                    shared_kernel = nnx.Param(kernel_val)
-                    YatNMN._KERNEL_BANKS[bank_key] = shared_kernel
+                    shared_kernel = _BankParam(kernel_val)
+                    if kernel_bank is not None:
+                        kernel_bank._set(bank_key, shared_kernel)
+                    else:
+                        YatNMN._KERNEL_BANKS[bank_key] = shared_kernel
                 else:
                     existing_shape = shared_kernel[...].shape
                     existing_bank_size = existing_shape[-1]
@@ -256,6 +277,9 @@ class YatNMN(Module):
             # In lazy mode the kernel is a FrozenParam (excluded from trainable state);
             # otherwise a normal trainable nnx.Param.
             self.kernel = _kernel_var(kernel_val)
+        # Assign after ``kernel`` so NNX keeps the backward-compatible state path
+        # and records the bank's copy as a graph reference to the same variable.
+        self.kernel_bank = kernel_bank
         self.bias: nnx.Param[jax.Array] | None
         self._constant_bias_value: tp.Optional[float] = None
         if constant_bias is not None and constant_bias is not False:

--- a/src/nmn/torch/README.md
+++ b/src/nmn/torch/README.md
@@ -189,14 +189,16 @@ linear = YatNMN(
 Share kernel parameters across multiple layers to **reduce model size** and **encourage feature learning**.
 
 **Key concepts:**
-- **Kernel Bank**: A shared parameter store for multiple layers
+- **Kernel Bank**: A model-owned shared parameter store for multiple layers
 - **Construction-time auto-expansion**: Grows when a larger layer is constructed,
   until the first tied consumer executes. The first forward freezes capacity so
   live gradients and optimizer state can never be invalidated.
 - **First-k slicing**: Layers extract the first k filters they need
 
 ```python
-from nmn.torch.layers import YatConv2D
+from nmn.torch import KernelBank, YatConv2D
+
+conv_bank = KernelBank()
 
 # Create multiple layers sharing same kernel bank
 layer1 = YatConv2D(
@@ -204,7 +206,8 @@ layer1 = YatConv2D(
     out_channels=32,  # Use first 32 filters from bank
     kernel_size=3,
     tie_kernel_bank=True,           # Enable weight tying
-    kernel_bank_id='resnet-conv'    # Bank namespace
+    kernel_bank_id='resnet-conv',   # Bank namespace
+    kernel_bank=conv_bank,           # Explicit model owner
 )
 
 layer2 = YatConv2D(
@@ -212,7 +215,8 @@ layer2 = YatConv2D(
     out_channels=64,  # Automatically expands bank to 64
     kernel_size=3,
     tie_kernel_bank=True,
-    kernel_bank_id='resnet-conv'
+    kernel_bank_id='resnet-conv',
+    kernel_bank=conv_bank,
 )
 
 layer3 = YatConv2D(
@@ -220,7 +224,8 @@ layer3 = YatConv2D(
     out_channels=128,  # Automatically expands bank to 128
     kernel_size=3,
     tie_kernel_bank=True,
-    kernel_bank_id='resnet-conv'
+    kernel_bank_id='resnet-conv',
+    kernel_bank=conv_bank,
 )
 
 # All three layers share kernels, bank auto-expanded: 32 -> 64 -> 128
@@ -229,6 +234,12 @@ layer3 = YatConv2D(
 Build every tied consumer before running any of them, or set
 `kernel_bank_size` on the first consumer to the maximum required capacity.
 Requesting a larger capacity after the first forward raises `ValueError`.
+Keep the `KernelBank` on the containing model and pass it to every intended
+consumer. Separate owners isolate models even when `kernel_bank_id` strings
+match. Omitting `kernel_bank=` retains legacy ID-based sharing through a weak
+compatibility registry, which releases an entry after its last layer dies.
+Live legacy consumers with matching IDs still share; use separate explicit
+owners whenever independently loaded models must be isolated.
 
 Because PyTorch applies `.to()`, `.float()`, `.double()`, and similar operations
 one module at a time, they cannot safely migrate a class-level shared bank.
@@ -246,21 +257,27 @@ Auto-expanding kernel bank 'resnet-conv': 64 -> 128 filters
 **For YatNMN:**
 
 ```python
-from nmn.torch.nmn import YatNMN
+from nmn.torch import KernelBank, YatNMN
+
+head_bank = KernelBank()
 
 head1 = YatNMN(
     in_features=512,
     out_features=256,
     tie_kernel_bank=True,
-    kernel_bank_id='classifier'
+    kernel_bank_id='classifier',
+    kernel_bank=head_bank,
 )
 
 head2 = YatNMN(
-    in_features=256,
+    in_features=512,
     out_features=128,
     tie_kernel_bank=True,
-    kernel_bank_id='classifier'
+    kernel_bank_id='classifier',
+    kernel_bank=head_bank,
 )
+
+assert head1.weight is head2.weight
 ```
 
 **Multiple independent banks:**

--- a/src/nmn/torch/__init__.py
+++ b/src/nmn/torch/__init__.py
@@ -14,6 +14,7 @@ from .attention import (
 
 # Import embedding
 from .embed import YatEmbed
+from .kernel_bank import KernelBank
 from .layers import (
     YatConv1D,
     YatConv2D,
@@ -39,6 +40,7 @@ __all__ = [
     "YatConvTranspose3D",
     # YAT NMN
     "YatNMN",
+    "KernelBank",
     # YAT Attention
     "MultiHeadYatAttention",
     # MAY / RAY linear-attention feature maps

--- a/src/nmn/torch/kernel_bank.py
+++ b/src/nmn/torch/kernel_bank.py
@@ -1,0 +1,48 @@
+"""Lifecycle-safe ownership for tied PyTorch YAT kernel banks."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, cast
+
+from torch.nn import Parameter
+
+__all__ = ["KernelBank"]
+
+
+class KernelBank:
+    """Own parameters shared by explicitly associated YAT layers.
+
+    Pass the same instance as ``kernel_bank=`` to layers that should share a
+    tied kernel. Separate instances isolate models even when their
+    ``kernel_bank_id`` values are equal.
+    """
+
+    def __init__(self) -> None:
+        self._parameters: dict[tuple[Any, ...], Parameter] = {}
+        self._used: dict[int, bool] = {}
+        self._lock = threading.RLock()
+
+    def __len__(self) -> int:
+        """Return the number of live banks owned by this context."""
+        return len(self._parameters)
+
+    def __getstate__(self) -> dict[str, object]:
+        """Serialize owned parameters without the process-local lock."""
+        return {
+            "_parameters": self._parameters,
+            "_used_keys": {
+                key: self._used.get(id(parameter), False)
+                for key, parameter in self._parameters.items()
+            },
+        }
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        """Restore owned parameters, usage state, and a process-local lock."""
+        self._parameters = cast(dict[tuple[Any, ...], Parameter], state["_parameters"])
+        used_keys = cast(dict[tuple[Any, ...], bool], state.get("_used_keys", {}))
+        self._used = {
+            id(parameter): used_keys.get(key, False)
+            for key, parameter in self._parameters.items()
+        }
+        self._lock = threading.RLock()

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import math
 import threading
+import weakref
 from typing import ClassVar, Optional, Union
 
 import torch
@@ -11,6 +12,7 @@ from torch.nn import functional as F
 from torch.nn.common_types import _size_1_t
 from torch.nn.parameter import Parameter
 
+from ..kernel_bank import KernelBank
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
     setup_yat_attrs,
@@ -39,14 +41,18 @@ class YatConv1D(Conv1d):
         kernel_bank_size: Optional explicit capacity. The bank auto-expands only
             during construction, before any tied consumer executes.
         kernel_bank_id: Namespace for shared banks (allows multiple independent banks).
+        kernel_bank: Optional explicit owner for shared banks. Reuse one object
+            within a model; separate objects isolate model lifecycles.
         param_dtype: dtype for parameter initialization (default: None, uses
             PyTorch Conv1d default). Separate from computation dtype.
     """
 
     # Class-level shared kernel banks
     weight: Parameter
-    _KERNEL_BANKS: ClassVar[dict[tuple[object, ...], Parameter]] = {}
-    _KERNEL_BANK_USED: ClassVar[dict[tuple[object, ...], bool]] = {}
+    _KERNEL_BANKS: ClassVar[
+        weakref.WeakValueDictionary[tuple[object, ...], Parameter]
+    ] = weakref.WeakValueDictionary()
+    _KERNEL_BANK_USED: ClassVar[dict[int, bool]] = {}
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -77,6 +83,7 @@ class YatConv1D(Conv1d):
         device=None,
         dtype=None,
         param_dtype=None,
+        kernel_bank: Optional[KernelBank] = None,
     ) -> None:
         # param_dtype controls parameter storage; dtype controls computation
         storage_dtype = param_dtype if param_dtype is not None else dtype
@@ -117,6 +124,7 @@ class YatConv1D(Conv1d):
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
+        self.kernel_bank = kernel_bank
         self._kernel_slice = slice(None, out_channels)
         self._actual_out_channels = out_channels
 
@@ -131,6 +139,7 @@ class YatConv1D(Conv1d):
         # Handle auto-expanding shared kernel bank
         if tie_kernel_bank:
             bank_key = (
+                "conv1d",
                 kernel_bank_id,
                 in_channels,
                 tuple(self.kernel_size),
@@ -138,11 +147,29 @@ class YatConv1D(Conv1d):
                 self.weight.dtype,
                 self.weight.device,
             )
-            with YatConv1D._KERNEL_BANKS_LOCK:
-                shared_weight = YatConv1D._KERNEL_BANKS.get(bank_key)
+            banks = (
+                kernel_bank._parameters
+                if kernel_bank is not None
+                else YatConv1D._KERNEL_BANKS
+            )
+            used = (
+                kernel_bank._used
+                if kernel_bank is not None
+                else YatConv1D._KERNEL_BANK_USED
+            )
+            lock = (
+                kernel_bank._lock
+                if kernel_bank is not None
+                else YatConv1D._KERNEL_BANKS_LOCK
+            )
+            with lock:
+                shared_weight = banks.get(bank_key)
                 if shared_weight is None:
-                    YatConv1D._KERNEL_BANKS[bank_key] = self.weight
-                    YatConv1D._KERNEL_BANK_USED[bank_key] = False
+                    banks[bank_key] = self.weight
+                    parameter_id = id(self.weight)
+                    used[parameter_id] = False
+                    if kernel_bank is None:
+                        weakref.finalize(self.weight, used.pop, parameter_id, None)
                 else:
                     if (
                         shared_weight.device != self.weight.device
@@ -153,7 +180,7 @@ class YatConv1D(Conv1d):
                         )
                     existing_channels = shared_weight.shape[0]
                     if bank_out_channels > existing_channels:
-                        if YatConv1D._KERNEL_BANK_USED.get(bank_key, False):
+                        if used.get(id(shared_weight), False):
                             raise ValueError(
                                 f"kernel bank '{kernel_bank_id}' capacity is frozen "
                                 f"at {existing_channels} after first use; requested "
@@ -202,8 +229,14 @@ class YatConv1D(Conv1d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            with YatConv1D._KERNEL_BANKS_LOCK:
-                YatConv1D._KERNEL_BANK_USED[self._kernel_bank_key] = True
+            owner = self.kernel_bank
+            lock = owner._lock if owner is not None else YatConv1D._KERNEL_BANKS_LOCK
+            used = owner._used if owner is not None else YatConv1D._KERNEL_BANK_USED
+            with lock:
+                if owner is not None or (
+                    YatConv1D._KERNEL_BANKS.get(self._kernel_bank_key) is self.weight
+                ):
+                    used[id(self.weight)] = True
             return yat_conv_forward(
                 self,
                 input,

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import math
 import threading
+import weakref
 from typing import ClassVar, Optional, Union
 
 import torch
@@ -11,6 +12,7 @@ from torch.nn import functional as F
 from torch.nn.common_types import _size_2_t
 from torch.nn.parameter import Parameter
 
+from ..kernel_bank import KernelBank
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
     setup_yat_attrs,
@@ -39,14 +41,18 @@ class YatConv2D(Conv2d):
         kernel_bank_size: Optional explicit capacity. The bank auto-expands only
             during construction, before any tied consumer executes.
         kernel_bank_id: Namespace for shared banks (allows multiple independent banks).
+        kernel_bank: Optional explicit owner for shared banks. Reuse one object
+            within a model; separate objects isolate model lifecycles.
         param_dtype: dtype for parameter initialization (default: None, uses
             PyTorch Conv2d default). Separate from computation dtype.
     """
 
     # Class-level shared kernel banks (guarded by a lock for thread safety)
     weight: Parameter
-    _KERNEL_BANKS: ClassVar[dict[tuple[object, ...], Parameter]] = {}
-    _KERNEL_BANK_USED: ClassVar[dict[tuple[object, ...], bool]] = {}
+    _KERNEL_BANKS: ClassVar[
+        weakref.WeakValueDictionary[tuple[object, ...], Parameter]
+    ] = weakref.WeakValueDictionary()
+    _KERNEL_BANK_USED: ClassVar[dict[int, bool]] = {}
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -77,6 +83,7 @@ class YatConv2D(Conv2d):
         device=None,
         dtype=None,
         param_dtype=None,
+        kernel_bank: Optional[KernelBank] = None,
     ) -> None:
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
@@ -126,6 +133,7 @@ class YatConv2D(Conv2d):
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
+        self.kernel_bank = kernel_bank
         self._kernel_slice = slice(None, out_channels)
         self._actual_out_channels = out_channels
 
@@ -140,6 +148,7 @@ class YatConv2D(Conv2d):
         # Handle auto-expanding shared kernel bank
         if tie_kernel_bank:
             bank_key = (
+                "conv2d",
                 kernel_bank_id,
                 in_channels,
                 tuple(self.kernel_size),
@@ -147,13 +156,31 @@ class YatConv2D(Conv2d):
                 self.weight.dtype,
                 self.weight.device,
             )
-            with YatConv2D._KERNEL_BANKS_LOCK:
-                shared_weight = YatConv2D._KERNEL_BANKS.get(bank_key)
+            banks = (
+                kernel_bank._parameters
+                if kernel_bank is not None
+                else YatConv2D._KERNEL_BANKS
+            )
+            used = (
+                kernel_bank._used
+                if kernel_bank is not None
+                else YatConv2D._KERNEL_BANK_USED
+            )
+            lock = (
+                kernel_bank._lock
+                if kernel_bank is not None
+                else YatConv2D._KERNEL_BANKS_LOCK
+            )
+            with lock:
+                shared_weight = banks.get(bank_key)
 
                 if shared_weight is None:
                     # First layer: register the weight as shared
-                    YatConv2D._KERNEL_BANKS[bank_key] = self.weight
-                    YatConv2D._KERNEL_BANK_USED[bank_key] = False
+                    banks[bank_key] = self.weight
+                    parameter_id = id(self.weight)
+                    used[parameter_id] = False
+                    if kernel_bank is None:
+                        weakref.finalize(self.weight, used.pop, parameter_id, None)
                 else:
                     if (
                         shared_weight.device != self.weight.device
@@ -164,7 +191,7 @@ class YatConv2D(Conv2d):
                         )
                     existing_channels = shared_weight.shape[0]
                     if bank_out_channels > existing_channels:
-                        if YatConv2D._KERNEL_BANK_USED.get(bank_key, False):
+                        if used.get(id(shared_weight), False):
                             raise ValueError(
                                 f"kernel bank '{kernel_bank_id}' capacity is frozen "
                                 f"at {existing_channels} after first use; requested "
@@ -215,8 +242,14 @@ class YatConv2D(Conv2d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            with YatConv2D._KERNEL_BANKS_LOCK:
-                YatConv2D._KERNEL_BANK_USED[self._kernel_bank_key] = True
+            owner = self.kernel_bank
+            lock = owner._lock if owner is not None else YatConv2D._KERNEL_BANKS_LOCK
+            used = owner._used if owner is not None else YatConv2D._KERNEL_BANK_USED
+            with lock:
+                if owner is not None or (
+                    YatConv2D._KERNEL_BANKS.get(self._kernel_bank_key) is self.weight
+                ):
+                    used[id(self.weight)] = True
             return yat_conv_forward(
                 self,
                 input,

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import math
 import threading
+import weakref
 from typing import ClassVar, Optional, Union
 
 import torch
@@ -11,6 +12,7 @@ from torch.nn import functional as F
 from torch.nn.common_types import _size_3_t
 from torch.nn.parameter import Parameter
 
+from ..kernel_bank import KernelBank
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
     setup_yat_attrs,
@@ -37,14 +39,18 @@ class YatConv3D(Conv3d):
         kernel_bank_size: Optional explicit capacity. The bank auto-expands only
             during construction, before any tied consumer executes.
         kernel_bank_id: Namespace for shared banks (allows multiple independent banks).
+        kernel_bank: Optional explicit owner for shared banks. Reuse one object
+            within a model; separate objects isolate model lifecycles.
         param_dtype: dtype for parameter initialization (default: None, uses
             PyTorch Conv3d default). Separate from computation dtype.
     """
 
     # Class-level shared kernel banks
     weight: Parameter
-    _KERNEL_BANKS: ClassVar[dict[tuple[object, ...], Parameter]] = {}
-    _KERNEL_BANK_USED: ClassVar[dict[tuple[object, ...], bool]] = {}
+    _KERNEL_BANKS: ClassVar[
+        weakref.WeakValueDictionary[tuple[object, ...], Parameter]
+    ] = weakref.WeakValueDictionary()
+    _KERNEL_BANK_USED: ClassVar[dict[int, bool]] = {}
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -75,6 +81,7 @@ class YatConv3D(Conv3d):
         device=None,
         dtype=None,
         param_dtype=None,
+        kernel_bank: Optional[KernelBank] = None,
     ) -> None:
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
@@ -114,6 +121,7 @@ class YatConv3D(Conv3d):
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
+        self.kernel_bank = kernel_bank
         self._kernel_slice = slice(None, out_channels)
         self._actual_out_channels = out_channels
 
@@ -128,6 +136,7 @@ class YatConv3D(Conv3d):
         # Handle auto-expanding shared kernel bank
         if tie_kernel_bank:
             bank_key = (
+                "conv3d",
                 kernel_bank_id,
                 in_channels,
                 tuple(self.kernel_size),
@@ -135,11 +144,29 @@ class YatConv3D(Conv3d):
                 self.weight.dtype,
                 self.weight.device,
             )
-            with YatConv3D._KERNEL_BANKS_LOCK:
-                shared_weight = YatConv3D._KERNEL_BANKS.get(bank_key)
+            banks = (
+                kernel_bank._parameters
+                if kernel_bank is not None
+                else YatConv3D._KERNEL_BANKS
+            )
+            used = (
+                kernel_bank._used
+                if kernel_bank is not None
+                else YatConv3D._KERNEL_BANK_USED
+            )
+            lock = (
+                kernel_bank._lock
+                if kernel_bank is not None
+                else YatConv3D._KERNEL_BANKS_LOCK
+            )
+            with lock:
+                shared_weight = banks.get(bank_key)
                 if shared_weight is None:
-                    YatConv3D._KERNEL_BANKS[bank_key] = self.weight
-                    YatConv3D._KERNEL_BANK_USED[bank_key] = False
+                    banks[bank_key] = self.weight
+                    parameter_id = id(self.weight)
+                    used[parameter_id] = False
+                    if kernel_bank is None:
+                        weakref.finalize(self.weight, used.pop, parameter_id, None)
                 else:
                     if (
                         shared_weight.device != self.weight.device
@@ -150,7 +177,7 @@ class YatConv3D(Conv3d):
                         )
                     existing_channels = shared_weight.shape[0]
                     if bank_out_channels > existing_channels:
-                        if YatConv3D._KERNEL_BANK_USED.get(bank_key, False):
+                        if used.get(id(shared_weight), False):
                             raise ValueError(
                                 f"kernel bank '{kernel_bank_id}' capacity is frozen "
                                 f"at {existing_channels} after first use; requested "
@@ -199,8 +226,14 @@ class YatConv3D(Conv3d):
     def forward(self, input: Tensor, *, deterministic: bool = False) -> Tensor:
         out_channels = self._actual_out_channels
         if self.tie_kernel_bank:
-            with YatConv3D._KERNEL_BANKS_LOCK:
-                YatConv3D._KERNEL_BANK_USED[self._kernel_bank_key] = True
+            owner = self.kernel_bank
+            lock = owner._lock if owner is not None else YatConv3D._KERNEL_BANKS_LOCK
+            used = owner._used if owner is not None else YatConv3D._KERNEL_BANK_USED
+            with lock:
+                if owner is not None or (
+                    YatConv3D._KERNEL_BANKS.get(self._kernel_bank_key) is self.weight
+                ):
+                    used[id(self.weight)] = True
             return yat_conv_forward(
                 self,
                 input,

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -3,6 +3,7 @@
 
 import math
 import threading
+import weakref
 from collections.abc import Callable
 from typing import ClassVar, Optional, Union
 
@@ -15,8 +16,10 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._kernel_bank import initializer_signature
 
 from .._precision import saturating_downcast, saturating_upcast
+from ..kernel_bank import KernelBank
 
 __all__ = ["YatNMN"]
 
@@ -69,6 +72,8 @@ class YatNMN(nn.Module):
           kernel_bank_size (int): Optional explicit size for the shared bank. Banks
               auto-expand only during construction, before any consumer executes.
           kernel_bank_id (str): Namespace for shared banks (allows multiple independent banks).
+          kernel_bank (KernelBank): Optional explicit owner for shared banks. Reuse
+              one object within a model; separate objects isolate model lifecycles.
           kernel_init (callable): Initializer for the weight matrix
           bias_init (callable): Initializer for the bias
           alpha_init (callable): Initializer for the scaling parameter (only used if constant_alpha is None)
@@ -80,8 +85,10 @@ class YatNMN(nn.Module):
     weight: nn.Parameter
     bias: Optional[nn.Parameter]
     alpha: Optional[nn.Parameter]
-    _KERNEL_BANKS: ClassVar[dict[tuple[object, ...], nn.Parameter]] = {}
-    _KERNEL_BANK_USED: ClassVar[dict[tuple[object, ...], bool]] = {}
+    _KERNEL_BANKS: ClassVar[
+        weakref.WeakValueDictionary[tuple[object, ...], nn.Parameter]
+    ] = weakref.WeakValueDictionary()
+    _KERNEL_BANK_USED: ClassVar[dict[int, bool]] = {}
     _KERNEL_BANKS_LOCK = threading.Lock()
 
     def __init__(
@@ -110,6 +117,7 @@ class YatNMN(nn.Module):
         bias_init: Optional[Callable[[torch.Tensor], object]] = None,
         alpha_init: Optional[Callable[[torch.Tensor], object]] = None,
         device=None,
+        kernel_bank: Optional[KernelBank] = None,
     ):
         super().__init__()
 
@@ -142,6 +150,7 @@ class YatNMN(nn.Module):
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
+        self.kernel_bank = kernel_bank
         self._kernel_slice = slice(None)
         initialize_kernel = True
 
@@ -160,16 +169,32 @@ class YatNMN(nn.Module):
                 )
             bank_device = torch.empty((), dtype=param_dtype, device=device).device
             bank_key = (
+                "dense",
                 kernel_bank_id,
                 in_features,
                 param_dtype,
                 bank_device,
-                id(kernel_init),
+                initializer_signature(kernel_init),
                 positive_init,
             )
 
-            with YatNMN._KERNEL_BANKS_LOCK:
-                shared_weight = YatNMN._KERNEL_BANKS.get(bank_key)
+            banks = (
+                kernel_bank._parameters
+                if kernel_bank is not None
+                else YatNMN._KERNEL_BANKS
+            )
+            used = (
+                kernel_bank._used
+                if kernel_bank is not None
+                else YatNMN._KERNEL_BANK_USED
+            )
+            lock = (
+                kernel_bank._lock
+                if kernel_bank is not None
+                else YatNMN._KERNEL_BANKS_LOCK
+            )
+            with lock:
+                shared_weight = banks.get(bank_key)
                 if shared_weight is None:
                     # First layer: create bank
                     self.weight = nn.Parameter(
@@ -179,8 +204,11 @@ class YatNMN(nn.Module):
                             device=bank_device,
                         )
                     )
-                    YatNMN._KERNEL_BANKS[bank_key] = self.weight
-                    YatNMN._KERNEL_BANK_USED[bank_key] = False
+                    banks[bank_key] = self.weight
+                    parameter_id = id(self.weight)
+                    used[parameter_id] = False
+                    if kernel_bank is None:
+                        weakref.finalize(self.weight, used.pop, parameter_id, None)
                 else:
                     if (
                         shared_weight.device != bank_device
@@ -197,7 +225,7 @@ class YatNMN(nn.Module):
                     initialize_kernel = False
                     existing_size = shared_weight.shape[0]
                     if bank_out_features > existing_size:
-                        if YatNMN._KERNEL_BANK_USED.get(bank_key, False):
+                        if used.get(id(shared_weight), False):
                             raise ValueError(
                                 f"kernel bank '{kernel_bank_id}' capacity is frozen "
                                 f"at {existing_size} after first use; requested "
@@ -375,8 +403,14 @@ class YatNMN(nn.Module):
         kernel = self.weight
         # Slice shared kernel if tying is enabled
         if self.tie_kernel_bank:
-            with YatNMN._KERNEL_BANKS_LOCK:
-                YatNMN._KERNEL_BANK_USED[self._kernel_bank_key] = True
+            owner = self.kernel_bank
+            lock = owner._lock if owner is not None else YatNMN._KERNEL_BANKS_LOCK
+            used = owner._used if owner is not None else YatNMN._KERNEL_BANK_USED
+            with lock:
+                if owner is not None or (
+                    YatNMN._KERNEL_BANKS.get(self._kernel_bank_key) is self.weight
+                ):
+                    used[id(self.weight)] = True
             kernel = kernel[self._kernel_slice]
 
         # Resolve bias (learnable or constant)

--- a/tests/test_nnx/test_kernel_bank_lifecycle.py
+++ b/tests/test_nnx/test_kernel_bank_lifecycle.py
@@ -1,0 +1,203 @@
+"""Lifecycle and model-ownership contracts for Flax NNX tied kernel banks."""
+
+from __future__ import annotations
+
+import copy
+import gc
+import weakref
+
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+from flax import nnx, serialization
+
+from nmn.nnx import KernelBank, YatConv, YatNMN
+
+
+class _TiedModel(nnx.Module):
+    def __init__(self, bank: KernelBank, *, dtype=jnp.float32) -> None:
+        common = {
+            "tie_kernel_bank": True,
+            "kernel_bank": bank,
+            "kernel_bank_id": "model-owned",
+            "use_bias": False,
+            "use_alpha": False,
+            "param_dtype": dtype,
+        }
+        self.first = YatNMN(3, 2, rngs=nnx.Rngs(0), **common)
+        self.second = YatNMN(3, 2, rngs=nnx.Rngs(1), **common)
+
+    def __call__(self, inputs):
+        return self.first(inputs) + self.second(inputs)
+
+
+@pytest.mark.parametrize(
+    ("layer_type", "factory"),
+    [
+        (
+            YatNMN,
+            lambda bank_id: YatNMN(
+                2,
+                2,
+                tie_kernel_bank=True,
+                kernel_bank_id=bank_id,
+                rngs=nnx.Rngs(0),
+            ),
+        ),
+        (
+            YatConv,
+            lambda bank_id: YatConv(
+                2,
+                2,
+                1,
+                tie_kernel_bank=True,
+                kernel_bank_id=bank_id,
+                rngs=nnx.Rngs(0),
+            ),
+        ),
+    ],
+)
+def test_legacy_bank_registry_releases_unowned_parameters(layer_type, factory):
+    layer = factory("legacy-gc")
+    parameter = weakref.ref(layer.kernel)
+
+    assert len(layer_type._KERNEL_BANKS) == 1
+    del layer
+    gc.collect()
+
+    assert parameter() is None
+    assert len(layer_type._KERNEL_BANKS) == 0
+
+
+def test_thousand_transient_models_do_not_grow_legacy_registry():
+    YatNMN._KERNEL_BANKS.clear()
+    for index in range(1_000):
+        layer = YatNMN(
+            2,
+            2,
+            tie_kernel_bank=True,
+            kernel_bank_id=f"transient-{index}",
+            rngs=nnx.Rngs(index),
+        )
+        del layer
+    gc.collect()
+
+    assert len(YatNMN._KERNEL_BANKS) == 0
+
+
+def test_live_legacy_id_sharing_remains_a_compatibility_path():
+    first = YatNMN(
+        2,
+        2,
+        tie_kernel_bank=True,
+        kernel_bank_id="legacy-sharing",
+        rngs=nnx.Rngs(0),
+    )
+    second = YatNMN(
+        2,
+        2,
+        tie_kernel_bank=True,
+        kernel_bank_id="legacy-sharing",
+        rngs=nnx.Rngs(1),
+    )
+
+    assert first.kernel is second.kernel
+    assert first.kernel_bank is second.kernel_bank is None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda bank, seed: YatNMN(
+            2,
+            2,
+            tie_kernel_bank=True,
+            kernel_bank=bank,
+            rngs=nnx.Rngs(seed),
+        ),
+        lambda bank, seed: YatConv(
+            2,
+            2,
+            1,
+            tie_kernel_bank=True,
+            kernel_bank=bank,
+            rngs=nnx.Rngs(seed),
+        ),
+    ],
+)
+def test_explicit_bank_shares_only_within_the_same_owner(factory):
+    first_bank = KernelBank()
+    second_bank = KernelBank()
+    first = factory(first_bank, 0)
+    peer = factory(first_bank, 1)
+    isolated = factory(second_bank, 2)
+
+    assert first.kernel is peer.kernel
+    assert isolated.kernel is not first.kernel
+
+
+def test_explicit_bank_owns_parameter_until_owner_is_released():
+    bank = KernelBank()
+    first = _TiedModel(bank)
+    second = _TiedModel(bank)
+    parameter = weakref.ref(first.first.kernel)
+
+    assert first.first.kernel is first.second.kernel
+    assert first.first.kernel is second.first.kernel
+    del first, second
+    gc.collect()
+    assert parameter() is not None
+
+    del bank
+    gc.collect()
+    assert parameter() is None
+
+
+def test_separate_models_restore_without_cross_mutation_and_preserve_sharing():
+    first = _TiedModel(KernelBank())
+    second = _TiedModel(KernelBank())
+    assert first.first.kernel is first.second.kernel
+    assert second.first.kernel is second.second.kernel
+    assert first.first.kernel is not second.first.kernel
+
+    first_before = np.asarray(first.first.kernel[...]).copy()
+    source = nnx.to_pure_dict(nnx.state(first, nnx.Param))
+    source["first"]["kernel"] = source["first"]["kernel"] + 1
+    encoded = serialization.to_bytes(source)
+    target = nnx.to_pure_dict(nnx.state(second, nnx.Param))
+    restored = serialization.from_bytes(target, encoded)
+    nnx.update(second, nnx.State(restored))
+
+    np.testing.assert_array_equal(np.asarray(first.first.kernel[...]), first_before)
+    assert first.first.kernel is not second.first.kernel
+    assert second.first.kernel is second.second.kernel
+    np.testing.assert_allclose(
+        np.asarray(second.first.kernel[...]), source["first"]["kernel"]
+    )
+
+    cloned = copy.deepcopy(first)
+    assert cloned.first.kernel is cloned.second.kernel
+    assert cloned.first.kernel is not first.first.kernel
+    assert cloned.first.kernel is cloned.first.kernel_bank._entries[0].parameter
+
+
+def test_optimizer_deduplicates_shared_parameter_and_jit_preserves_dtype():
+    model = _TiedModel(KernelBank(), dtype=jnp.float16)
+    state = nnx.state(model, nnx.Param)
+    assert set(state) == {"first"}
+    assert model.first.kernel is model.second.kernel
+    assert model.first.kernel[...].dtype == jnp.float16
+
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+
+    @nnx.jit
+    def step(current_model, current_optimizer, inputs):
+        _, grads = nnx.value_and_grad(lambda candidate: jnp.sum(candidate(inputs)))(
+            current_model
+        )
+        current_optimizer.update(current_model, grads)
+
+    step(model, optimizer, jnp.ones((2, 3), dtype=jnp.float16))
+    assert model.first.kernel is model.second.kernel
+    assert model.first.kernel[...].dtype == jnp.float16

--- a/tests/test_torch/test_kernel_bank_lifecycle.py
+++ b/tests/test_torch/test_kernel_bank_lifecycle.py
@@ -1,0 +1,259 @@
+"""Lifecycle and model-ownership contracts for PyTorch tied kernel banks."""
+
+from __future__ import annotations
+
+import copy
+import gc
+import io
+import os
+import subprocess
+import sys
+import weakref
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+
+from nmn.torch import KernelBank, YatConv1D, YatConv2D, YatConv3D, YatNMN
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class _TiedModel(nn.Module):
+    def __init__(self, bank: KernelBank, *, dtype=torch.float32) -> None:
+        super().__init__()
+        common = {
+            "tie_kernel_bank": True,
+            "kernel_bank": bank,
+            "kernel_bank_id": "model-owned",
+            "bias": False,
+            "alpha": False,
+            "param_dtype": dtype,
+        }
+        self.first = YatNMN(3, 2, **common)
+        self.second = YatNMN(3, 2, **common)
+
+    def forward(self, inputs):
+        return self.first(inputs) + self.second(inputs)
+
+
+class _ConstantInitializer:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __call__(self, tensor):
+        return nn.init.constant_(tensor, self.value)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda bank_id: YatNMN(2, 2, tie_kernel_bank=True, kernel_bank_id=bank_id),
+        lambda bank_id: YatConv1D(
+            2, 2, 1, tie_kernel_bank=True, kernel_bank_id=bank_id
+        ),
+        lambda bank_id: YatConv2D(
+            2, 2, 1, tie_kernel_bank=True, kernel_bank_id=bank_id
+        ),
+        lambda bank_id: YatConv3D(
+            2, 2, 1, tie_kernel_bank=True, kernel_bank_id=bank_id
+        ),
+    ],
+)
+def test_legacy_bank_registry_releases_unowned_parameters(factory):
+    layer = factory("legacy-gc")
+    registry = type(layer)._KERNEL_BANKS
+    parameter = weakref.ref(layer.weight)
+
+    assert len(registry) == 1
+    del layer
+    gc.collect()
+
+    assert parameter() is None
+    assert len(registry) == 0
+
+
+def test_thousand_transient_models_do_not_grow_legacy_registry():
+    YatNMN._KERNEL_BANKS.clear()
+    for index in range(1_000):
+        layer = YatNMN(
+            2,
+            2,
+            tie_kernel_bank=True,
+            kernel_bank_id=f"transient-{index}",
+        )
+        del layer
+    gc.collect()
+
+    assert len(YatNMN._KERNEL_BANKS) == 0
+    assert len(YatNMN._KERNEL_BANK_USED) == 0
+
+
+def test_thousand_legacy_deepcopies_do_not_grow_used_registry():
+    YatNMN._KERNEL_BANKS.clear()
+    YatNMN._KERNEL_BANK_USED.clear()
+    original = YatNMN(2, 2, tie_kernel_bank=True, kernel_bank_id="deepcopy-gc")
+    copies = [copy.deepcopy(original) for _ in range(1_000)]
+    inputs = torch.ones((1, 2))
+    for layer in copies:
+        layer(inputs)
+    del layer, copies
+    gc.collect()
+
+    assert len(YatNMN._KERNEL_BANKS) == 1
+    assert len(YatNMN._KERNEL_BANK_USED) == 1
+    del original
+    gc.collect()
+    assert len(YatNMN._KERNEL_BANKS) == 0
+    assert len(YatNMN._KERNEL_BANK_USED) == 0
+
+
+def test_live_legacy_id_sharing_remains_a_compatibility_path():
+    first = YatNMN(2, 2, tie_kernel_bank=True, kernel_bank_id="legacy-sharing")
+    second = YatNMN(2, 2, tie_kernel_bank=True, kernel_bank_id="legacy-sharing")
+
+    assert first.weight is second.weight
+    assert first.kernel_bank is second.kernel_bank is None
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda bank: YatNMN(2, 2, tie_kernel_bank=True, kernel_bank=bank),
+        lambda bank: YatConv1D(2, 2, 1, tie_kernel_bank=True, kernel_bank=bank),
+        lambda bank: YatConv2D(2, 2, 1, tie_kernel_bank=True, kernel_bank=bank),
+        lambda bank: YatConv3D(2, 2, 1, tie_kernel_bank=True, kernel_bank=bank),
+    ],
+)
+def test_explicit_bank_shares_only_within_the_same_owner(factory):
+    first_bank = KernelBank()
+    second_bank = KernelBank()
+    first = factory(first_bank)
+    peer = factory(first_bank)
+    isolated = factory(second_bank)
+
+    assert first.weight is peer.weight
+    assert isolated.weight is not first.weight
+
+
+def test_callable_initializer_instances_keep_distinct_bank_signatures():
+    bank = KernelBank()
+    first = YatNMN(
+        2,
+        2,
+        tie_kernel_bank=True,
+        kernel_bank=bank,
+        kernel_init=_ConstantInitializer(1.0),
+    )
+    second = YatNMN(
+        2,
+        2,
+        tie_kernel_bank=True,
+        kernel_bank=bank,
+        kernel_init=_ConstantInitializer(2.0),
+    )
+
+    assert first.weight is not second.weight
+    assert len(bank) == 2
+    torch.testing.assert_close(first.weight, torch.ones_like(first.weight))
+    torch.testing.assert_close(second.weight, torch.full_like(second.weight, 2.0))
+
+
+def test_explicit_bank_owns_parameter_until_owner_is_released():
+    bank = KernelBank()
+    first = _TiedModel(bank)
+    second = _TiedModel(bank)
+    parameter = weakref.ref(first.first.weight)
+
+    assert first.first.weight is first.second.weight
+    assert first.first.weight is second.first.weight
+    del first, second
+    gc.collect()
+    assert parameter() is not None
+
+    del bank
+    gc.collect()
+    assert parameter() is None
+
+
+def test_separate_models_load_without_cross_mutation_and_preserve_sharing():
+    first = _TiedModel(KernelBank())
+    second = _TiedModel(KernelBank())
+    assert first.first.weight is first.second.weight
+    assert second.first.weight is second.second.weight
+    assert first.first.weight is not second.first.weight
+
+    first_before = first.first.weight.detach().clone()
+    state = {name: value + 1 for name, value in first.state_dict().items()}
+    second.load_state_dict(state)
+
+    torch.testing.assert_close(first.first.weight, first_before)
+    assert first.first.weight is not second.first.weight
+    torch.testing.assert_close(second.first.weight, state["first.weight"])
+
+
+def test_optimizer_deduplicates_shared_parameter_and_round_trip_isolated():
+    model = _TiedModel(KernelBank(), dtype=torch.float64)
+    parameters = list(model.parameters())
+    assert parameters == [model.first.weight]
+    assert model.first.weight is model.second.weight
+    assert model.first.weight.dtype == torch.float64
+    assert model.first.weight.device.type == "cpu"
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    model(torch.ones((2, 3), dtype=torch.float64)).sum().backward()
+    optimizer.step()
+    assert list(optimizer.state) == [model.first.weight]
+
+    cloned = copy.deepcopy(model)
+    assert cloned.first.weight is cloned.second.weight
+    assert cloned.first.weight is not model.first.weight
+    assert cloned.first.weight is next(
+        iter(cloned.first.kernel_bank._parameters.values())
+    )
+
+    buffer = io.BytesIO()
+    torch.save(model.state_dict(), buffer)
+    buffer.seek(0)
+    restored = _TiedModel(KernelBank(), dtype=torch.float64)
+    restored.load_state_dict(torch.load(buffer, weights_only=True))
+
+    assert restored.first.weight is restored.second.weight
+    assert restored.first.weight is not model.first.weight
+    torch.testing.assert_close(restored.first.weight, model.first.weight)
+
+
+def test_restored_owner_accepts_compatible_consumer_in_fresh_process(tmp_path):
+    bank = KernelBank()
+    layer = YatNMN(3, 2, tie_kernel_bank=True, kernel_bank=bank)
+    copied_bank = copy.deepcopy(bank)
+    wider = YatNMN(3, 3, tie_kernel_bank=True, kernel_bank=copied_bank)
+    assert len(copied_bank) == 1
+    assert wider.weight.shape == (3, 3)
+    path = tmp_path / "kernel-bank.pt"
+    torch.save(bank, path)
+
+    program = """
+import sys
+import torch
+from nmn.torch import YatNMN
+
+bank = torch.load(sys.argv[1], weights_only=False)
+original = next(iter(bank._parameters.values()))
+layer = YatNMN(3, 3, tie_kernel_bank=True, kernel_bank=bank)
+assert len(bank) == 1
+assert layer.weight is original
+assert layer.weight.shape == (3, 3)
+"""
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(ROOT / "src")
+    subprocess.run(
+        [sys.executable, "-c", program, str(path)],
+        check=True,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+    assert len(bank) == 1
+    assert layer.weight is next(iter(bank._parameters.values()))


### PR DESCRIPTION
Closes #141.

Adds explicit model-owned KernelBank objects for Torch and NNX. Separate owners isolate independently built or loaded models; sharing one owner preserves tied parameters and optimizer deduplication. Legacy kernel_bank_id-only tying remains backward compatible through weak lifecycle-aware registries and is documented as a compatibility path.

The implementation also makes initializer identities stable across serialization, preserves Torch used-capacity state across save/load and deepcopy, and keeps NNX aliases intact through graph/state/JIT operations.

Verification:
- 853 passed, 3 skipped across full Torch and NNX suites after integration
- 87 focused lifecycle, optimizer, capacity, dtype/device, deepcopy, and serialization regressions
- exact-head independent review approved b2b61da088efea097286c7db18d07f41328b22c9
- Ruff, MyPy, conflict scan, and git diff checks clean