### PR TITLE
Define nonnegative L1 attention semantics for signed bias

### DIFF
--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -18,6 +18,9 @@ from flax.linen.module import Module, compact
 from jax import Array
 
 # Re-export attention functions from NNX (same JAX backend)
+from nmn.nnx.layers.attention._attention_core import (
+    validate_attention_normalization,
+)
 from nmn.nnx.layers.attention.yat_attention import (
     normalize_qk,
 )
@@ -46,6 +49,8 @@ def yat_attention_weights(
     epsilon: float = 1e-5,
     alpha: Optional[Array] = None,
     spherical: bool = False,
+    bias: Optional[Array] = None,
+    normalization: str = "softmax",
 ) -> Array:
     """Computes YAT attention weights.
 
@@ -61,6 +66,8 @@ def yat_attention_weights(
         epsilon: Numerical stability constant.
         alpha: Optional alpha scaling parameter.
         spherical: If True, normalize Q/K first.
+        bias: Optional signed additive attention bias.
+        normalization: ``"softmax"``, ``"l1"``, or ``"softermax"``.
 
     Returns:
         Attention weights (..., num_heads, q_len, kv_len).
@@ -76,6 +83,8 @@ def yat_attention_weights(
         deterministic=deterministic,
         epsilon=epsilon,
         alpha=alpha,
+        bias=bias,
+        normalization=normalization,
     )
 
 
@@ -89,8 +98,10 @@ def yat_attention(
     epsilon: float = 1e-5,
     alpha: Optional[Array] = None,
     spherical: bool = False,
+    bias: Optional[Array] = None,
+    normalization: str = "softmax",
 ) -> Array:
-    """Computes YAT attention: softmax((Q.K)^2 / (||Q-K||^2 + eps)) . V
+    """Computes normalized YAT attention over values.
 
     Args:
         query: (..., q_len, num_heads, head_dim)
@@ -102,6 +113,8 @@ def yat_attention(
         epsilon: Numerical stability constant.
         alpha: Optional alpha scaling.
         spherical: If True, normalize Q/K first.
+        bias: Optional signed additive attention bias.
+        normalization: ``"softmax"``, ``"l1"``, or ``"softermax"``.
 
     Returns:
         Output (..., q_len, num_heads, v_dim).
@@ -118,6 +131,8 @@ def yat_attention(
         deterministic=deterministic,
         epsilon=epsilon,
         alpha=alpha,
+        bias=bias,
+        normalization=normalization,
     )
 
 
@@ -130,6 +145,8 @@ def yat_attention_normalized(
     deterministic: bool = True,
     epsilon: float = 1e-5,
     alpha: Optional[Array] = None,
+    bias: Optional[Array] = None,
+    normalization: str = "softmax",
 ) -> Array:
     """YAT attention with normalized Q/K (optimized)."""
     return yat_attention(
@@ -142,6 +159,8 @@ def yat_attention_normalized(
         epsilon=epsilon,
         alpha=alpha,
         spherical=True,
+        bias=bias,
+        normalization=normalization,
     )
 
 
@@ -163,9 +182,9 @@ class MultiHeadAttention(Module):
         constant_alpha: If True, use sqrt(2). If float, use that value.
         normalize_qk: Whether to L2-normalize Q and K (default: False).
         spherical: If True, use spherical YAT formula (default: False).
-        normalization: Score normalization, either ``"softmax"`` (default) or
-            ``"l1"``. Constant and learnable alpha both scale scores before
-            this normalization.
+        normalization: Score normalization: ``"softmax"`` (default), ``"l1"``,
+            or ``"softermax"``. Constant and learnable alpha both scale scores
+            before this normalization.
         epsilon: Numerical stability constant (default: 1e-5).
         dtype: Computation dtype.
         param_dtype: Parameter dtype (default: float32).
@@ -213,11 +232,7 @@ class MultiHeadAttention(Module):
         Returns:
             Output (batch, q_len, out_features).
         """
-        if self.normalization not in ("softmax", "l1"):
-            raise ValueError(
-                "normalization must be either 'softmax' or 'l1', got "
-                f"{self.normalization!r}"
-            )
+        validate_attention_normalization(self.normalization)
         if inputs_k is None:
             inputs_k = inputs_q
         if inputs_v is None:

--- a/src/nmn/nnx/layers/attention/_attention_core.py
+++ b/src/nmn/nnx/layers/attention/_attention_core.py
@@ -19,12 +19,10 @@ yat_attention_weights runs the score math in float32 and casts bias to
 float32 before the helper call).
 
 ``normalization`` is one of ``"softmax"`` / ``"l1"`` / ``"softermax"``.
-``"l1"`` uses the YAT-friendly "scores are already non-negative" path:
-masked positions are zeroed (not set to -inf) and the final divide is
-``score / (sum + epsilon)``. Only ``yat_attention_weights`` exposes this
-normalization mode today; the other two callers always pass
-``"softmax"`` (and the ``use_softermax`` shortcut for backward
-compatibility).
+``"l1"`` uses the YAT-friendly non-negative path: after additive bias,
+negative scores are clipped to zero, masked positions are zeroed, and each
+nonzero row is divided by its sum.  This keeps the attention measure
+non-negative even when callers supply signed relative-position biases.
 
 Boolean masks and negative-infinity additive-bias entries follow one policy:
 masked weights are exact zero, and a query row with no eligible keys has zero
@@ -43,7 +41,22 @@ from jax import Array, random
 
 from nmn.nnx.layers.squashers import softermax
 
-__all__ = ["finalize_attention_weights"]
+SUPPORTED_ATTENTION_NORMALIZATIONS = ("softmax", "l1", "softermax")
+
+__all__ = [
+    "SUPPORTED_ATTENTION_NORMALIZATIONS",
+    "finalize_attention_weights",
+    "validate_attention_normalization",
+]
+
+
+def validate_attention_normalization(normalization: str) -> None:
+    """Validate the shared public attention normalization enum."""
+    if normalization not in SUPPORTED_ATTENTION_NORMALIZATIONS:
+        choices = ", ".join(repr(name) for name in SUPPORTED_ATTENTION_NORMALIZATIONS)
+        raise ValueError(
+            f"normalization must be one of {choices}; got {normalization!r}"
+        )
 
 
 def finalize_attention_weights(
@@ -78,7 +91,8 @@ def finalize_attention_weights(
         normalization: ``"softmax"`` (default), ``"l1"``, or ``"softermax"``.
         use_softermax: Legacy alias — if True forces softermax.
         power: ``softermax`` power parameter (used iff softermax is selected).
-        epsilon: L1 denominator epsilon (used iff ``normalization="l1"``).
+        epsilon: Retained for API compatibility with callers that also use it
+            in YAT score construction.
         broadcast_dropout / dropout_rng / dropout_rate / deterministic:
             Standard dropout knobs. Dropout is broadcast across batch dims
             when ``broadcast_dropout=True``.
@@ -88,6 +102,8 @@ def finalize_attention_weights(
     Returns:
         Normalized attention weights of the same shape, cast to ``dtype``.
     """
+    validate_attention_normalization(normalization)
+
     if alpha is not None:
         attn_weights = attn_weights * alpha
 
@@ -122,8 +138,34 @@ def finalize_attention_weights(
             attn_weights = jnp.where(row_has_key, attn_weights, 0.0)
 
     if normalization == "l1":
-        attn_sum = jnp.sum(attn_weights, axis=-1, keepdims=True)
-        attn_weights = (attn_weights / (attn_sum + epsilon)).astype(dtype)
+        # Additive attention biases are conventionally signed.  Clipping here
+        # defines L1 attention as a non-negative measure instead of allowing a
+        # negative bias to create negative "weights".  Scale by the row maximum
+        # before summing to avoid overflow for large but finite scores.
+        attn_weights = jnp.maximum(attn_weights, 0.0)
+        row_max = jnp.max(attn_weights, axis=-1, keepdims=True)
+        safe_max = jnp.where(row_max > 0.0, row_max, 1.0)
+        scaled_weights = attn_weights / safe_max
+        attn_sum = jnp.sum(scaled_weights, axis=-1, keepdims=True)
+        safe_sum = jnp.where(attn_sum > 0.0, attn_sum, 1.0)
+        normalized_weights = scaled_weights / safe_sum
+
+        # ReLU can erase an entire otherwise-valid row when every signed
+        # biased score is non-positive.  L1 normalization is undefined there,
+        # so use the unique uninformative probability measure: uniform over
+        # eligible keys.  A truly all-masked row has no eligible keys and stays
+        # exact zero, preserving the public masking policy.
+        eligible = (
+            jnp.ones_like(attn_weights, dtype=jnp.bool_)
+            if effective_mask is None
+            else effective_mask
+        )
+        eligible_count = jnp.sum(eligible, axis=-1, keepdims=True)
+        safe_count = jnp.where(eligible_count > 0, eligible_count, 1)
+        uniform_weights = eligible.astype(attn_weights.dtype) / safe_count
+        attn_weights = jnp.where(
+            attn_sum > 0.0, normalized_weights, uniform_weights
+        ).astype(dtype)
     elif use_softermax or normalization == "softermax":
         attn_weights = softermax(attn_weights, n=power).astype(dtype)
     else:

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -50,6 +50,7 @@ from nmn._attention_shape import validate_attention_inputs
 from nmn.nnx.layers.squashers import softermax
 
 from .._numerics import fp32_if_low_precision, inverse_softplus
+from ._attention_core import validate_attention_normalization
 from .maclaurin_yat import (
     _validate_linear_attention_mask,
     create_maclaurin_projection,
@@ -508,6 +509,8 @@ class RotaryYatAttention(Module):
                 use_alpha=True.
             rngs: Random number generators.
         """
+        validate_attention_normalization(normalization)
+
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.head_dim = embed_dim // num_heads

--- a/src/nmn/nnx/layers/attention/yat_attention.py
+++ b/src/nmn/nnx/layers/attention/yat_attention.py
@@ -95,9 +95,9 @@ def yat_attention_weights(
             or a float value (constant). If None, no alpha scaling is applied.
         normalization: Normalization method for attention weights. One of:
             - ``"softmax"`` (default): standard softmax normalization.
-            - ``"l1"``: L1 normalization (score / sum(scores)). More natural
-              for YAT since scores are already non-negative — no exp() overflow.
-            - ``"softermax"``: softermax normalization (requires use_softermax=True).
+            - ``"l1"``: clip signed biased scores to non-negative values, then
+              divide by their row sum (with a uniform eligible-row fallback).
+            - ``"softermax"``: softermax normalization.
 
     Returns:
         Attention weights of shape [..., num_heads, q_length, kv_length]

--- a/tests/test_nnx/test_l1_signed_bias_semantics.py
+++ b/tests/test_nnx/test_l1_signed_bias_semantics.py
@@ -1,0 +1,113 @@
+"""Regression tests for signed additive bias in JAX YAT L1 attention."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from nmn.linen.attention import yat_attention as linen_yat_attention
+from nmn.linen.attention import yat_attention_weights as linen_yat_attention_weights
+from nmn.nnx.layers.attention.yat_attention import yat_attention as nnx_yat_attention
+from nmn.nnx.layers.attention.yat_attention import (
+    yat_attention_weights as nnx_yat_attention_weights,
+)
+
+
+@pytest.mark.parametrize(
+    "attention_weights",
+    [nnx_yat_attention_weights, linen_yat_attention_weights],
+    ids=["nnx", "linen"],
+)
+def test_l1_signed_bias_defines_nonnegative_probability_rows(attention_weights):
+    query = jnp.zeros((1, 3, 1, 2), dtype=jnp.float32)
+    key = jnp.zeros((1, 3, 1, 2), dtype=jnp.float32)
+    bias = jnp.array(
+        [[[[1.0e30, -0.5, -jnp.inf], [-3.0, -2.0, -1.0], [2.0, 1.0, 0.5]]]]
+    )
+    mask = jnp.array(
+        [[[[True, True, True], [True, True, True], [False, False, False]]]]
+    )
+
+    weights = attention_weights(
+        query,
+        key,
+        bias=bias,
+        mask=mask,
+        normalization="l1",
+        deterministic=True,
+    )
+
+    assert np.all(np.isfinite(np.asarray(weights)))
+    assert np.all(np.asarray(weights) >= 0.0)
+    np.testing.assert_array_equal(np.asarray(weights[0, 0, 0]), [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(np.asarray(weights[0, 0, 1]), 1.0 / 3.0)
+    np.testing.assert_array_equal(np.asarray(weights[0, 0, 2]), 0.0)
+    np.testing.assert_allclose(np.asarray(weights.sum(axis=-1)), [[[1.0, 1.0, 0.0]]])
+
+
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "jit"])
+def test_nnx_linen_l1_forward_and_all_operand_gradients_match(compiled):
+    query = jax.random.normal(jax.random.key(1), (2, 3, 2, 4)) * 0.2
+    key = jax.random.normal(jax.random.key(2), (2, 4, 2, 4)) * 0.2
+    value = jax.random.normal(jax.random.key(3), (2, 4, 2, 5))
+    bias = jnp.linspace(-0.3, 0.2, 2 * 2 * 3 * 4).reshape((2, 2, 3, 4))
+    mask = jnp.ones((2, 2, 3, 4), dtype=jnp.bool_)
+    mask = mask.at[0, :, 0, :].set(False)
+    mask = mask.at[1, :, 1, 2:].set(False)
+    alpha = jnp.array(0.8, dtype=jnp.float32)
+    epsilon = jnp.array(2.0e-3, dtype=jnp.float32)
+    cotangent = jax.random.normal(jax.random.key(4), (2, 3, 2, 5))
+
+    def evaluate(attention_fn):
+        def loss(q, k, v, b, a, e):
+            output = attention_fn(
+                q,
+                k,
+                v,
+                mask=mask,
+                bias=b,
+                alpha=a,
+                epsilon=e,
+                normalization="l1",
+                deterministic=True,
+            )
+            return jnp.vdot(output, cotangent), output
+
+        value_and_grad = jax.value_and_grad(
+            loss, argnums=(0, 1, 2, 3, 4, 5), has_aux=True
+        )
+        if compiled:
+            value_and_grad = jax.jit(value_and_grad)
+        (_, output), gradients = value_and_grad(query, key, value, bias, alpha, epsilon)
+        return output, gradients
+
+    nnx_output, nnx_gradients = evaluate(nnx_yat_attention)
+    linen_output, linen_gradients = evaluate(linen_yat_attention)
+
+    np.testing.assert_allclose(linen_output, nnx_output, rtol=2e-6, atol=2e-6)
+    for linen_gradient, nnx_gradient in zip(linen_gradients, nnx_gradients):
+        assert np.all(np.isfinite(np.asarray(linen_gradient)))
+        np.testing.assert_allclose(linen_gradient, nnx_gradient, rtol=2e-6, atol=2e-6)
+
+
+@pytest.mark.parametrize(
+    "attention_weights",
+    [nnx_yat_attention_weights, linen_yat_attention_weights],
+    ids=["nnx", "linen"],
+)
+@pytest.mark.parametrize("compiled", [False, True], ids=["eager", "jit"])
+def test_unknown_normalization_is_rejected_centrally(attention_weights, compiled):
+    query = jnp.ones((1, 1, 1, 2), dtype=jnp.float32)
+    function = lambda q: attention_weights(  # noqa: E731
+        q, q, normalization="signed-l1", deterministic=True
+    )
+    if compiled:
+        function = jax.jit(function)
+
+    with pytest.raises(
+        ValueError,
+        match="normalization must be one of 'softmax', 'l1', 'softermax'",
+    ):
+        function(query)


### PR DESCRIPTION
Closes #147.

Defines one validated normalization enum and makes L1 attention a true nonnegative simplex even with signed additive bias. Negative biased scores are clipped, finite scores are max-scaled before normalization, all-nonpositive valid rows fall back uniformly over eligible keys, and fully masked rows remain exactly zero.

NNX and Linen now share the same functional semantics; Linen's new bias and normalization arguments are appended to preserve positional compatibility. Rotary construction also validates the normalization policy.

Verification:
- full NNX + Linen: 708 passed, 1 skipped
- final focused signed-bias + centralized shape suite: 117 passed
- independent adversarial review: huge finite biases remain finite/nonnegative, row sums within 1.2e-7, gradients finite for the supported finite/-inf contract
- exact-head independent approval de3d91e165d102b8a681412de999c618de29d90b
- pinned Black/isort, compile, and diff checks pass