### PR TITLE
build: define example dependencies and clean-install smokes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,12 +133,14 @@ Each of the six framework backends — `nmn.torch`, `nmn.nnx`, `nmn.linen`, `nmn
 
 | Extra | Installs | Backend(s) it enables |
 | --- | --- | --- |
-| `nmn[torch]` | torch, torchvision | `nmn.torch` |
+| `nmn[torch]` | torch | `nmn.torch` |
 | `nmn[nnx]` | jax, jaxlib, flax | `nmn.nnx` |
 | `nmn[linen]` | jax, jaxlib, flax | `nmn.linen` |
 | `nmn[keras]` | keras | `nmn.keras` (select a Keras backend separately) |
 | `nmn[tf]` | tensorflow | `nmn.tf` |
 | `nmn[mlx]` | mlx (Apple Silicon) | `nmn.mlx` |
+| `nmn[data]` | torchvision, tensorflow-datasets, datasets | Example data loaders |
+| `nmn[examples]` | data loaders and training/evaluation tools | Runnable examples |
 
 Practical consequences for contributors:
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -774,6 +774,12 @@ src/nmn/
 
 ### Running Examples
 
+Install the backend together with the example dependencies before running a
+training script. Exact installs are `pip install "nmn[torch,examples]"`,
+`pip install "nmn[nnx,examples]"`, `pip install "nmn[linen,examples]"`, and
+`pip install "nmn[mlx,examples]"`. Importing and instantiating the model classes
+requires only the backend extra and never downloads a dataset.
+
 ```bash
 # PyTorch / Flax NNX / Flax Linen (all runnable on CPU in seconds)
 PYTHONPATH=src python -m nmn.torch.examples.vision.mnist --report .context/torch_mnist.json
@@ -896,7 +902,6 @@ from nmn.mlx import softermax, softer_sigmoid, soft_tanh
 <p align="center">
   <sub>Built with ❤️ by <a href="https://azetta.ai">Azetta.ai</a></sub>
 </p>
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,14 @@ pip install "nmn[keras]"          # + Keras 3 (choose JAX, TF, or Torch separate
 pip install "nmn[tf]"             # + TensorFlow
 pip install "nmn[mlx]"            # + MLX (Apple Silicon only)
 pip install "nmn[all]"            # everything except MLX (Linux/Windows safe)
+pip install "nmn[data]"           # dataset loaders used by runnable examples
+pip install "nmn[nnx,examples]"   # NNX + all training/example dependencies
 ```
+
+Backend extras contain only what the library itself imports. Runnable training
+scripts need both their backend and the `examples` extra—for example,
+`nmn[torch,examples]`, `nmn[linen,examples]`, or `nmn[mlx,examples]`. The
+lighter `data` extra installs only the supported dataset loaders.
 
 **Requirements:** Python ≥ 3.10 (≥ 3.11 if you want JAX/Flax).
 

--- a/docs/guides/flax-linen.md
+++ b/docs/guides/flax-linen.md
@@ -57,6 +57,9 @@ No `nn.relu`. The Yat layer is non-linear by itself.
 
 ## 3. MNIST end-to-end
 
+For the runnable script, install `pip install "nmn[linen,examples]"`. Importing
+its `YatMLP` model still requires only `nmn[linen]` and does not load data.
+
 ```python
 import jax, jax.numpy as jnp
 import flax.linen as nn

--- a/docs/guides/flax-nnx.md
+++ b/docs/guides/flax-nnx.md
@@ -58,6 +58,9 @@ No `nnx.relu` needed.
 
 ## 3. MNIST end-to-end
 
+For the runnable script, install `pip install "nmn[nnx,examples]"`. Importing
+its `YatMLP` model still requires only `nmn[nnx]` and does not load data.
+
 ```python
 import jax, jax.numpy as jnp
 import optax

--- a/docs/guides/mlx.md
+++ b/docs/guides/mlx.md
@@ -63,6 +63,9 @@ No activation function — the non-linearity is baked into the layer.
 
 ## 3. MNIST end-to-end
 
+For the runnable script, install `pip install "nmn[mlx,examples]"`. Importing
+its `YatMLP` model still requires only `nmn[mlx]` and does not load data.
+
 ```python
 import mlx.core as mx
 import mlx.nn as nn

--- a/docs/guides/pytorch.md
+++ b/docs/guides/pytorch.md
@@ -54,6 +54,9 @@ The non-linearity is baked into the layer. No `ReLU` needed.
 
 ## 3. MNIST end-to-end
 
+For the runnable script, install `pip install "nmn[torch,examples]"`. Importing
+its `YatMLP` model still requires only `nmn[torch]` and does not load data.
+
 A minimal trainable model. Drop into a Python file and run.
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,34 @@ dev = [
     "tomli>=1.1.0; python_version < '3.11'",
 ]
 nnx = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
-torch = ["torch>=1.11.0", "torchvision>=0.12.0"]
+torch = ["torch>=1.11.0"]
 keras = ["keras>=3.0.0"]
 tf = ["tensorflow>=2.10.0"]
 linen = ["jax>=0.9.1", "jaxlib>=0.9.1", "flax>=0.12.5"]
 mlx = ["mlx>=0.18.1"]
 all = ["nmn[nnx,torch,keras,tf,linen]"]
