### PR TITLE
Stabilize MLX learnable epsilon handling

### DIFF
--- a/src/nmn/mlx/_epsilon.py
+++ b/src/nmn/mlx/_epsilon.py
@@ -1,0 +1,31 @@
+"""MLX adapters for the shared learnable-epsilon numerical contract."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import mlx.core as mx
+
+from nmn._epsilon import (
+    epsilon_parameter_dtype,
+    inverse_softplus,
+    validate_epsilon_for_dtype,
+)
+
+__all__ = ["make_epsilon_parameter"]
+
+
+def make_epsilon_parameter(
+    epsilon: float,
+    dtype: mx.Dtype,
+    shape: Sequence[int] = (1,),
+) -> mx.array:
+    """Create a stable raw-softplus epsilon parameter with safe storage.
+
+    Float16 and bfloat16 layers keep this scalar in float32, matching the
+    other backends.  That prevents valid tiny or large initial values from
+    silently becoming zero or infinity in low-precision parameter storage.
+    """
+    validate_epsilon_for_dtype(epsilon, dtype)
+    parameter_dtype = getattr(mx, epsilon_parameter_dtype(dtype))
+    return mx.full(tuple(shape), inverse_softplus(epsilon), dtype=parameter_dtype)

--- a/src/nmn/mlx/_yat_core.py
+++ b/src/nmn/mlx/_yat_core.py
@@ -15,6 +15,8 @@ from typing import cast
 import mlx.core as mx
 import mlx.nn as nn
 
+from ._precision import saturating_downcast
+
 __all__ = ["yat_score"]
 
 
@@ -53,6 +55,8 @@ def yat_score(
     # Effective epsilon (softplus-of-raw learnable, or constant).
     if layer.learnable_epsilon and getattr(layer, "epsilon_param", None) is not None:
         eps = nn.softplus(layer.epsilon_param)
+        dot_prod_map = dot_prod_map.astype(eps.dtype)
+        distance_sq_map = distance_sq_map.astype(eps.dtype)
     else:
         eps = layer.epsilon
 
@@ -65,4 +69,4 @@ def yat_score(
     elif layer.use_alpha and getattr(layer, "alpha", None) is not None:
         y = y * layer.alpha
 
-    return cast(mx.array, y)
+    return cast(mx.array, saturating_downcast(y, layer.dtype))

--- a/src/nmn/mlx/attention.py
+++ b/src/nmn/mlx/attention.py
@@ -20,6 +20,8 @@ from typing import Optional, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 
+from nmn._epsilon import validate_epsilon
+
 __all__ = [
     "normalize_qk",
     "yat_attention_weights",
@@ -202,11 +204,9 @@ class MultiHeadYatAttention(nn.Module):
         super().__init__()
         if embed_dim % num_heads != 0:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must be divisible by "
-                f"num_heads ({num_heads})."
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
             )
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
 
         self.embed_dim = embed_dim
         self.num_heads = num_heads

--- a/src/nmn/mlx/conv.py
+++ b/src/nmn/mlx/conv.py
@@ -34,6 +34,9 @@ from typing import List, Optional, Sequence, Tuple, Union
 import mlx.core as mx
 import mlx.nn as nn
 
+from nmn._epsilon import validate_epsilon
+
+from ._epsilon import make_epsilon_parameter
 from ._yat_core import yat_score
 
 # ---------------------------------------------------------------------------
@@ -235,8 +238,7 @@ class _YatConvBase(nn.Module):
         super().__init__()
         if self._ndim == 0:
             raise TypeError("_YatConvBase is not meant to be instantiated directly")
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
         if groups < 1:
             raise ValueError(f"groups must be >= 1, got {groups}")
         if not 0.0 <= drop_rate < 1.0:
@@ -293,8 +295,7 @@ class _YatConvBase(nn.Module):
             )
         if self.filters % self.groups != 0:
             raise ValueError(
-                f"filters ({self.filters}) must be divisible by groups "
-                f"({self.groups})"
+                f"filters ({self.filters}) must be divisible by groups ({self.groups})"
             )
         self.input_channels = input_channels
 
@@ -312,8 +313,7 @@ class _YatConvBase(nn.Module):
         if self.use_alpha and self._constant_alpha_value is None:
             self.alpha = mx.ones((1,), dtype=self.dtype)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
-            self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
+            self.epsilon_param = make_epsilon_parameter(self.epsilon, self.dtype)
 
         self.is_built = True
 
@@ -486,8 +486,7 @@ class _YatConvTransposeBase(nn.Module):
             raise TypeError(
                 "_YatConvTransposeBase is not meant to be instantiated directly"
             )
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
         if not 0.0 <= drop_rate < 1.0:
             raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
 
@@ -550,8 +549,7 @@ class _YatConvTransposeBase(nn.Module):
         if self.use_alpha and self._constant_alpha_value is None:
             self.alpha = mx.ones((1,), dtype=self.dtype)
         if self.learnable_epsilon:
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
-            self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
+            self.epsilon_param = make_epsilon_parameter(self.epsilon, self.dtype)
 
         self.is_built = True
 

--- a/src/nmn/mlx/embed.py
+++ b/src/nmn/mlx/embed.py
@@ -14,6 +14,8 @@ from typing import Optional, Union
 import mlx.core as mx
 import mlx.nn as nn
 
+from nmn._epsilon import validate_epsilon
+
 from ._precision import reduction_safe_upcast, saturating_downcast
 
 __all__ = ["YatEmbed"]
@@ -52,8 +54,7 @@ class YatEmbed(nn.Module):
         dtype: mx.Dtype = mx.float32,
     ) -> None:
         super().__init__()
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
 
         self.num_embeddings = num_embeddings
         self.features = features

--- a/src/nmn/mlx/goat.py
+++ b/src/nmn/mlx/goat.py
@@ -41,11 +41,14 @@ Mask convention matches the rest of ``nmn.mlx``: ``True`` = attend,
 
 from __future__ import annotations
 
-import math
 from typing import Optional
 
 import mlx.core as mx
 import mlx.nn as nn
+
+from nmn._epsilon import validate_epsilon
+
+from ._epsilon import make_epsilon_parameter
 
 __all__ = [
     "goat_yat_attention_weights",
@@ -120,6 +123,7 @@ def goat_yat_attention(
     """
     w = goat_yat_attention_weights(q, k, b, eps, mask=mask, self_mask=self_mask)
     vh = mx.transpose(v, (0, 2, 1, 3))  # (B, H, Lk, D)
