### PR TITLE
ci: sync public mirror with a scoped GitHub App

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,9 +1,9 @@
 name: Sync public mirror
 
 # This file is intentionally identical in the canonical and mirror repositories.
-# It executes only in mlnomadpy/nmn, where the ephemeral GITHUB_TOKEN has write
-# access to that repository and no access to azettaai/nmn. The canonical source
-# is fetched anonymously and the mirror refuses divergent history or tag edits.
+# It executes only in mlnomadpy/nmn. A GitHub App installed only on that mirror
+# supplies a short-lived token with Contents + Workflows write permission; the
+# canonical source is fetched anonymously. See docs/mirror-sync.md.
 
 on:
   schedule:
@@ -23,39 +23,26 @@ jobs:
     if: github.repository == 'mlnomadpy/nmn'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: write
     steps:
+      # With owner/repositories omitted, the action scopes the installation
+      # token to this repository only. It is revoked automatically after use.
+      - name: Create mirror-only installation token
+        id: mirror-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MIRROR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-workflows: write
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Fetch and verify canonical history
+      - name: Fetch and synchronize canonical history
+        env:
+          MIRROR_PUSH_REMOTE: https://x-access-token:${{ steps.mirror-token.outputs.token }}@github.com/${{ github.repository }}.git
         run: |
           git remote add canonical https://github.com/azettaai/nmn.git
-          git fetch --prune canonical master --tags
-          mirror_head="$(git rev-parse refs/remotes/origin/master)"
-          canonical_head="$(git rev-parse refs/remotes/canonical/master)"
-          if ! git merge-base --is-ancestor "${mirror_head}" "${canonical_head}"; then
-            echo "Mirror master has diverged from canonical master." >&2
-            exit 1
-          fi
-
-      - name: Update mirror with repository-scoped authentication
-        run: |
-          git push origin refs/remotes/canonical/master:refs/heads/master
-          git push origin --tags
-
-      - name: Verify remote master and tags
-        run: |
-          canonical_head="$(git rev-parse refs/remotes/canonical/master)"
-          mirrored_head="$(git ls-remote origin refs/heads/master | awk '{print $1}')"
-          test -n "${mirrored_head}"
-          test "${mirrored_head}" = "${canonical_head}"
-
-          while IFS= read -r tag_ref; do
-            canonical_tag="$(git rev-parse "${tag_ref}")"
-            mirrored_tag="$(git ls-remote origin "${tag_ref}" | awk '{print $1}')"
-            test -n "${mirrored_tag}"
-            test "${mirrored_tag}" = "${canonical_tag}"
-          done < <(git for-each-ref --format='%(refname)' refs/tags)
+          bash scripts/sync-public-mirror.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Welcome to the **Neural Matter Networks** documentation. This is the local-repo 
 | **See code snippets per framework**          | [`EXAMPLES.md`](../EXAMPLES.md) at repo root                |
 | **Run a full training script**               | [`src/nmn/<framework>/examples/`](../src/nmn/)              |
 | **Contribute**                                | [`CONTRIBUTING.md`](../CONTRIBUTING.md)                     |
+| **Maintain the public mirror**                | [Public mirror synchronization](mirror-sync.md)             |
 | **Report a security issue**                  | [`SECURITY.md`](../SECURITY.md)                             |
 
 ---

--- a/docs/mirror-sync.md
+++ b/docs/mirror-sync.md
@@ -1,0 +1,37 @@
+# Public mirror synchronization
+
+The `mlnomadpy/nmn` mirror synchronizes from the public canonical history with
+the hourly and manually dispatched `Sync public mirror` workflow. The workflow
+fetches `azettaai/nmn` anonymously and can write only to the mirror.
+
+## Mirror-only GitHub App
+
+GitHub's workflow `GITHUB_TOKEN` cannot update files below `.github/workflows/`.
+Configure a GitHub App as follows instead:
+
+1. Grant the app repository-level **Contents: write** and **Workflows: write**
+   permissions, with no organization permissions.
+2. Install it on **only** `mlnomadpy/nmn`.
+3. Set the mirror repository variable `MIRROR_APP_CLIENT_ID` to the app's client
+   ID and the Actions secret `MIRROR_APP_PRIVATE_KEY` to its private key.
+
+The workflow requests a short-lived installation token with only those two
+permissions. It deliberately omits `owner` and `repositories` from
+`actions/create-github-app-token`, which scopes the token to the current mirror
+repository. The action revokes the token after the job. The workflow's own
+`GITHUB_TOKEN` remains read-only.
+
+Checkout credential persistence is disabled. The installation token is passed
+only in a dedicated HTTPS push URL for `mlnomadpy/nmn`; neither the anonymous
+canonical fetch nor the remote-ref verification inherits an authorization
+header.
+
+## Safety properties
+
+`scripts/sync-public-mirror.sh` refuses a non-fast-forward `master` update.
+Canonical tags are fetched without force, so an attempt to change an existing
+tag fails before the push. The branch and tags are then sent in one atomic push:
+if GitHub rejects any ref, none are updated. After pushing, the script verifies
+the remote branch and every canonical tag by object ID. A canonical commit that
+changes a workflow file is otherwise an ordinary fast-forward and is supported
+by the mirror-only app's Workflows permission.