+data = [
+    "torchvision>=0.12.0",
+    "tensorflow-datasets>=4.8.0",
+    "datasets>=2.0.0",
+]
+examples = [
+    "nmn[data]",
+    "optax>=0.1.4",
+    "orbax-checkpoint>=0.4.0",
+    "wandb>=0.15.0",
+    "tokenizers>=0.13.0",
+    "mteb>=1.0.0",
+    "matplotlib>=3.5.0",
+    "seaborn>=0.11.0",
+    "scikit-learn>=1.1.0",
+    "pillow>=9.0.0",
+    "tqdm>=4.0.0",
+    "grain>=0.2.0",
+]
 test = [
     "nmn[dev,all]",
+    "torchvision>=0.12.0",
     "tensorflow-datasets>=4.8.0",
     "optax>=0.1.4",
     "matplotlib>=3.5.0",

--- a/src/nmn/_example_dependencies.py
+++ b/src/nmn/_example_dependencies.py
@@ -1,0 +1,39 @@
+"""Lazy, actionable imports for optional runnable-example dependencies."""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Any
+
+
+class LazyExampleDependency:
+    """Resolve an example-only module on first use, never on model import."""
+
+    def __init__(self, module: str, install: str, purpose: str) -> None:
+        self._module_name = module
+        self._install = install
+        self._purpose = purpose
+        self._module: ModuleType | None = None
+
+    def _load(self) -> ModuleType:
+        if self._module is None:
+            try:
+                self._module = importlib.import_module(self._module_name)
+            except ModuleNotFoundError as error:
+                raise ModuleNotFoundError(
+                    f"{self._purpose} requires the optional dependency "
+                    f"{self._module_name!r}. Install it with "
+                    f'`pip install "{self._install}"`.'
+                ) from error
+        return self._module
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
+
+
+def lazy_example_dependency(
+    module: str, *, install: str, purpose: str
+) -> LazyExampleDependency:
+    """Create a module proxy with an exact installation remedy."""
+    return LazyExampleDependency(module, install, purpose)

--- a/src/nmn/cli.py
+++ b/src/nmn/cli.py
@@ -406,6 +406,10 @@ Runnable examples live alongside each backend in the source tree:
 A curated walkthrough is in EXAMPLES.md:
   {ONLINE_EXAMPLES}
 
+Install a backend together with its runnable-example dependencies:
+  pip install "nmn[nnx,examples]"    # use linen, torch, or mlx as needed
+Dataset loaders alone are available through the smaller ``nmn[data]`` extra.
+
 Quickstart for the most popular backend (Flax NNX):
 
     import jax.numpy as jnp

--- a/src/nmn/linen/examples/mnist.py
+++ b/src/nmn/linen/examples/mnist.py
@@ -6,6 +6,8 @@ or:
     python src/nmn/linen/examples/mnist.py
 
 Uses torchvision to fetch MNIST so no tensorflow-datasets dependency is required.
+
+Install the runnable example with ``pip install "nmn[linen,examples]"``.
 """
 
 from __future__ import annotations
@@ -19,11 +21,25 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
 from flax.training import train_state
-from torchvision import datasets, transforms
 
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.linen import YatNMN
+
+_INSTALL = "nmn[linen,examples]"
+optax = lazy_example_dependency(
+    "optax", install=_INSTALL, purpose="The Flax Linen MNIST training example"
+)
+datasets = lazy_example_dependency(
+    "torchvision.datasets",
+    install=_INSTALL,
+    purpose="The Flax Linen MNIST data loader",
+)
+transforms = lazy_example_dependency(
+    "torchvision.transforms",
+    install=_INSTALL,
+    purpose="The Flax Linen MNIST data loader",
+)
 
 
 class YatMLP(nn.Module):

--- a/src/nmn/mlx/examples/mnist.py
+++ b/src/nmn/mlx/examples/mnist.py
@@ -8,6 +8,8 @@ or:
 Trains a 2-layer YatNMN MLP for 3 epochs on Apple Silicon (Metal GPU by
 default). Uses ``torchvision`` to fetch MNIST so no tensorflow-datasets
 dependency is required.
+
+Install the runnable example with ``pip install "nmn[mlx,examples]"``.
 """
 
 from __future__ import annotations
@@ -22,9 +24,17 @@ import mlx.core as mx
 import mlx.nn as nn
 import mlx.optimizers as optim
 import numpy as np
-from torchvision import datasets, transforms
 
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.mlx import YatNMN
+
+_INSTALL = "nmn[mlx,examples]"
+datasets = lazy_example_dependency(
+    "torchvision.datasets", install=_INSTALL, purpose="The MLX MNIST data loader"
+)
+transforms = lazy_example_dependency(
+    "torchvision.transforms", install=_INSTALL, purpose="The MLX MNIST data loader"
+)
 
 
 class YatMLP(nn.Module):

--- a/src/nmn/nnx/examples/language/m3za.py
+++ b/src/nmn/nnx/examples/language/m3za.py
@@ -82,7 +82,7 @@ class ModernTransformerBlock(nnx.Module):
     ):
         if mesh is not None:
             kernel_init = nnx.with_partitioning(
-                nnx.initializers.xavier_uniform(), NamedSharding(mesh, P(None, "model"))
+                nnx.initializers.xavier_uniform(), P(None, "model"), mesh=mesh
             )
         else:
             kernel_init = nnx.initializers.xavier_uniform()

--- a/src/nmn/nnx/examples/language/m3za.py
+++ b/src/nmn/nnx/examples/language/m3za.py
@@ -1,3 +1,11 @@
+"""M3ZA language-model example.
+
+Install training and dataset dependencies with ``pip install "nmn[nnx,examples]"``.
+The model definitions themselves require only ``nmn[nnx]``.
+"""
+
+from __future__ import annotations
+
 import json
 import os
 import time
@@ -8,18 +16,33 @@ import flax.nnx as nnx
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
-import orbax.checkpoint as orbax
-import wandb
-from datasets import load_dataset
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
-from mteb import MTEB, get_tasks
-from tokenizers import Tokenizer
 
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.nnx.layers import YatNMN
 from nmn.nnx.layers.attention import RotaryYatAttention
+
+_INSTALL = "nmn[nnx,examples]"
+optax = lazy_example_dependency(
+    "optax", install=_INSTALL, purpose="The M3ZA training example"
+)
+orbax = lazy_example_dependency(
+    "orbax.checkpoint", install=_INSTALL, purpose="The M3ZA checkpoint example"
+)
+wandb = lazy_example_dependency(
+    "wandb", install=_INSTALL, purpose="The M3ZA experiment logger"
+)
+datasets = lazy_example_dependency(
+    "datasets", install=_INSTALL, purpose="The M3ZA data loader"
+)
+mteb = lazy_example_dependency(
+    "mteb", install=_INSTALL, purpose="The M3ZA evaluation example"
+)
+tokenizers = lazy_example_dependency(
+    "tokenizers", install=_INSTALL, purpose="The M3ZA tokenizer"
+)
 
 # --- JAX Device and Mesh Setup ---
 if jax.default_backend() == "tpu":
@@ -492,11 +515,13 @@ def main_pretrain():
 
     # 1. Load Data Stream
     print("\n=== Data Loading ===")
-    full_dataset = load_dataset("HuggingFaceFW/fineweb", split="train", streaming=True)
+    full_dataset = datasets.load_dataset(
+        "HuggingFaceFW/fineweb", split="train", streaming=True
+    )
 
     # 2. Load Pretrained Tokenizer (RoBERTa)
     print("Loading pretrained 'roberta-base' tokenizer...")
-    tokenizer = Tokenizer.from_pretrained("roberta-base")
+    tokenizer = tokenizers.Tokenizer.from_pretrained("roberta-base")
     tokenizer.enable_truncation(max_length=config["maxlen"])
 
     config["vocab_size"] = tokenizer.get_vocab_size()
@@ -579,7 +604,7 @@ def main_contrastive_tuning(mlm_checkpoint_path, config):
     model = create_model(rngs, config)
 
     # Reload Tokenizer
-    tokenizer = Tokenizer.from_pretrained("roberta-base")
+    tokenizer = tokenizers.Tokenizer.from_pretrained("roberta-base")
     tokenizer.enable_truncation(max_length=config["maxlen"])
 
     print(f"Loading weights from {mlm_checkpoint_path}...")