+    w = w.astype(vh.dtype)
     out = w @ vh  # (B, H, Lq, D)
     return mx.transpose(out, (0, 2, 1, 3))  # (B, Lq, H, D)
 
@@ -158,8 +162,7 @@ class GoatYatAttention(nn.Module):
             )
         if variant not in ("v", "nov"):
             raise ValueError(f"variant must be 'v' or 'nov', got {variant!r}")
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
 
         self.embed_dim = embed_dim
         self.num_heads = num_heads
@@ -171,9 +174,8 @@ class GoatYatAttention(nn.Module):
 
         # Per-head learnable (b, eps), softplus-reparameterised.
         # b_raw = 0 -> softplus(0) = log 2; eps_raw chosen so softplus = epsilon.
-        raw_eps = math.log(math.exp(epsilon) - 1.0)
         self.b_raw = mx.zeros((num_heads,), dtype=dtype)
-        self.eps_raw = mx.full((num_heads,), raw_eps, dtype=dtype)
+        self.eps_raw = make_epsilon_parameter(epsilon, dtype, (num_heads,))
 
         scale = embed_dim**-0.5
         if variant == "v":

--- a/src/nmn/mlx/goat.py
+++ b/src/nmn/mlx/goat.py
@@ -97,15 +97,50 @@ def goat_yat_attention_weights(
     Returns:
         ``(B, H, Lq, Lk)`` row-stochastic weights.
     """
-    qh = mx.transpose(q, (0, 2, 1, 3))  # (B, H, Lq, D)
-    kh = mx.transpose(k, (0, 2, 1, 3))  # (B, H, Lk, D)
-    scores = _yat_scores(qh, kh, b, eps)  # (B, H, Lq, Lk) >= 0
-    if self_mask and scores.shape[-2] == scores.shape[-1]:
-        n = scores.shape[-1]
-        scores = scores * (1.0 - mx.eye(n, dtype=scores.dtype))[None, None]
+    # Normalising ``numerator / denominator`` directly is numerically unsafe
+    # for tiny learned epsilons: its backward materialises ``1 / eps**2``
+    # before the softplus chain rule can cancel the overflow.  Multiplying all
+    # scores in a row by the same positive scale is algebraically neutral.  A
+    # detached minimum denominator keeps every ratio at most one and bounds the
+    # reciprocal in the backward pass by ``1 / eps`` instead.
+    # ``mx.result_type`` is newer than NMN's minimum supported MLX.  Learned
+    # low-precision epsilon parameters are stored in float32, so this explicit
+    # promotion covers the stability path without raising the MLX floor.
+    compute_dtype = (
+        mx.float32 if mx.float32 in (q.dtype, k.dtype, b.dtype, eps.dtype) else q.dtype
+    )
+    qh = mx.transpose(q, (0, 2, 1, 3)).astype(compute_dtype)
+    kh = mx.transpose(k, (0, 2, 1, 3)).astype(compute_dtype)
+    b = b.astype(compute_dtype).reshape(1, -1, 1, 1)
+    eps = eps.reshape(1, -1, 1, 1)
+    dot = qh @ mx.swapaxes(kh, -1, -2)
+    qn = mx.sum(qh * qh, axis=-1, keepdims=True)
+    kn = mx.sum(kh * kh, axis=-1, keepdims=True)
+    dist2 = mx.maximum(qn + mx.swapaxes(kn, -1, -2) - 2.0 * dot, 0.0)
+    denominator = dist2 + eps
+    numerator = (dot + b) ** 2
+
+    eligible = None
+    if self_mask and denominator.shape[-2] == denominator.shape[-1]:
+        n = denominator.shape[-1]
+        eligible = (mx.eye(n, dtype=compute_dtype) == 0)[None, None]
     if mask is not None:
-        scores = scores * mask.astype(scores.dtype)
-    return scores / (mx.sum(scores, axis=-1, keepdims=True) + floor)
+        mask = mask.astype(mx.bool_)
+        eligible = mask if eligible is None else eligible & mask
+    if eligible is not None:
+        # Excluded entries must not traverse even a finite-but-extreme ratio:
+        # multiplying an infinite cotangent by a later zero mask is still NaN.
+        denominator = mx.where(eligible, denominator, mx.ones_like(denominator))
+        numerator = mx.where(eligible, numerator, mx.zeros_like(numerator))
+
+    row_scale = mx.stop_gradient(mx.min(denominator, axis=-1, keepdims=True))
+    scores = numerator * (row_scale / denominator)
+    row_sum = mx.sum(scores, axis=-1, keepdims=True)
+    # The additive indicator preserves the documented zero result for a fully
+    # masked row even when ``floor * row_scale`` underflows at the smallest
+    # supported fp32 epsilon.  It is zero for every nonempty row.
+    empty_row = (row_sum == 0).astype(scores.dtype)
+    return scores / (row_sum + floor * row_scale + empty_row)
 
 
 def goat_yat_attention(

--- a/src/nmn/mlx/goat.py
+++ b/src/nmn/mlx/goat.py
@@ -134,7 +134,12 @@ def goat_yat_attention_weights(
         numerator = mx.where(eligible, numerator, mx.zeros_like(numerator))
 
     row_scale = mx.stop_gradient(mx.min(denominator, axis=-1, keepdims=True))
-    scores = numerator * (row_scale / denominator)
+    # Do not spell this ratio as division.  Its quotient VJP may evaluate
+    # ``row_scale / denominator**2``; for epsilon=1e-20 the square underflows
+    # on Metal before the algebraically finite ratio can be recovered.  The
+    # log-domain identity only requires ``1 / denominator`` in its VJP.
+    denominator_ratio = mx.exp(mx.log(row_scale) - mx.log(denominator))
+    scores = numerator * denominator_ratio
     row_sum = mx.sum(scores, axis=-1, keepdims=True)
     # The additive indicator preserves the documented zero result for a fully
     # masked row even when ``floor * row_scale`` underflows at the smallest

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -20,6 +20,11 @@ from typing import List, Optional, Tuple, Union, cast
 import mlx.core as mx
 import mlx.nn as nn
 
+from nmn._epsilon import validate_epsilon
+
+from ._epsilon import make_epsilon_parameter
+from ._precision import saturating_downcast
+
 DEFAULT_CONSTANT_ALPHA = math.sqrt(2.0)
 
 
@@ -96,8 +101,7 @@ class YatNMN(nn.Module):
         freeze_kernel: Optional[bool] = None,
     ) -> None:
         super().__init__()
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
         if not 0.0 <= drop_rate < 1.0:
             raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
 
@@ -166,9 +170,7 @@ class YatNMN(nn.Module):
             self.bias = mx.zeros((self.features,), dtype=self.dtype)
 
         if self.learnable_epsilon:
-            # softplus(raw) = epsilon  ->  raw = log(exp(epsilon) - 1)
-            raw_eps = math.log(math.exp(self.epsilon) - 1.0)
-            self.epsilon_param = mx.array([raw_eps], dtype=self.dtype)
+            self.epsilon_param = make_epsilon_parameter(self.epsilon, self.dtype)
 
         self.is_built = True
 
@@ -217,6 +219,11 @@ class YatNMN(nn.Module):
             and not self.spherical
             and not self.weight_normalized
             and not self.return_weights
+            and not (
+                self.learnable_epsilon
+                and getattr(self, "epsilon_param", None) is not None
+                and self.epsilon_param.dtype != self.dtype
+            )
         ):
             from .fused import fused_yat_score
 
@@ -299,6 +306,8 @@ class YatNMN(nn.Module):
         # Effective epsilon.
         if self.learnable_epsilon and getattr(self, "epsilon_param", None) is not None:
             eps = nn.softplus(self.epsilon_param)
+            y = y.astype(eps.dtype)
+            distances = distances.astype(eps.dtype)
         else:
             eps = self.epsilon
 
@@ -309,6 +318,8 @@ class YatNMN(nn.Module):
             y = y * mx.array(self._constant_alpha_value, dtype=self.dtype)
         elif self.use_alpha and getattr(self, "alpha", None) is not None:
             y = y * self.alpha
+
+        y = saturating_downcast(y, self.dtype)
 
         if self.return_weights:
             return y, self.kernel
@@ -347,7 +358,7 @@ class YatNMN(nn.Module):
             self.alpha = weights[idx].astype(self.dtype)
             idx += 1
         if self.learnable_epsilon:
-            self.epsilon_param = weights[idx].astype(self.dtype)
+            self.epsilon_param = weights[idx].astype(self.epsilon_param.dtype)
 
 
 # Backward-compat alias used by the other backends.

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -23,6 +23,8 @@ import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
+from nmn._epsilon import validate_epsilon
+
 from .attention import yat_attention_weights
 
 __all__ = [
@@ -223,14 +225,12 @@ class RotaryYatAttention(nn.Module):
         super().__init__()
         if embed_dim % num_heads != 0:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must be divisible by "
-                f"num_heads ({num_heads})."
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
             )
         head_dim = embed_dim // num_heads
         if head_dim % 2 != 0:
             raise ValueError(f"head_dim ({head_dim}) must be even for RoPE.")
-        if epsilon <= 0:
-            raise ValueError(f"epsilon must be positive, got {epsilon}")
+        epsilon = validate_epsilon(epsilon)
 
         self.embed_dim = embed_dim
         self.num_heads = num_heads

--- a/tests/test_mlx/test_stable_learnable_epsilon.py
+++ b/tests/test_mlx/test_stable_learnable_epsilon.py
@@ -1,0 +1,276 @@
+"""Stable learnable-epsilon handling across MLX YAT layer families."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+mlx_nn = pytest.importorskip("mlx.nn")
+
+from nmn.mlx import (  # noqa: E402
+    GoatYatAttention,
+    MultiHeadYatAttention,
+    RotaryYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+    YatEmbed,
+    YatNMN,
+)
+
+EPSILONS = (1e-20, 1e-5, 1000.0)
+FAMILIES = (
+    (YatNMN, None, (1, 2)),
+    (YatConv1D, 1, (1, 1, 1)),
+    (YatConv2D, (1, 1), (1, 1, 1, 1)),
+    (YatConv3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+    (YatConvTranspose1D, 1, (1, 1, 1)),
+    (YatConvTranspose2D, (1, 1), (1, 1, 1, 1)),
+    (YatConvTranspose3D, (1, 1, 1), (1, 1, 1, 1, 1)),
+)
+
+
+def _make(layer_cls, kernel_size, epsilon, dtype=mx.float32):
+    kwargs = dict(
+        epsilon=epsilon,
+        learnable_epsilon=True,
+        use_bias=False,
+        use_alpha=False,
+        dtype=dtype,
+    )
+    if kernel_size is None:
+        return layer_cls(features=1, **kwargs)
+    return layer_cls(filters=1, kernel_size=kernel_size, **kwargs)
+
+
+def _evaluate(layer, inputs, compiled):
+    layer(inputs)
+    layer.kernel = mx.full(layer.kernel.shape, 0.3, dtype=layer.dtype)
+
+    def loss(model, values):
+        output = model(values)
+        return mx.sum(output.astype(mx.float32)), output
+
+    grad_fn = mlx_nn.value_and_grad(layer, loss)
+    input_grad_fn = mx.grad(lambda values: loss(layer, values)[0])
+    if compiled:
+
+        def evaluate(values):
+            value, parameter_gradients = grad_fn(layer, values)
+            return value, parameter_gradients, input_grad_fn(values)
+
+        (_, output), gradients, input_gradient = mx.compile(
+            evaluate, inputs=layer.state
+        )(inputs)
+    else:
+        (_, output), gradients = grad_fn(layer, inputs)
+        input_gradient = input_grad_fn(inputs)
+    mx.eval(output, gradients, input_gradient)
+    return output, gradients, input_gradient
+
+
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+@pytest.mark.parametrize("epsilon", EPSILONS)
+@pytest.mark.parametrize("compiled", [False, True])
+def test_learnable_epsilon_eager_compile_and_gradients(
+    layer_cls, kernel_size, input_shape, epsilon, compiled
+):
+    layer = _make(layer_cls, kernel_size, epsilon)
+    output, gradients, input_gradient = _evaluate(
+        layer, mx.full(input_shape, 0.2, dtype=mx.float32), compiled
+    )
+
+    effective = mlx_nn.softplus(layer.epsilon_param)
+    mx.eval(effective)
+    np.testing.assert_allclose(np.array(effective), epsilon, rtol=2e-6, atol=0.0)
+    assert np.isfinite(np.array(output)).all()
+    assert np.isfinite(np.array(input_gradient)).all()
+    assert np.isfinite(np.array(gradients["kernel"])).all()
+    epsilon_gradient = np.array(gradients["epsilon_param"])
+    assert np.isfinite(epsilon_gradient).all()
+    assert np.abs(epsilon_gradient).max() > 0.0
+
+
+def _validation_factories(epsilon):
+    return (
+        lambda: YatNMN(features=1, epsilon=epsilon),
+        lambda: YatConv1D(filters=1, kernel_size=1, epsilon=epsilon),
+        lambda: YatConv2D(filters=1, kernel_size=1, epsilon=epsilon),
+        lambda: YatConv3D(filters=1, kernel_size=1, epsilon=epsilon),
+        lambda: YatConvTranspose1D(filters=1, kernel_size=1, epsilon=epsilon),
+        lambda: YatConvTranspose2D(filters=1, kernel_size=1, epsilon=epsilon),
+        lambda: YatConvTranspose3D(filters=1, kernel_size=1, epsilon=epsilon),
+        lambda: YatEmbed(num_embeddings=2, features=2, epsilon=epsilon),
+        lambda: MultiHeadYatAttention(embed_dim=4, num_heads=2, epsilon=epsilon),
+        lambda: RotaryYatAttention(embed_dim=4, num_heads=2, epsilon=epsilon),
+        lambda: GoatYatAttention(embed_dim=4, num_heads=2, epsilon=epsilon),
+    )
+
+
+@pytest.mark.parametrize(
+    "epsilon", [0.0, -1.0, float("nan"), float("inf"), float("-inf")]
+)
+def test_every_mlx_layer_rejects_non_finite_or_non_positive_epsilon(epsilon):
+    for factory in _validation_factories(epsilon):
+        with pytest.raises(ValueError, match="positive and finite"):
+            factory()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+@pytest.mark.parametrize("epsilon", EPSILONS)
+@pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
+def test_epsilon_parameter_storage_dtype_and_representability(
+    layer_cls, kernel_size, input_shape, dtype, epsilon
+):
+    layer = _make(layer_cls, kernel_size, epsilon, dtype)
+    inputs = mx.full(input_shape, 0.2, dtype=dtype)
+    layer(inputs)
+    expected_dtype = mx.float32 if dtype in (mx.float16, mx.bfloat16) else dtype
+    assert layer.epsilon_param.dtype == expected_dtype
+    effective = mlx_nn.softplus(layer.epsilon_param)
+    mx.eval(effective)
+    np.testing.assert_allclose(np.array(effective), epsilon, rtol=2e-6, atol=0.0)
+    if dtype in (mx.float16, mx.bfloat16):
+        output, gradients, input_gradient = _evaluate(layer, inputs, False)
+        assert output.dtype == dtype
+        assert np.isfinite(np.array(output.astype(mx.float32))).all()
+        assert np.isfinite(np.array(input_gradient.astype(mx.float32))).all()
+        epsilon_gradient = np.array(gradients["epsilon_param"].astype(mx.float32))
+        assert np.isfinite(epsilon_gradient).all()
+        assert np.abs(epsilon_gradient).max() > 0.0
+
+
+@pytest.mark.parametrize("epsilon", [5e-324, 1e-46, 1e39])
+def test_float32_rejects_unrepresentable_epsilon(epsilon):
+    layer = _make(YatNMN, None, epsilon, mx.float32)
+    with pytest.raises(ValueError, match="not representable"):
+        layer(mx.ones((1, 2), dtype=mx.float32))
+
+
+@pytest.mark.parametrize("epsilon", EPSILONS)
+def test_dense_weight_serialization_roundtrip(tmp_path, epsilon):
+    layer = _make(YatNMN, None, epsilon, mx.float16)
+    inputs = mx.ones((1, 2), dtype=mx.float16)
+    layer(inputs)
+    layer.epsilon_param = layer.epsilon_param + mx.array([0.5], dtype=mx.float32)
+    mx.eval(layer.epsilon_param)
+    path = tmp_path / "epsilon.npz"
+    layer.save_weights(str(path))
+
+    restored = _make(YatNMN, None, epsilon, mx.float16)
+    restored(inputs)
+    mx.eval(restored.epsilon_param)
+    assert not np.array_equal(
+        np.array(restored.epsilon_param), np.array(layer.epsilon_param)
+    )
+    restored.load_weights(str(path))
+    source_effective = mlx_nn.softplus(layer.epsilon_param)
+    restored_effective = mlx_nn.softplus(restored.epsilon_param)
+    mx.eval(restored.parameters(), source_effective, restored_effective)
+    assert restored.epsilon_param.dtype == mx.float32
+    np.testing.assert_array_equal(
+        np.array(restored.epsilon_param), np.array(layer.epsilon_param)
+    )
+    np.testing.assert_array_equal(
+        np.array(restored_effective), np.array(source_effective)
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+@pytest.mark.parametrize("epsilon", [1e-20, 1e5])
+def test_dtype_extremes_eager_compile_and_metal(dtype, epsilon, mlx_gpu):
+    del mlx_gpu
+    layer = _make(YatNMN, None, epsilon, dtype)
+    inputs = mx.full((1, 2), 0.2, dtype=dtype)
+    eager_output, eager_gradients, eager_input_gradient = _evaluate(
+        layer, inputs, False
+    )
+    compiled_output, compiled_gradients, compiled_input_gradient = _evaluate(
+        layer, inputs, True
+    )
+
+    assert eager_output.dtype == compiled_output.dtype == dtype
+    for value in (
+        eager_output,
+        compiled_output,
+        eager_input_gradient,
+        compiled_input_gradient,
+        eager_gradients["epsilon_param"],
+        compiled_gradients["epsilon_param"],
+    ):
+        assert np.isfinite(np.array(value.astype(mx.float32))).all()
+    np.testing.assert_allclose(
+        np.array(compiled_output.astype(mx.float32)),
+        np.array(eager_output.astype(mx.float32)),
+        rtol=2e-2,
+        atol=2e-3,
+    )
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
+@pytest.mark.parametrize("epsilon", EPSILONS)
+@pytest.mark.parametrize("compiled", [False, True])
+def test_goat_uses_stable_epsilon_parameter(dtype, epsilon, compiled):
+    layer = GoatYatAttention(
+        embed_dim=4,
+        num_heads=2,
+        epsilon=epsilon,
+        dtype=dtype,
+    )
+    expected_dtype = mx.float32 if dtype in (mx.float16, mx.bfloat16) else dtype
+    assert layer.eps_raw.dtype == expected_dtype
+    effective = mlx_nn.softplus(layer.eps_raw)
+    inputs = mx.array(
+        [[[0.1, 0.2, -0.3, 0.4], [0.5, -0.2, 0.1, 0.3], [-0.4, 0.2, 0.6, 0.1]]],
+        dtype=dtype,
+    )
+
+    def loss(model, values):
+        output = model(values, self_mask=False)
+        return mx.sum(output.astype(mx.float32)), output
+
+    grad_fn = mlx_nn.value_and_grad(layer, loss)
+    if compiled:
+        (_, output), gradients = mx.compile(
+            lambda values: grad_fn(layer, values), inputs=layer.state
+        )(inputs)
+    else:
+        (_, output), gradients = grad_fn(layer, inputs)
+    mx.eval(effective, output, gradients)
+    np.testing.assert_allclose(np.array(effective), epsilon, rtol=2e-6, atol=0.0)
+    assert output.dtype == dtype
+    assert np.isfinite(np.array(output.astype(mx.float32))).all()
+    epsilon_gradient = np.array(gradients["eps_raw"].astype(mx.float32))
+    assert np.isfinite(epsilon_gradient).all()
+    if epsilon == 1e-5:
+        assert np.abs(epsilon_gradient).max() > 0.0
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("epsilon", [1e-20, 1e5])
+def test_goat_low_precision_compile_and_gradient_on_metal(dtype, epsilon, mlx_gpu):
+    del mlx_gpu
+    layer = GoatYatAttention(
+        embed_dim=4,
+        num_heads=2,
+        epsilon=epsilon,
+        dtype=dtype,
+    )
+    inputs = mx.array(
+        [[[0.1, 0.2, -0.3, 0.4], [0.5, -0.2, 0.1, 0.3], [-0.4, 0.2, 0.6, 0.1]]],
+        dtype=dtype,
+    )
+    grad_fn = mlx_nn.value_and_grad(
+        layer,
+        lambda model, values: mx.sum(model(values, self_mask=False).astype(mx.float32)),
+    )
+    _, gradients = mx.compile(
+        lambda values: grad_fn(layer, values), inputs=layer.state
+    )(inputs)
+    mx.eval(gradients)
+    assert layer.eps_raw.dtype == mx.float32
+    assert np.isfinite(np.array(gradients["eps_raw"])).all()

--- a/tests/test_mlx/test_stable_learnable_epsilon.py
+++ b/tests/test_mlx/test_stable_learnable_epsilon.py
@@ -312,6 +312,38 @@ def test_goat_fully_masked_rows_have_zero_finite_vjp():
         np.testing.assert_array_equal(np.array(gradient), np.zeros(gradient.shape))
 
 
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_goat_raw_softplus_compiled_low_precision_vjp_on_metal(dtype, mlx_gpu):
+    del mlx_gpu
+    values = mx.array([[[[0.1, 0.2]], [[0.5, -0.2]], [[-0.4, 0.2]]]], dtype=dtype)
+    b = mlx_nn.softplus(mx.zeros((1,), dtype=dtype))
+    epsilon_raw = mx.array([-46.0517], dtype=mx.float32)
+    cotangent = mx.array([[[[0.2, -0.4, 0.7]]]], dtype=dtype)
+
+    def loss(raw):
+        weights = goat_yat_attention_weights(
+            values,
+            values,
+            b,
+            mlx_nn.softplus(raw),
+            self_mask=False,
+        )
+        return mx.sum((weights.astype(dtype) * cotangent).astype(mx.float32))
+
+    eager_gradient = mx.grad(loss)(epsilon_raw)
+    compiled_gradient = mx.compile(mx.grad(loss))(epsilon_raw)
+    mx.eval(eager_gradient, compiled_gradient)
+    for gradient in (eager_gradient, compiled_gradient):
+        assert np.isfinite(np.array(gradient)).all()
+        assert np.abs(np.array(gradient)).max() > 0.0
+    np.testing.assert_allclose(
+        np.array(compiled_gradient),
+        np.array(eager_gradient),
+        rtol=2e-2,
+        atol=2e-6,
+    )
+
+
 @pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
 @pytest.mark.parametrize("epsilon", EPSILONS)
 @pytest.mark.parametrize("compiled", [False, True])

--- a/tests/test_mlx/test_stable_learnable_epsilon.py
+++ b/tests/test_mlx/test_stable_learnable_epsilon.py
@@ -20,6 +20,7 @@ from nmn.mlx import (  # noqa: E402
     YatConvTranspose3D,
     YatEmbed,
     YatNMN,
+    goat_yat_attention_weights,
 )
 
 EPSILONS = (1e-20, 1e-5, 1000.0)
@@ -61,16 +62,23 @@ def _evaluate(layer, inputs, compiled):
 
         def evaluate(values):
             value, parameter_gradients = grad_fn(layer, values)
-            return value, parameter_gradients, input_grad_fn(values)
+            effective_epsilon = mlx_nn.softplus(layer.epsilon_param)
+            return (
+                value,
+                parameter_gradients,
+                input_grad_fn(values),
+                effective_epsilon,
+            )
 
-        (_, output), gradients, input_gradient = mx.compile(
+        (_, output), gradients, input_gradient, effective_epsilon = mx.compile(
             evaluate, inputs=layer.state
         )(inputs)
     else:
         (_, output), gradients = grad_fn(layer, inputs)
         input_gradient = input_grad_fn(inputs)
-    mx.eval(output, gradients, input_gradient)
-    return output, gradients, input_gradient
+        effective_epsilon = mlx_nn.softplus(layer.epsilon_param)
+    mx.eval(output, gradients, input_gradient, effective_epsilon)
+    return output, gradients, input_gradient, effective_epsilon
 
 
 @pytest.mark.parametrize("layer_cls,kernel_size,input_shape", FAMILIES)
@@ -80,12 +88,10 @@ def test_learnable_epsilon_eager_compile_and_gradients(
     layer_cls, kernel_size, input_shape, epsilon, compiled
 ):
     layer = _make(layer_cls, kernel_size, epsilon)
-    output, gradients, input_gradient = _evaluate(
+    output, gradients, input_gradient, effective = _evaluate(
         layer, mx.full(input_shape, 0.2, dtype=mx.float32), compiled
     )
 
-    effective = mlx_nn.softplus(layer.epsilon_param)
-    mx.eval(effective)
     np.testing.assert_allclose(np.array(effective), epsilon, rtol=2e-6, atol=0.0)
     assert np.isfinite(np.array(output)).all()
     assert np.isfinite(np.array(input_gradient)).all()
@@ -135,7 +141,7 @@ def test_epsilon_parameter_storage_dtype_and_representability(
     mx.eval(effective)
     np.testing.assert_allclose(np.array(effective), epsilon, rtol=2e-6, atol=0.0)
     if dtype in (mx.float16, mx.bfloat16):
-        output, gradients, input_gradient = _evaluate(layer, inputs, False)
+        output, gradients, input_gradient, _ = _evaluate(layer, inputs, False)
         assert output.dtype == dtype
         assert np.isfinite(np.array(output.astype(mx.float32))).all()
         assert np.isfinite(np.array(input_gradient.astype(mx.float32))).all()
@@ -186,10 +192,10 @@ def test_dtype_extremes_eager_compile_and_metal(dtype, epsilon, mlx_gpu):
     del mlx_gpu
     layer = _make(YatNMN, None, epsilon, dtype)
     inputs = mx.full((1, 2), 0.2, dtype=dtype)
-    eager_output, eager_gradients, eager_input_gradient = _evaluate(
+    eager_output, eager_gradients, eager_input_gradient, _ = _evaluate(
         layer, inputs, False
     )
-    compiled_output, compiled_gradients, compiled_input_gradient = _evaluate(
+    compiled_output, compiled_gradients, compiled_input_gradient, _ = _evaluate(
         layer, inputs, True
     )
 
@@ -211,6 +217,101 @@ def test_dtype_extremes_eager_compile_and_metal(dtype, epsilon, mlx_gpu):
     )
 
 
+def _direct_goat_weights(q, k, b, epsilon, mask, floor):
+    qh = mx.transpose(q, (0, 2, 1, 3))
+    kh = mx.transpose(k, (0, 2, 1, 3))
+    dot = qh @ mx.swapaxes(kh, -1, -2)
+    q_norm = mx.sum(qh * qh, axis=-1, keepdims=True)
+    k_norm = mx.sum(kh * kh, axis=-1, keepdims=True)
+    distance = mx.maximum(q_norm + mx.swapaxes(k_norm, -1, -2) - 2.0 * dot, 0.0)
+    scores = (dot + b.reshape(1, -1, 1, 1)) ** 2 / (
+        distance + epsilon.reshape(1, -1, 1, 1)
+    )
+    if mask is not None:
+        scores = scores * mask.astype(scores.dtype)
+    return scores / (mx.sum(scores, axis=-1, keepdims=True) + floor)
+
+
+@pytest.mark.parametrize("mask_kind", ["unmasked", "partial"])
+def test_goat_stable_normalization_matches_direct_forward_and_vjp(mask_kind):
+    q = mx.array([[[[0.1, 0.2]], [[0.5, -0.2]]]], dtype=mx.float32)
+    k = mx.array([[[[0.2, -0.1]], [[-0.4, 0.2]], [[0.3, 0.6]]]], dtype=mx.float32)
+    b = mx.array([0.7], dtype=mx.float32)
+    epsilon = mx.array([0.3], dtype=mx.float32)
+    mask = None
+    if mask_kind == "partial":
+        mask = mx.array([[[[True, False, True], [False, True, True]]]])
+    floor = 3e-3
+    cotangent = mx.array([[[[0.2, -0.4, 0.7], [-0.3, 0.5, 0.1]]]])
+
+    def actual_loss(q, k, b, epsilon):
+        weights = goat_yat_attention_weights(
+            q, k, b, epsilon, mask=mask, self_mask=False, floor=floor
+        )
+        return mx.sum(weights * cotangent)
+
+    def reference_loss(q, k, b, epsilon):
+        weights = _direct_goat_weights(q, k, b, epsilon, mask, floor)
+        return mx.sum(weights * cotangent)
+
+    actual = goat_yat_attention_weights(
+        q, k, b, epsilon, mask=mask, self_mask=False, floor=floor
+    )
+    expected = _direct_goat_weights(q, k, b, epsilon, mask, floor)
+    actual_value, actual_gradients = mx.value_and_grad(
+        actual_loss, argnums=(0, 1, 2, 3)
+    )(q, k, b, epsilon)
+    expected_value, expected_gradients = mx.value_and_grad(
+        reference_loss, argnums=(0, 1, 2, 3)
+    )(q, k, b, epsilon)
+    mx.eval(
+        actual,
+        expected,
+        actual_value,
+        expected_value,
+        actual_gradients,
+        expected_gradients,
+    )
+
+    np.testing.assert_allclose(
+        np.array(actual), np.array(expected), rtol=2e-6, atol=1e-7
+    )
+    np.testing.assert_allclose(
+        np.array(actual_value), np.array(expected_value), rtol=2e-6, atol=1e-7
+    )
+    for actual_gradient, expected_gradient in zip(
+        actual_gradients, expected_gradients, strict=True
+    ):
+        np.testing.assert_allclose(
+            np.array(actual_gradient),
+            np.array(expected_gradient),
+            rtol=2e-5,
+            atol=2e-6,
+        )
+
+
+def test_goat_fully_masked_rows_have_zero_finite_vjp():
+    q = mx.array([[[[0.1, 0.2]], [[0.5, -0.2]]]], dtype=mx.float32)
+    k = mx.array([[[[0.2, -0.1]], [[-0.4, 0.2]], [[0.3, 0.6]]]], dtype=mx.float32)
+    b = mx.array([0.7], dtype=mx.float32)
+    epsilon = mx.array([1e-20], dtype=mx.float32)
+    mask = mx.zeros((1, 1, 2, 3), dtype=mx.bool_)
+
+    def loss(q, k, b, epsilon):
+        weights = goat_yat_attention_weights(
+            q, k, b, epsilon, mask=mask, self_mask=False
+        )
+        return mx.sum(weights)
+
+    weights = goat_yat_attention_weights(q, k, b, epsilon, mask=mask, self_mask=False)
+    _, gradients = mx.value_and_grad(loss, argnums=(0, 1, 2, 3))(q, k, b, epsilon)
+    mx.eval(weights, gradients)
+    np.testing.assert_array_equal(np.array(weights), np.zeros((1, 1, 2, 3)))
+    for gradient in gradients:
+        assert np.isfinite(np.array(gradient)).all()
+        np.testing.assert_array_equal(np.array(gradient), np.zeros(gradient.shape))
+
+
 @pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16, mx.float32])
 @pytest.mark.parametrize("epsilon", EPSILONS)
 @pytest.mark.parametrize("compiled", [False, True])
@@ -223,7 +324,6 @@ def test_goat_uses_stable_epsilon_parameter(dtype, epsilon, compiled):
     )
     expected_dtype = mx.float32 if dtype in (mx.float16, mx.bfloat16) else dtype
     assert layer.eps_raw.dtype == expected_dtype
-    effective = mlx_nn.softplus(layer.eps_raw)
     inputs = mx.array(
         [[[0.1, 0.2, -0.3, 0.4], [0.5, -0.2, 0.1, 0.3], [-0.4, 0.2, 0.6, 0.1]]],
         dtype=dtype,
@@ -235,11 +335,17 @@ def test_goat_uses_stable_epsilon_parameter(dtype, epsilon, compiled):
 
     grad_fn = mlx_nn.value_and_grad(layer, loss)
     if compiled:
-        (_, output), gradients = mx.compile(
-            lambda values: grad_fn(layer, values), inputs=layer.state
-        )(inputs)
+
+        def evaluate(values):
+            value, gradients = grad_fn(layer, values)
+            return value, gradients, mlx_nn.softplus(layer.eps_raw)
+
+        (_, output), gradients, effective = mx.compile(evaluate, inputs=layer.state)(
+            inputs
+        )
     else:
         (_, output), gradients = grad_fn(layer, inputs)
+        effective = mlx_nn.softplus(layer.eps_raw)
     mx.eval(effective, output, gradients)
     np.testing.assert_allclose(np.array(effective), epsilon, rtol=2e-6, atol=0.0)
     assert output.dtype == dtype

--- a/tests/test_mlx_goat_source.py
+++ b/tests/test_mlx_goat_source.py
@@ -1,0 +1,24 @@
+"""Dependency-light source checks for MLX GOAT compatibility."""
+
+import ast
+from pathlib import Path
+
+GOAT_SOURCE = Path(__file__).parents[1] / "src" / "nmn" / "mlx" / "goat.py"
+
+
+def test_goat_source_compiles_without_importing_mlx():
+    source = GOAT_SOURCE.read_text(encoding="utf-8")
+    compile(source, str(GOAT_SOURCE), "exec")
+
+
+def test_goat_precision_path_avoids_newer_result_type_api():
+    source = GOAT_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(GOAT_SOURCE))
+    mlx_attributes = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "mx"
+    }
+    assert "result_type" not in mlx_attributes


### PR DESCRIPTION
Closes #149.

Aligns MLX epsilon-bearing layers with the finite-positive cross-backend contract. The patch centralizes validation, uses stable inverse-softplus, keeps low-precision learned epsilon in fp32, validates representability, preserves configured output dtypes, and avoids narrowing epsilon in fused and GOAT paths.

Coverage spans all seven dense/conv/transpose families plus GOAT and constant-epsilon layers: invalid/tiny/large values, fp16/bfloat16/fp32, input/kernel/epsilon gradients, explicit-state mx.compile, NPZ round trips, and dedicated Metal execution.

Verification:
- 144 parameterized MLX regression cases prepared for Apple CI
- 86 dependency-light policy tests passed after final rebase
- compileall, Ruff, formatting, diff, and conflict checks clean
- exact-head independent review approved 3b14e6f778a206af7da77256d4cf475236673c22

Native MLX execution is intentionally gated on the repository's macos-15 Apple Silicon Metal job.