--- a/scripts/sync-public-mirror.sh
+++ b/scripts/sync-public-mirror.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remotes are configurable only so the same transaction can be exercised
+# against local bare repositories. The Actions workflow uses these defaults.
+canonical_remote="${CANONICAL_REMOTE:-canonical}"
+mirror_remote="${MIRROR_REMOTE:-origin}"
+mirror_push_remote="${MIRROR_PUSH_REMOTE:-${mirror_remote}}"
+branch="${MIRROR_BRANCH:-master}"
+canonical_ref="refs/remotes/${canonical_remote}/${branch}"
+mirror_ref="refs/remotes/${mirror_remote}/${branch}"
+
+# Fetching canonical tags without force fails before any push if an existing
+# mirror tag has the same name but a different object (tag rewrites are refused).
+git fetch --prune "${canonical_remote}" "${branch}" --tags
+mirror_head="$(git rev-parse "${mirror_ref}")"
+canonical_head="$(git rev-parse "${canonical_ref}")"
+if ! git merge-base --is-ancestor "${mirror_head}" "${canonical_head}"; then
+  echo "Mirror ${branch} has diverged from canonical ${branch}." >&2
+  exit 1
+fi
+
+git push --atomic "${mirror_push_remote}" \
+  "${canonical_ref}:refs/heads/${branch}" --tags
+
+mirrored_head="$(git ls-remote "${mirror_remote}" "refs/heads/${branch}" | awk '{print $1}')"
+test -n "${mirrored_head}"
+test "${mirrored_head}" = "${canonical_head}"
+
+while IFS= read -r tag_ref; do
+  canonical_tag="$(git rev-parse "${tag_ref}")"
+  mirrored_tag="$(git ls-remote "${mirror_remote}" "${tag_ref}" | awk '{print $1}')"
+  test -n "${mirrored_tag}"
+  test "${mirrored_tag}" = "${canonical_tag}"
+done < <(git for-each-ref --format='%(refname)' refs/tags)