@@ -594,7 +619,7 @@ def main_contrastive_tuning(mlm_checkpoint_path, config):
 
     print("Loading SNLI dataset for pairs...")
     # FIX: Added streaming=True to return an IterableDataset compatible with shuffle(buffer_size) and .iter()
-    snli_dataset = load_dataset("snli", split="train", streaming=True)
+    snli_dataset = datasets.load_dataset("snli", split="train", streaming=True)
     contrastive_dataset = process_dataset_for_contrastive(
         snli_dataset, tokenizer, config["maxlen"]
     )
@@ -642,7 +667,7 @@ def main_eval(checkpoint_path, config):
     model = create_model(rngs, config)
 
     # Reload Tokenizer
-    tokenizer = Tokenizer.from_pretrained("roberta-base")
+    tokenizer = tokenizers.Tokenizer.from_pretrained("roberta-base")
     tokenizer.enable_truncation(max_length=config["maxlen"])
 
     checkpointer = orbax.PyTreeCheckpointer()
@@ -657,13 +682,13 @@ def main_eval(checkpoint_path, config):
 
     # FIX: Use get_tasks to convert string names to Task objects
     try:
-        tasks = get_tasks(tasks=tasks)
+        tasks = mteb.get_tasks(tasks=tasks)
     except Exception as e:
         print(f"Warning: Could not load specific tasks {tasks}: {e}")
         # Fallback to STS12 if specific tasks fail
-        tasks = get_tasks(tasks=["STS12"])
+        tasks = mteb.get_tasks(tasks=["STS12"])
 
-    evaluation = MTEB(tasks=tasks)
+    evaluation = mteb.MTEB(tasks=tasks)
     results = evaluation.run(
         mteb_model, output_folder="mteb_results", eval_splits=["test"]
     )

--- a/src/nmn/nnx/examples/language/m3za_perf.py
+++ b/src/nmn/nnx/examples/language/m3za_perf.py
@@ -90,7 +90,7 @@ class ModernTransformerBlock(nnx.Module):
     ):
         if mesh is not None:
             kernel_init = nnx.with_partitioning(
-                nnx.initializers.xavier_uniform(), NamedSharding(mesh, P(None, "model"))
+                nnx.initializers.xavier_uniform(), P(None, "model"), mesh=mesh
             )
         else:
             kernel_init = nnx.initializers.xavier_uniform()

--- a/src/nmn/nnx/examples/language/m3za_perf.py
+++ b/src/nmn/nnx/examples/language/m3za_perf.py
@@ -1,3 +1,11 @@
+"""Performance-oriented M3ZA language-model example.
+
+Install training and dataset dependencies with ``pip install "nmn[nnx,examples]"``.
+The model definitions themselves require only ``nmn[nnx]``.
+"""
+
+from __future__ import annotations
+
 import json
 import os
 import time
@@ -8,18 +16,35 @@ import flax.nnx as nnx
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
-import orbax.checkpoint as orbax
-import wandb
-from datasets import load_dataset
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
-from mteb import MTEB, get_tasks
-from tokenizers import Tokenizer
 
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.nnx.layers import YatNMN
 from nmn.nnx.layers.attention import RotaryYatAttention
+
+_INSTALL = "nmn[nnx,examples]"
+optax = lazy_example_dependency(
+    "optax", install=_INSTALL, purpose="The M3ZA performance example"
+)
+orbax = lazy_example_dependency(
+    "orbax.checkpoint",
+    install=_INSTALL,
+    purpose="The M3ZA performance checkpoint example",
+)
+wandb = lazy_example_dependency(
+    "wandb", install=_INSTALL, purpose="The M3ZA performance experiment logger"
+)
+datasets = lazy_example_dependency(
+    "datasets", install=_INSTALL, purpose="The M3ZA performance data loader"
+)
+mteb = lazy_example_dependency(
+    "mteb", install=_INSTALL, purpose="The M3ZA performance evaluation"
+)
+tokenizers = lazy_example_dependency(
+    "tokenizers", install=_INSTALL, purpose="The M3ZA performance tokenizer"
+)
 
 # --- JAX Device and Mesh Setup ---
 if jax.default_backend() == "tpu":
@@ -506,11 +531,13 @@ def main_pretrain():
 
     # 1. Load Data Stream
     print("\n=== Data Loading ===")
-    full_dataset = load_dataset("HuggingFaceFW/fineweb", split="train", streaming=True)
+    full_dataset = datasets.load_dataset(
+        "HuggingFaceFW/fineweb", split="train", streaming=True
+    )
 
     # 2. Load Pretrained Tokenizer (RoBERTa)
     print("Loading pretrained 'roberta-base' tokenizer...")
-    tokenizer = Tokenizer.from_pretrained("roberta-base")
+    tokenizer = tokenizers.Tokenizer.from_pretrained("roberta-base")
     tokenizer.enable_truncation(max_length=config["maxlen"])
 
     config["vocab_size"] = tokenizer.get_vocab_size()
@@ -593,7 +620,7 @@ def main_contrastive_tuning(mlm_checkpoint_path, config):
     model = create_model(rngs, config)
 
     # Reload Tokenizer
-    tokenizer = Tokenizer.from_pretrained("roberta-base")
+    tokenizer = tokenizers.Tokenizer.from_pretrained("roberta-base")
     tokenizer.enable_truncation(max_length=config["maxlen"])
 
     print(f"Loading weights from {mlm_checkpoint_path}...")
@@ -608,7 +635,7 @@ def main_contrastive_tuning(mlm_checkpoint_path, config):
 
     print("Loading SNLI dataset for pairs...")
     # FIX: Added streaming=True to return an IterableDataset compatible with shuffle(buffer_size) and .iter()
-    snli_dataset = load_dataset("snli", split="train", streaming=True)
+    snli_dataset = datasets.load_dataset("snli", split="train", streaming=True)
     contrastive_dataset = process_dataset_for_contrastive(
         snli_dataset, tokenizer, config["maxlen"]
     )
@@ -656,7 +683,7 @@ def main_eval(checkpoint_path, config):
     model = create_model(rngs, config)
 
     # Reload Tokenizer
-    tokenizer = Tokenizer.from_pretrained("roberta-base")
+    tokenizer = tokenizers.Tokenizer.from_pretrained("roberta-base")
     tokenizer.enable_truncation(max_length=config["maxlen"])
 
     checkpointer = orbax.PyTreeCheckpointer()
@@ -671,13 +698,13 @@ def main_eval(checkpoint_path, config):
 
     # FIX: Use get_tasks to convert string names to Task objects
     try:
-        tasks = get_tasks(tasks=tasks)
+        tasks = mteb.get_tasks(tasks=tasks)
     except Exception as e:
         print(f"Warning: Could not load specific tasks {tasks}: {e}")
         # Fallback to STS12 if specific tasks fail
-        tasks = get_tasks(tasks=["STS12"])
+        tasks = mteb.get_tasks(tasks=["STS12"])
 
-    evaluation = MTEB(tasks=tasks)
+    evaluation = mteb.MTEB(tasks=tasks)
     results = evaluation.run(
         mteb_model, output_folder="mteb_results", eval_splits=["test"]
     )

--- a/src/nmn/nnx/examples/vision/aether_resnet50_tpu.py
+++ b/src/nmn/nnx/examples/vision/aether_resnet50_tpu.py
@@ -11,7 +11,7 @@ import importlib.util
 import os
 import sys
 import warnings
-from typing import List, Optional
+from typing import Any, List, Optional
 
 # JAX / Flax / Optax / Sharding
 import jax
@@ -39,13 +39,13 @@ wandb = lazy_example_dependency(
 datasets = lazy_example_dependency(
     "datasets", install=_INSTALL, purpose="The TPU ResNet data example"
 )
-grain = lazy_example_dependency(
+grain: Any = lazy_example_dependency(
     "grain.python", install=_INSTALL, purpose="The TPU ResNet Grain data example"
 )
-torch_data = lazy_example_dependency(
+torch_data: Any = lazy_example_dependency(
     "torch.utils.data", install=_INSTALL, purpose="The TPU ResNet fallback data example"
 )
-png_image_plugin = lazy_example_dependency(
+png_image_plugin: Any = lazy_example_dependency(
     "PIL.PngImagePlugin",
     install=_INSTALL,
     purpose="The TPU ResNet fallback data example",
@@ -990,7 +990,11 @@ def main():
         print("!" * 80 + "\n")
         png_image_plugin.MAX_TEXT_CHUNK = 100 * (1024**2)
 
-        # Setup PyTorch DataLoader fallback with in-memory option
+        # Setup PyTorch DataLoader fallback with in-memory option. These two
+        # variables intentionally hold either the streaming adapter or the
+        # map-style dataset selected below.
+        train_dataset: Any
+        val_dataset: Any
         if args.streaming:
             print("Using Streaming Dataset")
             train_dataset = ImageNetStreamDataset(

--- a/src/nmn/nnx/examples/vision/aether_resnet50_tpu.py
+++ b/src/nmn/nnx/examples/vision/aether_resnet50_tpu.py
@@ -1,4 +1,13 @@
+"""TPU ResNet example.
+
+Install training and dataset dependencies with ``pip install "nmn[nnx,examples]"``.
+The model definitions themselves require only ``nmn[nnx]``.
+"""
+
+from __future__ import annotations
+
 import argparse
+import importlib.util
 import os
 import sys
 import warnings
@@ -7,35 +16,50 @@ from typing import List, Optional
 # JAX / Flax / Optax / Sharding
 import jax
 import jax.numpy as jnp
-import optax
-
-# Checkpointing & Logging
-import orbax.checkpoint as ocp
-import wandb
+import numpy as np
 from flax import nnx
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-# Data Loading
-try:
-    import grain.python as grain
-
-    GRAIN_AVAILABLE = True
-except ImportError:
-    GRAIN_AVAILABLE = False
-    from PIL import PngImagePlugin
-    from torch.utils.data import DataLoader, Dataset, IterableDataset
-    from torchvision import transforms
-
-    PngImagePlugin.MAX_TEXT_CHUNK = 100 * (1024**2)
-
-import numpy as np
-from datasets import load_dataset
-from tqdm import tqdm
-
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.nnx.layers import YatNMN
 from nmn.nnx.layers.conv import YatConv
+
+_INSTALL = "nmn[nnx,examples]"
+optax = lazy_example_dependency(
+    "optax", install=_INSTALL, purpose="The TPU ResNet training example"
+)
+ocp = lazy_example_dependency(
+    "orbax.checkpoint", install=_INSTALL, purpose="The TPU ResNet checkpoint example"
+)
+wandb = lazy_example_dependency(
+    "wandb", install=_INSTALL, purpose="The TPU ResNet logging example"
+)
+datasets = lazy_example_dependency(
+    "datasets", install=_INSTALL, purpose="The TPU ResNet data example"
+)
+grain = lazy_example_dependency(
+    "grain.python", install=_INSTALL, purpose="The TPU ResNet Grain data example"
+)
+torch_data = lazy_example_dependency(
+    "torch.utils.data", install=_INSTALL, purpose="The TPU ResNet fallback data example"
+)
+png_image_plugin = lazy_example_dependency(
+    "PIL.PngImagePlugin",
+    install=_INSTALL,
+    purpose="The TPU ResNet fallback data example",
+)
+transforms = lazy_example_dependency(
+    "torchvision.transforms",
+    install=_INSTALL,
+    purpose="The TPU ResNet fallback data example",
+)
+tqdm_module = lazy_example_dependency(
+    "tqdm", install=_INSTALL, purpose="The TPU ResNet progress display"
+)
+
+GRAIN_AVAILABLE = importlib.util.find_spec("grain") is not None
 
 # Training Monitor
 try:
@@ -343,151 +367,123 @@ class ResNet(nnx.Module):
 # 2. Data Loading
 # -----------------------------------------------------------------------------
 
-if GRAIN_AVAILABLE:
-    # Grain-based data pipeline (optimized for TPU)
-    class HFDataSource(grain.RandomAccessDataSource):
-        """Grain data source wrapping HuggingFace dataset."""
 
-        def __init__(self, split="train", cache_dir=None):
-            self.dataset = load_dataset(
-                "mlnomad/imagenet-1k-224",
-                split=split,
-                streaming=False,
-                cache_dir=cache_dir,
-            )
+class HFDataSource:
+    """Grain-compatible data source wrapping HuggingFace datasets."""
 
-        def __len__(self):
-            return len(self.dataset)
+    def __init__(self, split="train", cache_dir=None):
+        self.dataset = datasets.load_dataset(
+            "mlnomad/imagenet-1k-224",
+            split=split,
+            streaming=False,
+            cache_dir=cache_dir,
+        )
 
-        def __getitem__(self, idx):
-            sample = self.dataset[idx]
-            image = sample["image"]
-            label = sample["label"]
-            # Convert PIL to numpy (HWC format)
-            if image.mode != "RGB":
-                image = image.convert("RGB")
-            image_np = np.array(image, dtype=np.uint8)
-            return {"image": image_np, "label": label}
+    def __len__(self):
+        return len(self.dataset)
 
-    class PreprocessOp(grain.MapTransform):
-        """JAX-native preprocessing operations."""
+    def __getitem__(self, idx):
+        sample = self.dataset[idx]
+        image = sample["image"]
+        label = sample["label"]
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        return {"image": np.array(image, dtype=np.uint8), "label": label}
 
-        def __init__(self, is_train=True, image_size=224):
-            self.is_train = is_train
-            self.image_size = image_size
-            self.mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
-            self.std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 
-        def map(self, element):
-            image = element["image"]
-            label = element["label"]
+class PreprocessOp:
+    """JAX-native preprocessing implementation, adapted to Grain at runtime."""
 
-            # Random crop/resize
-            if self.is_train:
-                # Simple random crop for now (could add more augmentations)
-                h, w = image.shape[:2]
-                if h > self.image_size or w > self.image_size:
-                    # Center crop as fallback
-                    top = (h - self.image_size) // 2
-                    left = (w - self.image_size) // 2
-                    image = image[
-                        top : top + self.image_size, left : left + self.image_size
-                    ]
-            else:
-                # Center crop
-                h, w = image.shape[:2]
-                top = (h - self.image_size) // 2
-                left = (w - self.image_size) // 2
-                image = image[
-                    top : top + self.image_size, left : left + self.image_size
-                ]
+    def __init__(self, is_train=True, image_size=224):
+        self.is_train = is_train
+        self.image_size = image_size
+        self.mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+        self.std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 
-            # Normalize
-            image = image.astype(np.float32) / 255.0
-            image = (image - self.mean) / self.std
+    def map(self, element):
+        image = element["image"]
+        label = element["label"]
+        h, w = image.shape[:2]
+        if not self.is_train or h > self.image_size or w > self.image_size:
+            top = (h - self.image_size) // 2
+            left = (w - self.image_size) // 2
+            image = image[top : top + self.image_size, left : left + self.image_size]
+        image = image.astype(np.float32) / 255.0
+        return {"image": (image - self.mean) / self.std, "label": label}
 
-            return {"image": image, "label": label}
 
-else:
-    # Fallback to PyTorch DataLoader
-    class ImageNetStreamDataset(IterableDataset):
-        def __init__(self, split="train", transform=None):
-            self.dataset = load_dataset(
-                "mlnomad/imagenet-1k-224", split=split, streaming=True
-            )
-            self.transform = transform
+class ImageNetStreamDataset:
+    def __init__(self, split="train", transform=None):
+        self.dataset = datasets.load_dataset(
+            "mlnomad/imagenet-1k-224", split=split, streaming=True
+        )
+        self.transform = transform
 
-        def __iter__(self):
-            for sample in self.dataset:
-                try:
-                    image = sample["image"]
-                    label = sample["label"]
-                    if image.mode != "RGB":
-                        image = image.convert("RGB")
-                    if self.transform:
-                        image = self.transform(image)
-                    yield image, label
-                except Exception:
-                    continue
-
-    class ImageNetMapDataset(Dataset):
-        def __init__(
-            self, split="train", transform=None, cache_dir=None, keep_in_memory=False
-        ):
-            self.dataset = load_dataset(
-                "mlnomad/imagenet-1k-224",
-                split=split,
-                streaming=False,
-                cache_dir=cache_dir,
-                keep_in_memory=keep_in_memory,
-            )
-            self.transform = transform
-
-        def __len__(self):
-            return len(self.dataset)
-
-        def __getitem__(self, idx):
+    def __iter__(self):
+        for sample in self.dataset:
             try:
-                sample = self.dataset[idx]
                 image = sample["image"]
                 label = sample["label"]
                 if image.mode != "RGB":
                     image = image.convert("RGB")
                 if self.transform:
                     image = self.transform(image)
-                return image, label
-            except Exception as e:
-                raise e
+                yield image, label
+            except Exception:
+                continue
 
-    def get_transforms(is_train=True):
-        if is_train:
-            return transforms.Compose(
-                [
-                    transforms.RandomResizedCrop(224),
-                    transforms.RandomHorizontalFlip(),
-                    transforms.ToTensor(),
-                    transforms.Normalize(
-                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                    ),
-                ]
-            )
-        else:
-            return transforms.Compose(
-                [
-                    transforms.CenterCrop(224),
-                    transforms.ToTensor(),
-                    transforms.Normalize(
-                        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                    ),
-                ]
-            )
 
-    def get_numpy_batch(batch):
-        images, labels = batch
-        # PyTorch NCHW -> JAX NHWC
-        images_np = images.numpy().transpose(0, 2, 3, 1)
-        labels_np = labels.numpy()
-        return images_np, labels_np
+class ImageNetMapDataset:
+    def __init__(
+        self, split="train", transform=None, cache_dir=None, keep_in_memory=False
+    ):
+        self.dataset = datasets.load_dataset(
+            "mlnomad/imagenet-1k-224",
+            split=split,
+            streaming=False,
+            cache_dir=cache_dir,
+            keep_in_memory=keep_in_memory,
+        )
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        sample = self.dataset[idx]
+        image = sample["image"]
+        label = sample["label"]
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+        if self.transform:
+            image = self.transform(image)
+        return image, label
+
+
+def get_transforms(is_train=True):
+    if is_train:
+        return transforms.Compose(
+            [
+                transforms.RandomResizedCrop(224),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+    return transforms.Compose(
+        [
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
+
+def get_numpy_batch(batch):
+    images, labels = batch
+    return images.numpy().transpose(0, 2, 3, 1), labels.numpy()
 
 
 def create_grain_dataloader(
@@ -522,8 +518,14 @@ def create_grain_dataloader(
             )
 
         # Create transformations (including batching)
+        preprocess = PreprocessOp(is_train=is_train)
+
+        class GrainPreprocessOp(grain.MapTransform):
+            def map(self, element):
+                return preprocess.map(element)
+
         transformations = [
-            PreprocessOp(is_train=is_train),
+            GrainPreprocessOp(),
             grain.Batch(batch_size=batch_size, drop_remainder=True),
         ]
 
@@ -986,6 +988,7 @@ def main():
         print("Grain is REQUIRED for TPU training. Install with: pip install grain")
         print("Falling back to PyTorch DataLoader (significantly slower on TPU)")
         print("!" * 80 + "\n")
+        png_image_plugin.MAX_TEXT_CHUNK = 100 * (1024**2)
 
         # Setup PyTorch DataLoader fallback with in-memory option
         if args.streaming:
@@ -996,6 +999,16 @@ def main():
             val_dataset = ImageNetStreamDataset(
                 split="validation", transform=get_transforms(False)
             )
+
+            class TorchIterableAdapter(torch_data.IterableDataset):
+                def __init__(self, dataset):
+                    self.dataset = dataset
+
+                def __iter__(self):
+                    return iter(self.dataset)
+
+            train_dataset = TorchIterableAdapter(train_dataset)
+            val_dataset = TorchIterableAdapter(val_dataset)
         else:
             print(f"Using Map-Style Dataset")
             if args.in_memory:
@@ -1120,14 +1133,14 @@ def main():
         else:
             # PyTorch DataLoader fallback
             try:
-                train_loader = DataLoader(
+                train_loader = torch_data.DataLoader(
                     train_dataset,
                     batch_size=args.batch_size // num_devices,
                     num_workers=0,
                     drop_last=True,
                     shuffle=True,
                 )
-                val_loader = DataLoader(
+                val_loader = torch_data.DataLoader(
                     val_dataset,
                     batch_size=args.batch_size // num_devices,
                     num_workers=0,
@@ -1150,7 +1163,9 @@ def main():
         epoch_metrics = []  # Accuracy
 
         print(f"Starting training for epoch {epoch}...")
-        pbar = tqdm(train_loader, desc=f"Epoch {epoch}", total=iterations_per_epoch)
+        pbar = tqdm_module.tqdm(
+            train_loader, desc=f"Epoch {epoch}", total=iterations_per_epoch
+        )
         for batch_idx, batch in enumerate(pbar):
             iter_start_time = time.time()
             global_step += 1
@@ -1246,7 +1261,7 @@ def main():
         total_loss = []
         val_batch_idx = 0
         for val_batch_idx, batch in enumerate(
-            tqdm(val_loader, desc="Val", total=val_iterations_per_epoch)
+            tqdm_module.tqdm(val_loader, desc="Val", total=val_iterations_per_epoch)
         ):
             imgs_np, lbls_np = process_batch(batch)
 

--- a/src/nmn/nnx/examples/vision/mnist.py
+++ b/src/nmn/nnx/examples/vision/mnist.py
@@ -7,6 +7,8 @@ or:
 
 Trains a 2-layer YatNMN MLP for 3 epochs. Uses torchvision to fetch MNIST so
 no tensorflow-datasets dependency is required.
+
+Install the runnable example with ``pip install "nmn[nnx,examples]"``.
 """
 
 from __future__ import annotations
@@ -19,11 +21,25 @@ from pathlib import Path
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
 from flax import nnx
-from torchvision import datasets, transforms
 
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.nnx import YatNMN
+
+_INSTALL = "nmn[nnx,examples]"
+optax = lazy_example_dependency(
+    "optax", install=_INSTALL, purpose="The Flax NNX MNIST training example"
+)
+datasets = lazy_example_dependency(
+    "torchvision.datasets",
+    install=_INSTALL,
+    purpose="The Flax NNX MNIST data loader",
+)
+transforms = lazy_example_dependency(
+    "torchvision.transforms",
+    install=_INSTALL,
+    purpose="The Flax NNX MNIST data loader",
+)
 
 
 class YatMLP(nnx.Module):

--- a/src/nmn/torch/examples/README.md
+++ b/src/nmn/torch/examples/README.md
@@ -13,6 +13,10 @@ Runnable training scripts using NMN's PyTorch layers.
 ## Quick start — MNIST
 
 ```bash
+pip install "nmn[torch,examples]"
+```
+
+```bash
 PYTHONPATH=src python -m nmn.torch.examples.vision.mnist \
     --epochs 3 --batch-size 128 --lr 3e-4 \
     --report .context/torch_mnist.json

--- a/src/nmn/torch/examples/vision/mnist.py
+++ b/src/nmn/torch/examples/vision/mnist.py
@@ -7,6 +7,8 @@ or:
 
 Trains a 2-layer YatNMN MLP for 3 epochs and prints train loss + test accuracy.
 On CPU (Apple Silicon, batch size 128) ~30-60s per epoch.
+
+Install the runnable example with ``pip install "nmn[torch,examples]"``.
 """
 
 from __future__ import annotations
@@ -20,9 +22,17 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
-from torchvision import datasets, transforms
 
+from nmn._example_dependencies import lazy_example_dependency
 from nmn.torch import YatNMN
+
+_INSTALL = "nmn[torch,examples]"
+datasets = lazy_example_dependency(
+    "torchvision.datasets", install=_INSTALL, purpose="The PyTorch MNIST data loader"
+)
+transforms = lazy_example_dependency(
+    "torchvision.transforms", install=_INSTALL, purpose="The PyTorch MNIST data loader"
+)
 
 
 class YatMLP(nn.Module):
@@ -55,6 +65,14 @@ def evaluate(model: nn.Module, loader: DataLoader, device: str) -> tuple[float, 
     return total_loss / n, correct / n
 
 
+def load_mnist(root: str):
+    """Load MNIST after resolving the example-only torchvision dependency."""
+    transform = transforms.ToTensor()
+    train = datasets.MNIST(root, train=True, download=True, transform=transform)
+    test = datasets.MNIST(root, train=False, download=True, transform=transform)
+    return train, test
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="YatNMN MNIST training (PyTorch)")
     parser.add_argument("--epochs", type=int, default=3)
@@ -70,9 +88,7 @@ def main() -> None:
     torch.manual_seed(args.seed)
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    tfm = transforms.ToTensor()
-    train_ds = datasets.MNIST(args.data_root, train=True, download=True, transform=tfm)
-    test_ds = datasets.MNIST(args.data_root, train=False, download=True, transform=tfm)
+    train_ds, test_ds = load_mnist(args.data_root)
     train_dl = DataLoader(
         train_ds, batch_size=args.batch_size, shuffle=True, num_workers=0
     )

--- a/src/nmn/torch/examples/vision/resnet_training.py
+++ b/src/nmn/torch/examples/vision/resnet_training.py
@@ -3,9 +3,7 @@
 # YAT ResNet Training with Weight Tying, Weight Normalization, and Constant Alpha
 #
 # To run this script, you'll need to install the following packages:
-# pip install torch torchvision torchaudio
-# pip install datasets nmn-pytorch # For the original YAT models and TinyImageNet
-# pip install wandb matplotlib seaborn scikit-learn
+# pip install "nmn[torch,examples]"
 #
 # Example usage:
 #
@@ -38,20 +36,40 @@ import time
 import warnings
 from io import BytesIO
 
-import matplotlib.pyplot as plt
 import numpy as np
-import seaborn as sns
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
-import wandb
-from datasets import load_dataset
-from PIL import Image
-from sklearn.metrics import confusion_matrix
 from torch.utils.data import DataLoader
-from torchvision import datasets as torchvision_datasets
-from torchvision import transforms
+
+from nmn._example_dependencies import lazy_example_dependency
+
+_INSTALL = "nmn[torch,examples]"
+plt = lazy_example_dependency(
+    "matplotlib.pyplot", install=_INSTALL, purpose="The ResNet reporting example"
+)
+sns = lazy_example_dependency(
+    "seaborn", install=_INSTALL, purpose="The ResNet reporting example"
+)
+wandb = lazy_example_dependency(
+    "wandb", install=_INSTALL, purpose="The ResNet experiment logger"
+)
+huggingface_datasets = lazy_example_dependency(
+    "datasets", install=_INSTALL, purpose="The ResNet Hugging Face data loader"
+)
+pillow_image = lazy_example_dependency(
+    "PIL.Image", install=_INSTALL, purpose="The ResNet image data loader"
+)
+sklearn_metrics = lazy_example_dependency(
+    "sklearn.metrics", install=_INSTALL, purpose="The ResNet reporting example"
+)
+torchvision_datasets = lazy_example_dependency(
+    "torchvision.datasets", install=_INSTALL, purpose="The ResNet data loader"
+)
+transforms = lazy_example_dependency(
+    "torchvision.transforms", install=_INSTALL, purpose="The ResNet data loader"
+)
 
 warnings.filterwarnings("ignore", category=UserWarning, module="datasets.builder")
 
@@ -70,14 +88,16 @@ class HuggingFaceDataset(torch.utils.data.IterableDataset):
     """Generic wrapper for streaming image classification datasets from Hugging Face Hub."""
 
     def __init__(self, dataset_name, split, transform=None, shuffle_buffer_size=50000):
-        self.dataset = load_dataset(dataset_name, split=split, streaming=True)
+        self.dataset = huggingface_datasets.load_dataset(
+            dataset_name, split=split, streaming=True
+        )
         if split == "train":
             # Shuffle the training data with a large buffer for better randomness
             self.dataset = self.dataset.shuffle(
                 buffer_size=shuffle_buffer_size, seed=int(time.time())
             )
         self.transform = transform
-        self.info = load_dataset(dataset_name, split=split).info
+        self.info = huggingface_datasets.load_dataset(dataset_name, split=split).info
 
     def __iter__(self):
         for sample in self.dataset:
@@ -91,7 +111,7 @@ class HuggingFaceDataset(torch.utils.data.IterableDataset):
                 )
 
             img_data = sample[image_key]
-            if not isinstance(img_data, Image.Image):
+            if not isinstance(img_data, pillow_image.Image):
                 img = img_data.convert("RGB")
             else:
                 img = img_data
@@ -461,7 +481,7 @@ def plot_confusion_matrix(all_preds, all_targets, class_names, use_wandb=False):
     if not use_wandb:
         return
 
-    cm = confusion_matrix(all_targets, all_preds)
+    cm = sklearn_metrics.confusion_matrix(all_targets, all_preds)
     plt.figure(figsize=(15, 15))
     sns.heatmap(
         cm,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -642,6 +642,8 @@ def test_examples_points_to_examples_md(capsys):
     assert cli.main(["examples"]) == 0
     out = capsys.readouterr().out
     assert "EXAMPLES.md" in out
+    assert 'pip install "nmn[nnx,examples]"' in out
+    assert "nmn[data]" in out
     assert "nmn guide" in out
 
 

--- a/tests/test_example_dependency_contract.py
+++ b/tests/test_example_dependency_contract.py
@@ -1,0 +1,80 @@
+"""Packaging and lazy-import contract for runnable examples."""
+
+from __future__ import annotations
+
+import importlib
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from nmn._example_dependencies import lazy_example_dependency
+
+
+def _extras():
+    project = Path(__file__).parents[1] / "pyproject.toml"
+    return tomllib.loads(project.read_text())["project"]["optional-dependencies"]
+
+
+def test_core_backend_extras_exclude_example_and_data_dependencies():
+    extras = _extras()
+    forbidden = {
+        "datasets",
+        "grain",
+        "matplotlib",
+        "mteb",
+        "optax",
+        "orbax-checkpoint",
+        "pillow",
+        "scikit-learn",
+        "seaborn",
+        "tensorflow-datasets",
+        "tokenizers",
+        "torchvision",
+        "tqdm",
+        "wandb",
+    }
+    for extra in ("nnx", "torch", "keras", "tf", "linen", "mlx"):
+        names = {
+            requirement.split("[")[0].split("=")[0].split(">")[0]
+            for requirement in extras[extra]
+        }
+        assert names.isdisjoint(forbidden), (extra, names & forbidden)
+
+
+def test_data_and_example_extras_publish_the_documented_dependencies():
+    extras = _extras()
+    assert extras["torch"] == ["torch>=1.11.0"]
+    assert {item.split(">")[0] for item in extras["data"]} == {
+        "torchvision",
+        "tensorflow-datasets",
+        "datasets",
+    }
+    example_text = " ".join(extras["examples"])
+    for dependency in (
+        "nmn[data]",
+        "optax",
+        "orbax-checkpoint",
+        "wandb",
+        "grain",
+    ):
+        assert dependency in example_text
+
+
+def test_lazy_dependency_does_not_import_until_first_use(monkeypatch):
+    calls = []
+
+    def missing(name):
+        calls.append(name)
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+    dependency = lazy_example_dependency(
+        "optional_data", install="nmn[torch,examples]", purpose="This example"
+    )
+    assert calls == []
+    with pytest.raises(
+        ModuleNotFoundError, match=r'pip install "nmn\[torch,examples\]"'
+    ):
+        dependency.load_data
+    assert calls == ["optional_data"]

--- a/tests/test_linen/test_examples.py
+++ b/tests/test_linen/test_examples.py
@@ -1,0 +1,44 @@
+"""Clean-backend smoke tests for the documented Linen example model."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+
+def _block_example_imports(monkeypatch):
+    original = builtins.__import__
+
+    def guarded(name, *args, **kwargs):
+        if name.split(".", 1)[0] in {"optax", "torchvision"}:
+            raise AssertionError(f"example dependency imported eagerly: {name}")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded)
+
+
+def test_mnist_model_imports_and_runs_without_example_dependencies(monkeypatch):
+    sys.modules.pop("nmn.linen.examples.mnist", None)
+    _block_example_imports(monkeypatch)
+    module = importlib.import_module("nmn.linen.examples.mnist")
+    model = module.YatMLP(hidden1=8, hidden2=4, num_classes=3)
+    inputs = jnp.ones((2, 28, 28, 1))
+    variables = model.init(jax.random.key(0), inputs)
+    assert model.apply(variables, inputs).shape == (2, 3)
+
+
+def test_mnist_loader_reports_exact_example_install(monkeypatch):
+    module = importlib.import_module("nmn.linen.examples.mnist")
+    monkeypatch.setattr(module.datasets, "_module", None)
+
+    def missing(name):
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+    with pytest.raises(ModuleNotFoundError, match=r"nmn\[linen,examples\]"):
+        module.load_mnist("unused")

--- a/tests/test_mlx/test_examples.py
+++ b/tests/test_mlx/test_examples.py
@@ -1,0 +1,40 @@
+"""Clean-backend smoke tests for the documented MLX example model."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+
+def test_mnist_model_imports_and_runs_without_torchvision(monkeypatch):
+    original = builtins.__import__
+
+    def guarded(name, *args, **kwargs):
+        if name.split(".", 1)[0] == "torchvision":
+            raise AssertionError(f"example dependency imported eagerly: {name}")
+        return original(name, *args, **kwargs)
+
+    sys.modules.pop("nmn.mlx.examples.mnist", None)
+    monkeypatch.setattr(builtins, "__import__", guarded)
+    module = importlib.import_module("nmn.mlx.examples.mnist")
+    model = module.YatMLP(hidden1=8, hidden2=4, num_classes=3)
+    output = model(mx.ones((2, 28, 28, 1)))
+    mx.eval(output)
+    assert output.shape == (2, 3)
+
+
+def test_mnist_loader_reports_exact_example_install(monkeypatch):
+    module = importlib.import_module("nmn.mlx.examples.mnist")
+    monkeypatch.setattr(module.datasets, "_module", None)
+
+    def missing(name):
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+    with pytest.raises(ModuleNotFoundError, match=r"nmn\[mlx,examples\]"):
+        module.load_mnist("unused")

--- a/tests/test_nnx/test_examples.py
+++ b/tests/test_nnx/test_examples.py
@@ -1,0 +1,98 @@
+"""Clean-backend smoke tests for the documented NNX example model."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+
+def _block_example_imports(monkeypatch):
+    original = builtins.__import__
+
+    def guarded(name, *args, **kwargs):
+        if name.split(".", 1)[0] in {
+            "datasets",
+            "grain",
+            "mteb",
+            "optax",
+            "orbax",
+            "tokenizers",
+            "torchvision",
+            "wandb",
+        }:
+            raise AssertionError(f"example dependency imported eagerly: {name}")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded)
+
+
+def test_mnist_model_imports_and_runs_without_example_dependencies(monkeypatch):
+    sys.modules.pop("nmn.nnx.examples.vision.mnist", None)
+    _block_example_imports(monkeypatch)
+    module = importlib.import_module("nmn.nnx.examples.vision.mnist")
+    model = module.YatMLP(rngs=nnx.Rngs(0), hidden1=8, hidden2=4, num_classes=3)
+    assert model(jnp.ones((2, 28, 28, 1))).shape == (2, 3)
+
+
+def test_mnist_loader_reports_exact_example_install(monkeypatch):
+    module = importlib.import_module("nmn.nnx.examples.vision.mnist")
+    monkeypatch.setattr(module.datasets, "_module", None)
+
+    def missing(name):
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+    with pytest.raises(ModuleNotFoundError, match=r"nmn\[nnx,examples\]"):
+        module.load_mnist("unused")
+
+
+@pytest.mark.parametrize(
+    ("module_name", "factory"),
+    [
+        (
+            "nmn.nnx.examples.language.m3za",
+            lambda module: module.MiniBERT(
+                maxlen=8,
+                vocab_size=16,
+                embed_dim=8,
+                num_heads=2,
+                feed_forward_dim=12,
+                num_transformer_blocks=1,
+                rngs=nnx.Rngs(0),
+            ),
+        ),
+        (
+            "nmn.nnx.examples.language.m3za_perf",
+            lambda module: module.MiniBERT(
+                maxlen=8,
+                vocab_size=16,
+                embed_dim=8,
+                num_heads=2,
+                feed_forward_dim=12,
+                num_transformer_blocks=1,
+                rngs=nnx.Rngs(0),
+            ),
+        ),
+        (
+            "nmn.nnx.examples.vision.aether_resnet50_tpu",
+            lambda module: module.ResNet(
+                module.BasicBlock,
+                [1, 1, 1, 1],
+                num_classes=3,
+                rngs=nnx.Rngs(0),
+            ),
+        ),
+    ],
+)
+def test_advanced_models_import_without_example_dependencies(
+    monkeypatch, module_name, factory
+):
+    sys.modules.pop(module_name, None)
+    _block_example_imports(monkeypatch)
+    module = importlib.import_module(module_name)
+    assert factory(module) is not None

--- a/tests/test_torch/test_examples.py
+++ b/tests/test_torch/test_examples.py
@@ -1,5 +1,12 @@
 """Smoke tests for documented PyTorch examples."""
 
+import builtins
+import importlib
+import sys
+
+import pytest
+import torch
+
 
 def test_quick_example_basic_layers_run(capsys):
     from nmn.torch.examples.quick_example import example_1_basic_yat_layers
@@ -9,3 +16,56 @@ def test_quick_example_basic_layers_run(capsys):
     output = capsys.readouterr().out
     assert "Conv forward pass" in output
     assert "Linear forward pass" in output
+
+
+def test_mnist_model_imports_and_runs_without_torchvision(monkeypatch):
+    original = builtins.__import__
+
+    def guarded(name, *args, **kwargs):
+        if name.split(".", 1)[0] == "torchvision":
+            raise AssertionError(f"example dependency imported eagerly: {name}")
+        return original(name, *args, **kwargs)
+
+    sys.modules.pop("nmn.torch.examples.vision.mnist", None)
+    monkeypatch.setattr(builtins, "__import__", guarded)
+    module = importlib.import_module("nmn.torch.examples.vision.mnist")
+    model = module.YatMLP(hidden1=8, hidden2=4, num_classes=3)
+    assert model(torch.ones((2, 28, 28))).shape == (2, 3)
+
+
+def test_mnist_loader_reports_exact_example_install(monkeypatch):
+    module = importlib.import_module("nmn.torch.examples.vision.mnist")
+    monkeypatch.setattr(module.datasets, "_module", None)
+
+    def missing(name):
+        raise ModuleNotFoundError(name=name)
+
+    monkeypatch.setattr(importlib, "import_module", missing)
+    with pytest.raises(ModuleNotFoundError, match=r"nmn\[torch,examples\]"):
+        module.load_mnist("unused")
+
+
+def test_resnet_models_import_without_example_dependencies(monkeypatch):
+    original = builtins.__import__
+
+    def guarded(name, *args, **kwargs):
+        if name.split(".", 1)[0] in {
+            "datasets",
+            "matplotlib",
+            "PIL",
+            "seaborn",
+            "sklearn",
+            "torchvision",
+            "wandb",
+        }:
+            raise AssertionError(f"example dependency imported eagerly: {name}")
+        return original(name, *args, **kwargs)
+
+    module_name = "nmn.torch.examples.vision.resnet_training"
+    sys.modules.pop(module_name, None)
+    monkeypatch.setattr(builtins, "__import__", guarded)
+    module = importlib.import_module(module_name)
+    standard = module.StandardConvNet(module.BasicStandardBlock, [1, 1, 1, 1])
+    yat = module.YATConvNet(module.BasicYATBlock, [1, 1, 1, 1])
+    assert standard is not None
+    assert yat is not None


### PR DESCRIPTION
Closes #159.\n\nSeparates optional example/data dependencies from core backend extras, keeps example model imports light, adds actionable missing-dependency errors, documents exact installs, and adds clean no-download construction smokes across supported frameworks.\n\nValidated with full Torch and JAX/Flax suites, clean-environment smoke tests, wheel metadata/build checks, pinned formatting/lint gates, and independent exact-head review.