--- a/tests/test_mirror_sync.py
+++ b/tests/test_mirror_sync.py
@@ -1,0 +1,157 @@
+"""Local integration regressions for the public-mirror sync transaction."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+SYNC_SCRIPT = ROOT / "scripts" / "sync-public-mirror.sh"
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repositories(tmp_path):
+    canonical = tmp_path / "canonical.git"
+    mirror = tmp_path / "mirror.git"
+    author = tmp_path / "author"
+    runner = tmp_path / "runner"
+    _git(tmp_path, "init", "--bare", str(canonical))
+    _git(tmp_path, "init", "--bare", str(mirror))
+    _git(canonical, "symbolic-ref", "HEAD", "refs/heads/master")
+    _git(mirror, "symbolic-ref", "HEAD", "refs/heads/master")
+    _git(tmp_path, "init", "-b", "master", str(author))
+    _git(author, "config", "user.name", "Mirror Test")
+    _git(author, "config", "user.email", "mirror@example.invalid")
+    (author / "README.md").write_text("base\n")
+    _git(author, "add", "README.md")
+    _git(author, "commit", "-m", "base")
+    _git(author, "tag", "-a", "v0.3.5", "-m", "v0.3.5")
+    _git(author, "remote", "add", "canonical", str(canonical))
+    _git(author, "remote", "add", "mirror", str(mirror))
+    _git(author, "push", "canonical", "master", "--tags")
+    _git(author, "push", "mirror", "master", "--tags")
+    _git(tmp_path, "clone", str(mirror), str(runner))
+    _git(runner, "remote", "add", "canonical", str(canonical))
+    return canonical, mirror, author, runner
+
+
+def _sync(runner: Path, *, check: bool = True):
+    environment = os.environ.copy()
+    environment.update(
+        CANONICAL_REMOTE="canonical", MIRROR_REMOTE="origin", MIRROR_BRANCH="master"
+    )
+    return subprocess.run(
+        ["bash", str(SYNC_SCRIPT)],
+        cwd=runner,
+        env=environment,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _remote_ref(repository: Path, ref: str) -> str:
+    return _git(repository, "rev-parse", ref).stdout.strip()
+
+
+def test_sync_fast_forwards_across_workflow_file_change(repositories):
+    canonical, mirror, author, runner = repositories
+    workflow = author / ".github" / "workflows" / "changed.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text("name: changed\non: workflow_dispatch\n")
+    _git(author, "add", str(workflow.relative_to(author)))
+    _git(author, "commit", "-m", "change workflow")
+    _git(author, "push", "canonical", "master")
+
+    _sync(runner)
+
+    assert _remote_ref(mirror, "refs/heads/master") == _remote_ref(
+        canonical, "refs/heads/master"
+    )
+    assert _remote_ref(mirror, "refs/tags/v0.3.5") == _remote_ref(
+        canonical, "refs/tags/v0.3.5"
+    )
+
+
+def test_sync_refuses_divergent_master(repositories):
+    canonical, mirror, author, runner = repositories
+    (author / "canonical.txt").write_text("canonical\n")
+    _git(author, "add", "canonical.txt")
+    _git(author, "commit", "-m", "canonical change")
+    _git(author, "push", "canonical", "master")
+
+    mirror_writer = runner.parent / "mirror-writer"
+    _git(runner.parent, "clone", str(mirror), str(mirror_writer))
+    _git(mirror_writer, "config", "user.name", "Mirror Test")
+    _git(mirror_writer, "config", "user.email", "mirror@example.invalid")
+    (mirror_writer / "mirror.txt").write_text("mirror\n")
+    _git(mirror_writer, "add", "mirror.txt")
+    _git(mirror_writer, "commit", "-m", "divergent mirror change")
+    _git(mirror_writer, "push", "origin", "master")
+    _git(runner, "fetch", "origin", "master")
+    before = _remote_ref(mirror, "refs/heads/master")
+
+    result = _sync(runner, check=False)
+
+    assert result.returncode != 0
+    assert "has diverged" in result.stderr
+    assert _remote_ref(mirror, "refs/heads/master") == before
+
+
+def test_sync_refuses_tag_rewrite_before_branch_push(repositories):
+    canonical, mirror, author, runner = repositories
+    (author / "canonical.txt").write_text("canonical\n")
+    _git(author, "add", "canonical.txt")
+    _git(author, "commit", "-m", "canonical change")
+    _git(author, "tag", "-f", "-a", "v0.3.5", "-m", "rewritten v0.3.5")
+    _git(author, "push", "canonical", "master")
+    _git(author, "push", "--force", "canonical", "refs/tags/v0.3.5")
+    branch_before = _remote_ref(mirror, "refs/heads/master")
+    tag_before = _remote_ref(mirror, "refs/tags/v0.3.5")
+
+    result = _sync(runner, check=False)
+
+    assert result.returncode != 0
+    assert _remote_ref(mirror, "refs/heads/master") == branch_before
+    assert _remote_ref(mirror, "refs/tags/v0.3.5") == tag_before
+
+
+def test_sync_atomically_refuses_branch_when_server_rejects_tag(repositories):
+    canonical, mirror, author, runner = repositories
+    (author / "canonical.txt").write_text("canonical\n")
+    _git(author, "add", "canonical.txt")
+    _git(author, "commit", "-m", "canonical change")
+    _git(author, "tag", "-a", "v0.3.6", "-m", "v0.3.6")
+    _git(author, "push", "canonical", "master", "--tags")
+    branch_before = _remote_ref(mirror, "refs/heads/master")
+
+    hook = mirror / "hooks" / "pre-receive"
+    hook.write_text(
+        "#!/usr/bin/env bash\n"
+        "while read -r old new ref; do\n"
+        '  if [ "${ref}" = refs/tags/v0.3.6 ]; then exit 1; fi\n'
+        "done\n"
+    )
+    hook.chmod(0o755)
+
+    result = _sync(runner, check=False)
+
+    assert result.returncode != 0
+    assert _remote_ref(mirror, "refs/heads/master") == branch_before
+    assert (
+        _git(mirror, "show-ref", "--verify", "refs/tags/v0.3.6", check=False).returncode
+        != 0
+    )

--- a/tests/test_mirror_sync.py
+++ b/tests/test_mirror_sync.py
@@ -87,7 +87,7 @@ def test_sync_fast_forwards_across_workflow_file_change(repositories):
 
 
 def test_sync_refuses_divergent_master(repositories):
-    canonical, mirror, author, runner = repositories
+    _canonical, mirror, author, runner = repositories
     (author / "canonical.txt").write_text("canonical\n")
     _git(author, "add", "canonical.txt")
     _git(author, "commit", "-m", "canonical change")
@@ -112,7 +112,7 @@ def test_sync_refuses_divergent_master(repositories):
 
 
 def test_sync_refuses_tag_rewrite_before_branch_push(repositories):
-    canonical, mirror, author, runner = repositories
+    _canonical, mirror, author, runner = repositories
     (author / "canonical.txt").write_text("canonical\n")
     _git(author, "add", "canonical.txt")
     _git(author, "commit", "-m", "canonical change")
@@ -130,7 +130,7 @@ def test_sync_refuses_tag_rewrite_before_branch_push(repositories):
 
 
 def test_sync_atomically_refuses_branch_when_server_rejects_tag(repositories):
-    canonical, mirror, author, runner = repositories
+    _canonical, mirror, author, runner = repositories
     (author / "canonical.txt").write_text("canonical\n")
     _git(author, "add", "canonical.txt")
     _git(author, "commit", "-m", "canonical change")

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -286,17 +286,34 @@ def test_sdist_excludes_the_local_dacli_evidence_ledger():
 
 def test_mirror_uses_repository_scoped_self_sync_and_verifies_every_ref():
     workflow = (WORKFLOWS / "mirror.yml").read_text()
+    sync_script = (ROOT / "scripts" / "sync-public-mirror.sh").read_text()
 
     assert "github.repository == 'mlnomadpy/nmn'" in workflow
-    assert "contents: write" in workflow
+    assert "actions/create-github-app-token@v3" in workflow
+    assert "client-id: ${{ vars.MIRROR_APP_CLIENT_ID }}" in workflow
+    assert "private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}" in workflow
+    assert "permission-contents: write" in workflow
+    assert "permission-workflows: write" in workflow
+    token_step = workflow.split("id: mirror-token", 1)[1].split("\n\n", 1)[0]
+    assert "owner:" not in token_step
+    assert "repositories:" not in token_step
+    assert "persist-credentials: false" in workflow
+    assert "MIRROR_PUSH_REMOTE: https://x-access-token:" in workflow
+    assert "${{ github.repository }}.git" in workflow
+    assert workflow.count("${{ steps.mirror-token.outputs.token }}") == 1
+    assert 'mirror_push_remote="${MIRROR_PUSH_REMOTE:-${mirror_remote}}"' in sync_script
+    assert workflow.count("contents: read") == 1
+    assert "\n      contents: write\n" not in workflow
     assert "MIRROR_PAT" not in workflow
+    assert "DEPLOY_KEY" not in workflow
     assert "https://github.com/azettaai/nmn.git" in workflow
-    assert "git merge-base --is-ancestor" in workflow
-    assert "git push origin refs/remotes/canonical/master:refs/heads/master" in workflow
-    assert "git push origin --tags" in workflow
-    assert "git ls-remote" in workflow
-    assert "mirrored_head" in workflow
-    assert "mirrored_tag" in workflow
+    assert "bash scripts/sync-public-mirror.sh" in workflow
+    assert "git merge-base --is-ancestor" in sync_script
+    assert 'git push --atomic "${mirror_push_remote}"' in sync_script
+    assert '"${canonical_ref}:refs/heads/${branch}" --tags' in sync_script
+    assert "git ls-remote" in sync_script
+    assert "mirrored_head" in sync_script
+    assert "mirrored_tag" in sync_script
     assert "continue-on-error" not in workflow
 
 


### PR DESCRIPTION
Implements the repository changes for #137. The issue must remain open until the mirror-only GitHub App is installed and a live workflow-file-changing sync verifies master and annotated v0.3.5 exactly.\n\nAdds a short-lived mirror-scoped installation token, read-only default token, non-persisted checkout credentials, fast-forward/tag-rewrite refusal, atomic push verification, setup documentation, and policy/regression coverage.\n\nValidated with 32 focused tests, pinned formatting/lint/shell/static checks, and independent exact-head review.