### PR TITLE
feat: align ConvTranspose output-shape semantics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Welcome to the **Neural Matter Networks** documentation. This is the local-repo 
 | -------------------------------------------- | ----------------------------------------------------------- |
 | **Understand the math**                       | [Architecture & Theory](architecture.md)                    |
 | **Port an existing model**                   | [Migration Cheat Sheet](migration.md)                       |
+| **Align transposed-convolution shapes**      | [ConvTranspose shape contract](conv-transpose-shapes.md)     |
 | **Pick the right framework**                 | [Framework comparison](#framework-comparison) below          |
 | **Discover the package from a terminal**     | Run `nmn` / `nmn guide <fw>` / `nmn features` / `nmn doctor`  |
 | **See code snippets per framework**          | [`EXAMPLES.md`](../EXAMPLES.md) at repo root                |

--- a/docs/conv-transpose-shapes.md
+++ b/docs/conv-transpose-shapes.md
@@ -1,0 +1,50 @@
+# Transposed-convolution output shapes
+
+NMN defines one canonical spatial-size contract for transposed convolution.
+For each spatial axis, let `L` be the input size, `k` the kernel size, `s` the
+stride, `d` the kernel dilation, `o` the output padding, and
+`e = d * (k - 1) + 1` the effective kernel size. Then:
+
+```text
+VALID: (L - 1) * s + e + o
+SAME:  L * s + o
+```
+
+`k`, `s`, and `d` must be positive. `o` must satisfy `0 <= o < s`. Multi-axis
+1D/2D/3D layers apply these equations independently to every axis. Output
+padding extends only the high side; it does not add symmetric input padding.
+
+## Backward-compatible selection
+
+Frameworks historically disagreed when `s > e`: PyTorch and MLX used the
+canonical `VALID` result, while JAX, Keras, and TensorFlow inferred
+`L * s + max(e - s, 0)` when output padding was omitted. NMN preserves those
+legacy defaults so loading an existing model cannot silently change its shape.
+
+| Backend | Select the canonical contract |
+| --- | --- |
+| PyTorch | Existing numeric `padding=0` and `output_padding=o` (`VALID`) |
+| Flax NNX | Pass `output_padding=o` explicitly; omission keeps JAX sizing |
+| Flax Linen | Pass `output_padding=o` explicitly; omission keeps JAX sizing |
+| Keras 3 | Pass `output_shape_mode="nmn"`; omitted output padding means zero |
+| TensorFlow | Pass `output_padding=o` explicitly; omission keeps TF sizing |
+| MLX | Existing `padding="valid"`/`"same"` and `output_padding=o` |
+
+Keras keeps `output_shape_mode="framework"` as its default for configuration
+and saved-model compatibility. Its `"nmn"` mode is serialized by `get_config`.
+TensorFlow, Linen, and NNX added only optional keyword arguments, so existing
+constructor calls and implicit shapes are unchanged.
+
+PyTorch exposes numeric rather than string padding. Its general native formula
+is `(L - 1) * s - 2 * p + e + o`; `p=0` is canonical `VALID`. A numeric padding
+configuration is canonical `SAME` only when that equation equals `L * s + o`.
+Use a framework with asymmetric string padding when no such integer `p` exists.
+PyTorch can also accept `o >= s` when dilation is larger than the stride. NMN
+retains that native behavior for backward compatibility, but those configurations
+are outside the canonical contract and are not portable; use `0 <= o < s` for
+cross-framework models.
+
+## Example
+
+For `L=3`, `k=2`, `s=3`, `d=1`, and `o=0`, canonical `VALID` output length is
+`(3 - 1) * 3 + 2 = 8`. The legacy JAX/Keras/TensorFlow inferred length is 9.

--- a/src/nmn/_conv_transpose.py
+++ b/src/nmn/_conv_transpose.py
@@ -1,0 +1,123 @@
+"""Framework-independent transposed-convolution shape helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def _tuple(value: int | Sequence[int], rank: int, name: str) -> tuple[int, ...]:
+    if isinstance(value, int):
+        result = (value,) * rank
+    else:
+        result = tuple(int(item) for item in value)
+    if len(result) != rank:
+        raise ValueError(f"{name} must have {rank} values, got {result}")
+    return result
+
+
+def canonical_transpose_config(
+    kernel_size: int | Sequence[int],
+    strides: int | Sequence[int],
+    padding: str,
+    dilation_rate: int | Sequence[int] = 1,
+    output_padding: int | Sequence[int] = 0,
+) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], str, tuple[int, ...]]:
+    """Normalize and validate the canonical NMN transpose shape arguments."""
+    rank = 1 if isinstance(kernel_size, int) else len(tuple(kernel_size))
+    kernel = _tuple(kernel_size, rank, "kernel_size")
+    stride = _tuple(strides, rank, "strides")
+    dilation = _tuple(dilation_rate, rank, "dilation_rate")
+    extra = _tuple(output_padding, rank, "output_padding")
+    mode = padding.upper()
+    if mode not in {"SAME", "VALID"}:
+        raise ValueError(f"padding must be 'same' or 'valid', got {padding!r}")
+    for name, values in (
+        ("kernel_size", kernel),
+        ("strides", stride),
+        ("dilation_rate", dilation),
+    ):
+        if any(value <= 0 for value in values):
+            raise ValueError(f"{name} values must be positive, got {values}")
+    if any(value < 0 for value in extra):
+        raise ValueError(f"output_padding values must be nonnegative, got {extra}")
+    if any(value >= step for value, step in zip(extra, stride)):
+        raise ValueError(
+            "output_padding values must be smaller than the corresponding "
+            f"stride, got output_padding={extra}, strides={stride}"
+        )
+    return kernel, stride, dilation, mode, extra
+
+
+def canonical_transpose_output_spatial(
+    input_spatial: Sequence[int],
+    kernel_size: int | Sequence[int],
+    strides: int | Sequence[int],
+    padding: str,
+    dilation_rate: int | Sequence[int] = 1,
+    output_padding: int | Sequence[int] = 0,
+) -> tuple[int, ...]:
+    """Return spatial sizes under the canonical NMN transpose contract."""
+    kernel, stride, dilation, mode, extra = canonical_transpose_config(
+        kernel_size, strides, padding, dilation_rate, output_padding
+    )
+    spatial = tuple(int(value) for value in input_spatial)
+    if len(spatial) != len(kernel):
+        raise ValueError(f"input_spatial must have {len(kernel)} values, got {spatial}")
+    effective = tuple(d * (k - 1) + 1 for k, d in zip(kernel, dilation))
+    if mode == "SAME":
+        return tuple(
+            size * step + out for size, step, out in zip(spatial, stride, extra)
+        )
+    return tuple(
+        (size - 1) * step + width + out
+        for size, step, width, out in zip(spatial, stride, effective, extra)
+    )
+
+
+def canonical_jax_transpose_padding(
+    kernel_size: int | Sequence[int],
+    strides: int | Sequence[int],
+    padding: str,
+    dilation_rate: int | Sequence[int] = 1,
+    output_padding: int | Sequence[int] = 0,
+) -> tuple[tuple[int, int], ...]:
+    """Return explicit JAX padding pairs implementing the NMN contract."""
+    kernel, stride, dilation, mode, extra = canonical_transpose_config(
+        kernel_size, strides, padding, dilation_rate, output_padding
+    )
+    effective = tuple(d * (k - 1) + 1 for k, d in zip(kernel, dilation))
+    pairs = []
+    for width, step, out in zip(effective, stride, extra):
+        if mode == "VALID":
+            low = width - 1
+            high = width - 1 + out
+        else:
+            total = width + step - 2
+            low = width - 1 if step > width - 1 else (total + 1) // 2
+            high = total - low + out
+        pairs.append((low, high))
+    return tuple(pairs)
+
+
+def canonical_same_crop_or_pad(
+    kernel_size: int | Sequence[int],
+    strides: int | Sequence[int],
+    dilation_rate: int | Sequence[int] = 1,
+    output_padding: int | Sequence[int] = 0,
+) -> tuple[tuple[int, int], ...]:
+    """Return low/high crops (negative values are pads) from canonical VALID.
+
+    This lets backends without explicit asymmetric transpose padding implement
+    canonical ``SAME`` by evaluating ``VALID`` and then adjusting its borders.
+    """
+    kernel, _, dilation, _, _ = canonical_transpose_config(
+        kernel_size, strides, "SAME", dilation_rate, output_padding
+    )
+    same_padding = canonical_jax_transpose_padding(
+        kernel_size, strides, "SAME", dilation_rate, output_padding
+    )
+    effective = tuple(d * (k - 1) + 1 for k, d in zip(kernel, dilation))
+    return tuple(
+        (width - 1 - low, width - 1 - high)
+        for width, (low, high) in zip(effective, same_padding)
+    )

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -16,6 +16,10 @@ from keras.src.ops.operation_utils import compute_conv_output_shape
 from keras.src.saving.object_registration import register_keras_serializable
 from keras.src.saving.serialization_lib import deserialize_keras_object
 
+from nmn._conv_transpose import (
+    canonical_same_crop_or_pad,
+    canonical_transpose_output_spatial,
+)
 from nmn._epsilon import (
     epsilon_parameter_dtype,
     inverse_softplus,
@@ -181,6 +185,28 @@ def _conv_output_shape(layer, input_shape):
 
 
 def _conv_transpose_output_shape(layer, input_shape):
+    if getattr(layer, "output_shape_mode", "framework") == "nmn":
+        rank = len(layer.kernel_size)
+        channels_first = (layer.data_format or "channels_last") == "channels_first"
+        spatial = input_shape[2:] if channels_first else input_shape[1:-1]
+        output_spatial = []
+        for axis, size in enumerate(spatial):
+            if size is None:
+                output_spatial.append(None)
+            else:
+                output_spatial.append(
+                    canonical_transpose_output_spatial(
+                        (size,),
+                        (layer.kernel_size[axis],),
+                        (layer.strides[axis],),
+                        layer.padding,
+                        (layer.dilation_rate[axis],),
+                        (layer.output_padding or (0,) * rank)[axis],
+                    )[0]
+                )
+        if channels_first:
+            return (input_shape[0], layer.filters, *output_spatial)
+        return (input_shape[0], *output_spatial, layer.filters)
     return tuple(
         compute_conv_transpose_output_shape(
             input_shape,
@@ -193,6 +219,51 @@ def _conv_transpose_output_shape(layer, input_shape):
             dilation_rate=tuple(layer.dilation_rate),
         )
     )
+
+
+def _nmn_conv_transpose(layer, inputs, kernel):
+    """Run Keras transpose convolution with optional canonical NMN sizing."""
+    output_padding = layer.output_padding
+    canonical = getattr(layer, "output_shape_mode", "framework") == "nmn"
+    if canonical and layer.padding == "same":
+        padding = "valid"
+        output_padding = (0,) * len(layer.kernel_size)
+    elif canonical and output_padding is None:
+        padding = layer.padding
+        output_padding = (0,) * len(layer.kernel_size)
+    else:
+        padding = layer.padding
+    result = ops.conv_transpose(
+        inputs,
+        kernel,
+        strides=layer.strides,
+        padding=padding,
+        output_padding=output_padding,
+        data_format="channels_last",
+        dilation_rate=layer.dilation_rate,
+    )
+    if canonical and layer.padding == "same":
+        adjustments = canonical_same_crop_or_pad(
+            layer.kernel_size,
+            layer.strides,
+            layer.dilation_rate,
+            layer.output_padding or (0,) * len(layer.kernel_size),
+        )
+        slices = [slice(None)]
+        slices.extend(
+            slice(max(low, 0), -high if high > 0 else None)
+            for low, high in adjustments
+        )
+        slices.append(slice(None))
+        result = result[tuple(slices)]
+        border_padding = [(0, 0)]
+        border_padding.extend(
+            (max(-low, 0), max(-high, 0)) for low, high in adjustments
+        )
+        border_padding.append((0, 0))
+        if any(low or high for low, high in border_padding):
+            result = ops.pad(result, border_padding)
+    return result
 
 
 def _standardize_output_padding(output_padding, rank):
@@ -1340,6 +1411,8 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         dilation_rate: an integer or tuple/list of a single integer.
         output_padding: Optional integer or tuple/list of a single integer
             specifying the added output size along the spatial dimension.
+        output_shape_mode: `"framework"` preserves Keras-native inferred shapes;
+            `"nmn"` selects NMN's canonical cross-framework shape contract.
         use_bias: Boolean, whether the layer uses a bias vector.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to `True`.
         epsilon: Float, small constant for numerical stability.
@@ -1381,6 +1454,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         kernel_constraint=None,
         bias_constraint=None,
         output_padding=None,
+        output_shape_mode="framework",
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -1397,6 +1471,12 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             else (dilation_rate,)
         )
         self.output_padding = _standardize_output_padding(output_padding, 1)
+        if output_shape_mode not in {"framework", "nmn"}:
+            raise ValueError(
+                "output_shape_mode must be 'framework' or 'nmn', "
+                f"got {output_shape_mode!r}"
+            )
+        self.output_shape_mode = output_shape_mode
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
@@ -1526,15 +1606,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
             )
 
         # Compute transposed convolution (dot product)
-        dot_prod_map = ops.conv_transpose(
-            inputs,
-            kernel,
-            strides=self.strides,
-            padding=self.padding,
-            output_padding=self.output_padding,
-            data_format="channels_last",
-            dilation_rate=self.dilation_rate,
-        )
+        dot_prod_map = _nmn_conv_transpose(self, inputs, kernel)
 
         # Compute squared input for YAT distance
         inputs_squared = inputs * inputs
@@ -1543,14 +1615,8 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         ones_kernel_shape = tuple(self.kernel_size) + (1, self.input_dim)
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
-        patch_sq_sum_map_raw = ops.conv_transpose(
-            inputs_squared,
-            ones_kernel,
-            strides=self.strides,
-            padding=self.padding,
-            output_padding=self.output_padding,
-            data_format="channels_last",
-            dilation_rate=self.dilation_rate,
+        patch_sq_sum_map_raw = _nmn_conv_transpose(
+            self, inputs_squared, ones_kernel
         )
 
         patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
@@ -1585,6 +1651,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
                 "data_format": self.data_format,
                 "dilation_rate": self.dilation_rate,
                 "output_padding": self.output_padding,
+                "output_shape_mode": self.output_shape_mode,
                 "use_bias": self.use_bias,
                 "constant_bias": self.constant_bias,
                 "use_alpha": self.use_alpha,
@@ -1632,6 +1699,8 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         dilation_rate: an integer or tuple/list of 2 integers.
         output_padding: Optional integer or tuple/list of 2 integers specifying
             the added output size along each spatial dimension.
+        output_shape_mode: `"framework"` preserves Keras-native inferred shapes;
+            `"nmn"` selects NMN's canonical cross-framework shape contract.
         use_bias: Boolean, whether the layer uses a bias vector.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to `True`.
         epsilon: Float, small constant for numerical stability.
@@ -1673,6 +1742,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         kernel_constraint=None,
         bias_constraint=None,
         output_padding=None,
+        output_shape_mode="framework",
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -1693,6 +1763,12 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             else (dilation_rate, dilation_rate)
         )
         self.output_padding = _standardize_output_padding(output_padding, 2)
+        if output_shape_mode not in {"framework", "nmn"}:
+            raise ValueError(
+                "output_shape_mode must be 'framework' or 'nmn', "
+                f"got {output_shape_mode!r}"
+            )
+        self.output_shape_mode = output_shape_mode
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
@@ -1822,15 +1898,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
             )
 
         # Compute transposed convolution (dot product)
-        dot_prod_map = ops.conv_transpose(
-            inputs,
-            kernel,
-            strides=self.strides,
-            padding=self.padding,
-            output_padding=self.output_padding,
-            data_format="channels_last",
-            dilation_rate=self.dilation_rate,
-        )
+        dot_prod_map = _nmn_conv_transpose(self, inputs, kernel)
 
         # Compute squared input for YAT distance
         inputs_squared = inputs * inputs
@@ -1839,14 +1907,8 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         ones_kernel_shape = tuple(self.kernel_size) + (1, self.input_dim)
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
-        patch_sq_sum_map_raw = ops.conv_transpose(
-            inputs_squared,
-            ones_kernel,
-            strides=self.strides,
-            padding=self.padding,
-            output_padding=self.output_padding,
-            data_format="channels_last",
-            dilation_rate=self.dilation_rate,
+        patch_sq_sum_map_raw = _nmn_conv_transpose(
+            self, inputs_squared, ones_kernel
         )
 
         patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
@@ -1881,6 +1943,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
                 "data_format": self.data_format,
                 "dilation_rate": self.dilation_rate,
                 "output_padding": self.output_padding,
+                "output_shape_mode": self.output_shape_mode,
                 "use_bias": self.use_bias,
                 "constant_bias": self.constant_bias,
                 "use_alpha": self.use_alpha,
@@ -1928,6 +1991,8 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         dilation_rate: an integer or tuple/list of 3 integers.
         output_padding: Optional integer or tuple/list of 3 integers specifying
             the added output size along each spatial dimension.
+        output_shape_mode: `"framework"` preserves Keras-native inferred shapes;
+            `"nmn"` selects NMN's canonical cross-framework shape contract.
         use_bias: Boolean, whether the layer uses a bias vector.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to `True`.
         epsilon: Float, small constant for numerical stability.
@@ -1969,6 +2034,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         kernel_constraint=None,
         bias_constraint=None,
         output_padding=None,
+        output_shape_mode="framework",
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
@@ -1991,6 +2057,12 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             else (dilation_rate, dilation_rate, dilation_rate)
         )
         self.output_padding = _standardize_output_padding(output_padding, 3)
+        if output_shape_mode not in {"framework", "nmn"}:
+            raise ValueError(
+                "output_shape_mode must be 'framework' or 'nmn', "
+                f"got {output_shape_mode!r}"
+            )
+        self.output_shape_mode = output_shape_mode
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
@@ -2120,15 +2192,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
             )
 
         # Compute transposed convolution (dot product)
-        dot_prod_map = ops.conv_transpose(
-            inputs,
-            kernel,
-            strides=self.strides,
-            padding=self.padding,
-            output_padding=self.output_padding,
-            data_format="channels_last",
-            dilation_rate=self.dilation_rate,
-        )
+        dot_prod_map = _nmn_conv_transpose(self, inputs, kernel)
 
         # Compute squared input for YAT distance
         inputs_squared = inputs * inputs
@@ -2137,14 +2201,8 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         ones_kernel_shape = tuple(self.kernel_size) + (1, self.input_dim)
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
-        patch_sq_sum_map_raw = ops.conv_transpose(
-            inputs_squared,
-            ones_kernel,
-            strides=self.strides,
-            padding=self.padding,
-            output_padding=self.output_padding,
-            data_format="channels_last",
-            dilation_rate=self.dilation_rate,
+        patch_sq_sum_map_raw = _nmn_conv_transpose(
+            self, inputs_squared, ones_kernel
         )
 
         patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
@@ -2178,6 +2236,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
                 "data_format": self.data_format,
                 "dilation_rate": self.dilation_rate,
                 "output_padding": self.output_padding,
+                "output_shape_mode": self.output_shape_mode,
                 "use_bias": self.use_bias,
                 "constant_bias": self.constant_bias,
                 "use_alpha": self.use_alpha,

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -189,7 +189,7 @@ def _conv_transpose_output_shape(layer, input_shape):
         rank = len(layer.kernel_size)
         channels_first = (layer.data_format or "channels_last") == "channels_first"
         spatial = input_shape[2:] if channels_first else input_shape[1:-1]
-        output_spatial = []
+        output_spatial: list[int | None] = []
         for axis, size in enumerate(spatial):
             if size is None:
                 output_spatial.append(None)

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -251,8 +251,7 @@ def _nmn_conv_transpose(layer, inputs, kernel):
         )
         slices = [slice(None)]
         slices.extend(
-            slice(max(low, 0), -high if high > 0 else None)
-            for low, high in adjustments
+            slice(max(low, 0), -high if high > 0 else None) for low, high in adjustments
         )
         slices.append(slice(None))
         result = result[tuple(slices)]
@@ -1615,9 +1614,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         ones_kernel_shape = tuple(self.kernel_size) + (1, self.input_dim)
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
-        patch_sq_sum_map_raw = _nmn_conv_transpose(
-            self, inputs_squared, ones_kernel
-        )
+        patch_sq_sum_map_raw = _nmn_conv_transpose(self, inputs_squared, ones_kernel)
 
         patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
@@ -1907,9 +1904,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         ones_kernel_shape = tuple(self.kernel_size) + (1, self.input_dim)
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
-        patch_sq_sum_map_raw = _nmn_conv_transpose(
-            self, inputs_squared, ones_kernel
-        )
+        patch_sq_sum_map_raw = _nmn_conv_transpose(self, inputs_squared, ones_kernel)
 
         patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 
@@ -2201,9 +2196,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         ones_kernel_shape = tuple(self.kernel_size) + (1, self.input_dim)
         ones_kernel = ops.ones(ones_kernel_shape, dtype=kernel.dtype)
 
-        patch_sq_sum_map_raw = _nmn_conv_transpose(
-            self, inputs_squared, ones_kernel
-        )
+        patch_sq_sum_map_raw = _nmn_conv_transpose(self, inputs_squared, ones_kernel)
 
         patch_sq_sum_map = ops.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
 

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -10,6 +10,7 @@ from flax.linen import Module, compact
 from flax.linen.dtypes import promote_dtype
 from flax.linen.initializers import zeros_init
 
+from nmn._conv_transpose import canonical_jax_transpose_padding
 from nmn._epsilon import (
     epsilon_parameter_dtype,
     inverse_softplus,
@@ -552,6 +553,9 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
         kernel_size: Size of the convolving kernel as a tuple (length,).
         strides: Stride of the transposed convolution. Default (1,).
         padding: Padding algorithm. Either 'VALID' or 'SAME'.
+        kernel_dilation: Dilation factor for the kernel. Default (1,).
+        output_padding: Optional high-side extension. Explicit zero selects the
+            canonical NMN output-shape contract; None preserves JAX sizing.
         use_bias: Whether to add a bias. Default True.
         use_alpha: Whether to use alpha scaling. Default True.
         dtype: The dtype of the computation.
@@ -575,6 +579,8 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
     alpha_init: Any = lambda key, shape, dtype: jnp.ones(shape, dtype)
     epsilon: float = 1e-5
     learnable_epsilon: bool = False
+    kernel_dilation: Sequence[int] = (1,)
+    output_padding: Optional[Union[int, Sequence[int]]] = None
 
     @compact
     def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
@@ -636,11 +642,26 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
             inputs.shape, kernel.shape, ("NWC", "WIO", "NWC")
         )
 
+        transpose_padding = self.padding
+        if self.output_padding is not None:
+            if not isinstance(self.padding, str):
+                raise ValueError(
+                    "output_padding requires padding to be 'SAME' or 'VALID'"
+                )
+            transpose_padding = canonical_jax_transpose_padding(
+                self.kernel_size,
+                self.strides,
+                self.padding,
+                self.kernel_dilation,
+                self.output_padding,
+            )
+
         dot_prod_map = lax.conv_transpose(
             inputs,
             kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=transpose_padding,
+            rhs_dilation=self.kernel_dilation,
             dimension_numbers=dn,
         )
 
@@ -653,7 +674,8 @@ class YatConvTranspose1D(_EpsilonValidatedModule):
             inputs_squared,
             ones_kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=transpose_padding,
+            rhs_dilation=self.kernel_dilation,
             dimension_numbers=dn,
         )
 
@@ -687,6 +709,9 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
         kernel_size: Size of the convolving kernel as a tuple (height, width).
         strides: Stride of the transposed convolution. Default (1, 1).
         padding: Padding algorithm. Either 'VALID' or 'SAME'.
+        kernel_dilation: Dilation factors for the kernel. Default (1, 1).
+        output_padding: Optional high-side extensions. Explicit zero selects the
+            canonical NMN output-shape contract; None preserves JAX sizing.
         use_bias: Whether to add a bias. Default True.
         use_alpha: Whether to use alpha scaling. Default True.
         dtype: The dtype of the computation.
@@ -710,6 +735,8 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
     alpha_init: Any = lambda key, shape, dtype: jnp.ones(shape, dtype)
     epsilon: float = 1e-5
     learnable_epsilon: bool = False
+    kernel_dilation: Sequence[int] = (1, 1)
+    output_padding: Optional[Union[int, Sequence[int]]] = None
 
     @compact
     def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
@@ -771,11 +798,26 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
             inputs.shape, kernel.shape, ("NHWC", "HWIO", "NHWC")
         )
 
+        transpose_padding = self.padding
+        if self.output_padding is not None:
+            if not isinstance(self.padding, str):
+                raise ValueError(
+                    "output_padding requires padding to be 'SAME' or 'VALID'"
+                )
+            transpose_padding = canonical_jax_transpose_padding(
+                self.kernel_size,
+                self.strides,
+                self.padding,
+                self.kernel_dilation,
+                self.output_padding,
+            )
+
         dot_prod_map = lax.conv_transpose(
             inputs,
             kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=transpose_padding,
+            rhs_dilation=self.kernel_dilation,
             dimension_numbers=dn,
         )
 
@@ -788,7 +830,8 @@ class YatConvTranspose2D(_EpsilonValidatedModule):
             inputs_squared,
             ones_kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=transpose_padding,
+            rhs_dilation=self.kernel_dilation,
             dimension_numbers=dn,
         )
 
@@ -822,6 +865,9 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
         kernel_size: Size of the convolving kernel as a tuple (depth, height, width).
         strides: Stride of the transposed convolution. Default (1, 1, 1).
         padding: Padding algorithm. Either 'VALID' or 'SAME'.
+        kernel_dilation: Dilation factors for the kernel. Default (1, 1, 1).
+        output_padding: Optional high-side extensions. Explicit zero selects the
+            canonical NMN output-shape contract; None preserves JAX sizing.
         use_bias: Whether to add a bias. Default True.
         use_alpha: Whether to use alpha scaling. Default True.
         dtype: The dtype of the computation.
@@ -845,6 +891,8 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
     alpha_init: Any = lambda key, shape, dtype: jnp.ones(shape, dtype)
     epsilon: float = 1e-5
     learnable_epsilon: bool = False
+    kernel_dilation: Sequence[int] = (1, 1, 1)
+    output_padding: Optional[Union[int, Sequence[int]]] = None
 
     @compact
     def __call__(self, inputs: jnp.ndarray) -> jnp.ndarray:
@@ -906,11 +954,26 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
             inputs.shape, kernel.shape, ("NDHWC", "DHWIO", "NDHWC")
         )
 
+        transpose_padding = self.padding
+        if self.output_padding is not None:
+            if not isinstance(self.padding, str):
+                raise ValueError(
+                    "output_padding requires padding to be 'SAME' or 'VALID'"
+                )
+            transpose_padding = canonical_jax_transpose_padding(
+                self.kernel_size,
+                self.strides,
+                self.padding,
+                self.kernel_dilation,
+                self.output_padding,
+            )
+
         dot_prod_map = lax.conv_transpose(
             inputs,
             kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=transpose_padding,
+            rhs_dilation=self.kernel_dilation,
             dimension_numbers=dn,
         )
 
@@ -923,7 +986,8 @@ class YatConvTranspose3D(_EpsilonValidatedModule):
             inputs_squared,
             ones_kernel,
             strides=self.strides,
-            padding=self.padding,
+            padding=transpose_padding,
+            rhs_dilation=self.kernel_dilation,
             dimension_numbers=dn,
         )
 

--- a/src/nmn/nnx/layers/conv/yat_conv_transpose.py
+++ b/src/nmn/nnx/layers/conv/yat_conv_transpose.py
@@ -27,6 +27,8 @@ from flax.typing import (
 )
 from jax import lax
 
+from nmn._conv_transpose import canonical_jax_transpose_padding
+
 from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 from .utils import (
     DEFAULT_CONSTANT_ALPHA,
@@ -73,6 +75,8 @@ class YatConvTranspose(Module):
         strides: Inter-window strides (default: 1).
         padding: 'SAME', 'VALID', 'CIRCULAR', or sequence of (low, high) pairs.
         kernel_dilation: Dilation factor for kernel (default: 1).
+        output_padding: Optional high-side output extension. Passing it explicitly,
+            including zero, selects the canonical NMN output-shape contract.
         use_bias: Whether to add a bias (default: True).
         constant_bias: If a float, use that value as a fixed (non-learnable)
             bias constant. If None (default), use learnable bias.
@@ -112,6 +116,7 @@ class YatConvTranspose(Module):
         *,
         padding: PaddingLike = "SAME",
         kernel_dilation: int | tp.Sequence[int] | None = None,
+        output_padding: int | tp.Sequence[int] | None = None,
         use_bias: bool = True,
         constant_bias: tp.Optional[float] = None,
         softplus_bias: bool = False,
@@ -150,6 +155,7 @@ class YatConvTranspose(Module):
         self.strides = strides
         self.padding = padding
         self.kernel_dilation = kernel_dilation
+        self.output_padding = output_padding
         self.use_dropconnect = use_dropconnect
         self.mask = mask
         self.dtype = dtype
@@ -262,6 +268,18 @@ class YatConvTranspose(Module):
         padding_lax = canonicalize_padding(self.padding, len(self.kernel_size))
         if padding_lax == "CIRCULAR":
             padding_lax = "VALID"
+        if self.output_padding is not None:
+            if not isinstance(padding_lax, str):
+                raise ValueError(
+                    "output_padding requires padding to be 'SAME' or 'VALID'"
+                )
+            padding_lax = canonical_jax_transpose_padding(
+                self.kernel_size,
+                strides,
+                padding_lax,
+                kernel_dilation,
+                self.output_padding,
+            )
 
         kernel_val = self.kernel[...]
 

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -98,9 +98,7 @@ def _adjust_transpose_same(value, adjustments):
     size.append(shape[-1])
     value = tf.slice(value, begin, size)
     paddings = [[0, 0]]
-    paddings.extend(
-        [[max(-low, 0), max(-high, 0)] for low, high in adjustments]
-    )
+    paddings.extend([[max(-low, 0), max(-high, 0)] for low, high in adjustments])
     paddings.append([0, 0])
     return tf.pad(value, paddings)
 

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -4,6 +4,10 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 
 import tensorflow as tf
 
+from nmn._conv_transpose import (
+    canonical_same_crop_or_pad,
+    canonical_transpose_config,
+)
 from nmn._epsilon import (
     epsilon_parameter_dtype,
     inverse_softplus,
@@ -63,6 +67,42 @@ def _upcast_yat_operands(inputs, kernel):
     if inputs.dtype in (tf.float16, tf.bfloat16):
         return reduction_safe_upcast(inputs), reduction_safe_upcast(kernel)
     return inputs, kernel
+
+
+def _transpose_output_length(
+    input_length, kernel_size, stride, padding, dilation, output_padding
+):
+    """TensorFlow-compatible implementation of the documented shape contract."""
+    effective_kernel = dilation * (kernel_size - 1) + 1
+    if output_padding is None:
+        if padding == "SAME":
+            return input_length * stride
+        return input_length * stride + max(effective_kernel - stride, 0)
+    if padding == "SAME":
+        return input_length * stride + output_padding
+    return (input_length - 1) * stride + effective_kernel + output_padding
+
+
+def _adjust_transpose_same(value, adjustments):
+    if adjustments is None:
+        return value
+    shape = tf.shape(value)
+    begin = [0]
+    begin.extend(max(low, 0) for low, _ in adjustments)
+    begin.append(0)
+    size = [shape[0]]
+    size.extend(
+        shape[axis] - max(low, 0) - max(high, 0)
+        for axis, (low, high) in enumerate(adjustments, start=1)
+    )
+    size.append(shape[-1])
+    value = tf.slice(value, begin, size)
+    paddings = [[0, 0]]
+    paddings.extend(
+        [[max(-low, 0), max(-high, 0)] for low, high in adjustments]
+    )
+    paddings.append([0, 0])
+    return tf.pad(value, paddings)
 
 
 class YatConv1D(SingleInputSavedModelMixin, tf.Module):
@@ -692,6 +732,9 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         kernel_size: Integer, specifying the length of the 1D convolution window.
         strides: Integer, specifying the stride length. Defaults to 1.
         padding: String, either "valid" or "same". Defaults to "same".
+        dilation_rate: Kernel dilation. Defaults to 1.
+        output_padding: Optional high-side extension. Passing it explicitly,
+            including zero, selects the canonical NMN output-shape contract.
         use_bias: Boolean, whether to add a bias to the output. Defaults to True.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to True.
         epsilon: Float, small constant for numerical stability. Defaults to 1e-6.
@@ -718,12 +761,21 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         learnable_epsilon: bool = False,
         dtype: tf.DType = tf.float32,
         name: Optional[str] = None,
+        *,
+        dilation_rate: int = 1,
+        output_padding: Optional[int] = None,
     ):
         super().__init__(name=name)
         self.filters = filters
         self.kernel_size = kernel_size
         self.strides = strides
         self.padding = padding.upper()
+        self.dilation_rate = dilation_rate
+        self.output_padding = output_padding
+        if output_padding is not None:
+            canonical_transpose_config(
+                kernel_size, strides, self.padding, dilation_rate, output_padding
+            )
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
@@ -817,18 +869,43 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         strides = self.strides
         kernel_size = self.kernel_size
 
-        if self.padding == "SAME":
-            output_length = input_length * strides
-        else:
-            output_length = input_length * strides + tf.maximum(
-                kernel_size - strides, 0
+        output_length = _transpose_output_length(
+            input_length,
+            kernel_size,
+            strides,
+            self.padding,
+            self.dilation_rate,
+            self.output_padding,
+        )
+        same_adjustments = (
+            canonical_same_crop_or_pad(
+                kernel_size,
+                strides,
+                self.dilation_rate,
+                self.output_padding,
             )
+            if self.padding == "SAME" and self.output_padding is not None
+            else None
+        )
+        native_output_length = (
+            _transpose_output_length(
+                input_length,
+                kernel_size,
+                strides,
+                "VALID",
+                self.dilation_rate,
+                0,
+            )
+            if same_adjustments
+            else output_length
+        )
+        native_padding = "VALID" if same_adjustments else self.padding
 
         # Build output shape as a 1D tensor
         output_shape = tf.concat(
             [
                 tf.reshape(batch_size, [1]),
-                tf.reshape(output_length, [1]),
+                tf.reshape(native_output_length, [1]),
                 tf.constant([self.filters], dtype=tf.int32),
             ],
             axis=0,
@@ -837,7 +914,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         output_shape_ones = tf.concat(
             [
                 tf.reshape(batch_size, [1]),
-                tf.reshape(output_length, [1]),
+                tf.reshape(native_output_length, [1]),
                 tf.constant([1], dtype=tf.int32),
             ],
             axis=0,
@@ -849,7 +926,8 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
             kernel,
             output_shape=output_shape,
             strides=strides,
-            padding=self.padding,
+            padding=native_padding,
+            dilations=self.dilation_rate,
         )
 
         # For transpose conv, compute YAT distance calculation
@@ -864,7 +942,12 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
             ones_kernel,
             output_shape=output_shape_ones,
             strides=strides,
-            padding=self.padding,
+            padding=native_padding,
+            dilations=self.dilation_rate,
+        )
+        dot_prod_map = _adjust_transpose_same(dot_prod_map, same_adjustments)
+        patch_sq_sum_map_raw = _adjust_transpose_same(
+            patch_sq_sum_map_raw, same_adjustments
         )
 
         patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
@@ -888,6 +971,9 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         kernel_size: Integer or tuple of 2 integers for kernel dimensions.
         strides: Integer or tuple of 2 integers. Defaults to (1, 1).
         padding: String, either "valid" or "same". Defaults to "same".
+        dilation_rate: Kernel dilation. Defaults to (1, 1).
+        output_padding: Optional high-side extensions. Passing it explicitly,
+            including zero, selects the canonical NMN output-shape contract.
         use_bias: Boolean, whether to add a bias to the output. Defaults to True.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to True.
         epsilon: Float, small constant for numerical stability. Defaults to 1e-6.
@@ -914,6 +1000,9 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         learnable_epsilon: bool = False,
         dtype: tf.DType = tf.float32,
         name: Optional[str] = None,
+        *,
+        dilation_rate: Union[int, Tuple[int, int]] = (1, 1),
+        output_padding: Optional[Union[int, Tuple[int, int]]] = None,
     ):
         super().__init__(name=name)
         self.filters = filters
@@ -926,6 +1015,28 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
             strides if isinstance(strides, (list, tuple)) else (strides, strides)
         )
         self.padding = padding.upper()
+        self.dilation_rate = (
+            dilation_rate
+            if isinstance(dilation_rate, (list, tuple))
+            else (dilation_rate, dilation_rate)
+        )
+        self.output_padding = (
+            None
+            if output_padding is None
+            else (
+                tuple(output_padding)
+                if isinstance(output_padding, (list, tuple))
+                else (output_padding, output_padding)
+            )
+        )
+        if self.output_padding is not None:
+            canonical_transpose_config(
+                self.kernel_size,
+                self.strides,
+                self.padding,
+                self.dilation_rate,
+                self.output_padding,
+            )
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
@@ -1014,19 +1125,65 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         input_height = tf.shape(inputs)[1]
         input_width = tf.shape(inputs)[2]
 
-        # Calculate output shape
-        if self.padding == "SAME":
-            output_height = input_height * self.strides[0]
-            output_width = input_width * self.strides[1]
-        else:
-            output_height = input_height * self.strides[0] + max(
-                self.kernel_size[0] - self.strides[0], 0
-            )
-            output_width = input_width * self.strides[1] + max(
-                self.kernel_size[1] - self.strides[1], 0
-            )
+        output_height = _transpose_output_length(
+            input_height,
+            self.kernel_size[0],
+            self.strides[0],
+            self.padding,
+            self.dilation_rate[0],
+            None if self.output_padding is None else self.output_padding[0],
+        )
+        output_width = _transpose_output_length(
+            input_width,
+            self.kernel_size[1],
+            self.strides[1],
+            self.padding,
+            self.dilation_rate[1],
+            None if self.output_padding is None else self.output_padding[1],
+        )
 
-        output_shape = [batch_size, output_height, output_width, self.filters]
+        same_adjustments = (
+            canonical_same_crop_or_pad(
+                self.kernel_size,
+                self.strides,
+                self.dilation_rate,
+                self.output_padding,
+            )
+            if self.padding == "SAME" and self.output_padding is not None
+            else None
+        )
+        native_output_height = (
+            _transpose_output_length(
+                input_height,
+                self.kernel_size[0],
+                self.strides[0],
+                "VALID",
+                self.dilation_rate[0],
+                0,
+            )
+            if same_adjustments
+            else output_height
+        )
+        native_output_width = (
+            _transpose_output_length(
+                input_width,
+                self.kernel_size[1],
+                self.strides[1],
+                "VALID",
+                self.dilation_rate[1],
+                0,
+            )
+            if same_adjustments
+            else output_width
+        )
+        native_padding = "VALID" if same_adjustments else self.padding
+
+        output_shape = [
+            batch_size,
+            native_output_height,
+            native_output_width,
+            self.filters,
+        ]
 
         # Transpose convolution
         dot_prod_map = tf.nn.conv2d_transpose(
@@ -1034,7 +1191,8 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
             kernel,
             output_shape=output_shape,
             strides=[1] + list(self.strides) + [1],
-            padding=self.padding,
+            padding=native_padding,
+            dilations=[1] + list(self.dilation_rate) + [1],
         )
 
         # For transpose conv, compute YAT distance calculation
@@ -1047,9 +1205,14 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         patch_sq_sum_map_raw = tf.nn.conv2d_transpose(
             inputs_squared,
             ones_kernel,
-            output_shape=[batch_size, output_height, output_width, 1],
+            output_shape=[batch_size, native_output_height, native_output_width, 1],
             strides=[1] + list(self.strides) + [1],
-            padding=self.padding,
+            padding=native_padding,
+            dilations=[1] + list(self.dilation_rate) + [1],
+        )
+        dot_prod_map = _adjust_transpose_same(dot_prod_map, same_adjustments)
+        patch_sq_sum_map_raw = _adjust_transpose_same(
+            patch_sq_sum_map_raw, same_adjustments
         )
 
         patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)
@@ -1073,6 +1236,9 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         kernel_size: Integer or tuple of 3 integers for kernel dimensions.
         strides: Integer or tuple of 3 integers. Defaults to (1, 1, 1).
         padding: String, either "valid" or "same". Defaults to "same".
+        dilation_rate: Kernel dilation. Defaults to (1, 1, 1).
+        output_padding: Optional high-side extensions. Passing it explicitly,
+            including zero, selects the canonical NMN output-shape contract.
         use_bias: Boolean, whether to add a bias to the output. Defaults to True.
         use_alpha: Boolean, whether to use alpha scaling. Defaults to True.
         epsilon: Float, small constant for numerical stability. Defaults to 1e-6.
@@ -1099,6 +1265,9 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         learnable_epsilon: bool = False,
         dtype: tf.DType = tf.float32,
         name: Optional[str] = None,
+        *,
+        dilation_rate: Union[int, Tuple[int, int, int]] = (1, 1, 1),
+        output_padding: Optional[Union[int, Tuple[int, int, int]]] = None,
     ):
         super().__init__(name=name)
         self.filters = filters
@@ -1113,6 +1282,28 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
             else (strides, strides, strides)
         )
         self.padding = padding.upper()
+        self.dilation_rate = (
+            dilation_rate
+            if isinstance(dilation_rate, (list, tuple))
+            else (dilation_rate, dilation_rate, dilation_rate)
+        )
+        self.output_padding = (
+            None
+            if output_padding is None
+            else (
+                tuple(output_padding)
+                if isinstance(output_padding, (list, tuple))
+                else (output_padding, output_padding, output_padding)
+            )
+        )
+        if self.output_padding is not None:
+            canonical_transpose_config(
+                self.kernel_size,
+                self.strides,
+                self.padding,
+                self.dilation_rate,
+                self.output_padding,
+            )
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
@@ -1209,27 +1400,84 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         input_height = tf.shape(inputs)[2]
         input_width = tf.shape(inputs)[3]
 
-        # Calculate output shape
-        if self.padding == "SAME":
-            output_depth = input_depth * self.strides[0]
-            output_height = input_height * self.strides[1]
-            output_width = input_width * self.strides[2]
-        else:
-            output_depth = input_depth * self.strides[0] + max(
-                self.kernel_size[0] - self.strides[0], 0
+        output_depth = _transpose_output_length(
+            input_depth,
+            self.kernel_size[0],
+            self.strides[0],
+            self.padding,
+            self.dilation_rate[0],
+            None if self.output_padding is None else self.output_padding[0],
+        )
+        output_height = _transpose_output_length(
+            input_height,
+            self.kernel_size[1],
+            self.strides[1],
+            self.padding,
+            self.dilation_rate[1],
+            None if self.output_padding is None else self.output_padding[1],
+        )
+        output_width = _transpose_output_length(
+            input_width,
+            self.kernel_size[2],
+            self.strides[2],
+            self.padding,
+            self.dilation_rate[2],
+            None if self.output_padding is None else self.output_padding[2],
+        )
+
+        same_adjustments = (
+            canonical_same_crop_or_pad(
+                self.kernel_size,
+                self.strides,
+                self.dilation_rate,
+                self.output_padding,
             )
-            output_height = input_height * self.strides[1] + max(
-                self.kernel_size[1] - self.strides[1], 0
+            if self.padding == "SAME" and self.output_padding is not None
+            else None
+        )
+        native_output_depth = (
+            _transpose_output_length(
+                input_depth,
+                self.kernel_size[0],
+                self.strides[0],
+                "VALID",
+                self.dilation_rate[0],
+                0,
             )
-            output_width = input_width * self.strides[2] + max(
-                self.kernel_size[2] - self.strides[2], 0
+            if same_adjustments
+            else output_depth
+        )
+        native_output_height = (
+            _transpose_output_length(
+                input_height,
+                self.kernel_size[1],
+                self.strides[1],
+                "VALID",
+                self.dilation_rate[1],
+                0,
             )
+            if same_adjustments
+            else output_height
+        )
+        native_output_width = (
+            _transpose_output_length(
+                input_width,
+                self.kernel_size[2],
+                self.strides[2],
+                "VALID",
+                self.dilation_rate[2],
+                0,
+            )
+            if same_adjustments
+            else output_width
+        )
+        native_padding = "VALID" if same_adjustments else self.padding
 
         output_shape = [
             batch_size,
-            output_depth,
-            output_height,
-            output_width,
+            native_output_depth,
+            native_output_height,
+            native_output_width,
             self.filters,
         ]
 
@@ -1239,7 +1487,8 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
             kernel,
             output_shape=output_shape,
             strides=[1] + list(self.strides) + [1],
-            padding=self.padding,
+            padding=native_padding,
+            dilations=[1] + list(self.dilation_rate) + [1],
         )
 
         # For transpose conv, compute YAT distance calculation
@@ -1252,9 +1501,20 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         patch_sq_sum_map_raw = tf.nn.conv3d_transpose(
             inputs_squared,
             ones_kernel,
-            output_shape=[batch_size, output_depth, output_height, output_width, 1],
+            output_shape=[
+                batch_size,
+                native_output_depth,
+                native_output_height,
+                native_output_width,
+                1,
+            ],
             strides=[1] + list(self.strides) + [1],
-            padding=self.padding,
+            padding=native_padding,
+            dilations=[1] + list(self.dilation_rate) + [1],
+        )
+        dot_prod_map = _adjust_transpose_same(dot_prod_map, same_adjustments)
+        patch_sq_sum_map_raw = _adjust_transpose_same(
+            patch_sq_sum_map_raw, same_adjustments
         )
 
         patch_sq_sum_map = tf.repeat(patch_sq_sum_map_raw, self.filters, axis=-1)

--- a/tests/integration/test_conv_transpose_shape_contract.py
+++ b/tests/integration/test_conv_transpose_shape_contract.py
@@ -1,0 +1,296 @@
+"""Runnable cross-framework tests for canonical ConvTranspose sizing."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+from flax import nnx
+
+from nmn.linen import (
+    YatConvTranspose1D as LinenTranspose1D,
+    YatConvTranspose2D as LinenTranspose2D,
+    YatConvTranspose3D as LinenTranspose3D,
+)
+from nmn.nnx import YatConvTranspose as NnxTranspose
+from nmn.torch import (
+    YatConvTranspose1D as TorchTranspose1D,
+    YatConvTranspose2D as TorchTranspose2D,
+    YatConvTranspose3D as TorchTranspose3D,
+)
+
+
+CASES = [
+    (
+        LinenTranspose1D,
+        TorchTranspose1D,
+        (1, 3, 1),
+        (2,),
+        (3,),
+        (1,),
+        (0,),
+        (1, 8, 1),
+    ),
+    (
+        LinenTranspose2D,
+        TorchTranspose2D,
+        (1, 2, 3, 1),
+        (2, 3),
+        (3, 2),
+        (1, 2),
+        (1, 0),
+        (1, 6, 9, 1),
+    ),
+    (
+        LinenTranspose3D,
+        TorchTranspose3D,
+        (1, 2, 2, 2, 1),
+        (2, 3, 2),
+        (3, 2, 4),
+        (1, 2, 1),
+        (0, 1, 2),
+        (1, 5, 8, 8, 1),
+    ),
+]
+
+
+def _channels_first(value):
+    return np.transpose(value, (0, value.ndim - 1, *range(1, value.ndim - 1)))
+
+
+def _channels_last(value):
+    return np.transpose(value, (0, *range(2, value.ndim), 1))
+
+
+def test_jax_implicit_legacy_shape_is_preserved_until_output_padding_is_explicit():
+    inputs = jnp.ones((1, 3, 1), dtype=jnp.float32)
+    linen_legacy = LinenTranspose1D(
+        1, (2,), strides=(3,), padding="VALID", use_bias=False, use_alpha=False
+    )
+    linen_canonical = LinenTranspose1D(
+        1,
+        (2,),
+        strides=(3,),
+        padding="VALID",
+        output_padding=0,
+        use_bias=False,
+        use_alpha=False,
+    )
+    legacy_variables = linen_legacy.init(jax.random.key(0), inputs)
+    canonical_variables = linen_canonical.init(jax.random.key(0), inputs)
+    assert linen_legacy.apply(legacy_variables, inputs).shape == (1, 9, 1)
+    assert linen_canonical.apply(canonical_variables, inputs).shape == (1, 8, 1)
+
+    nnx_legacy = NnxTranspose(
+        1,
+        1,
+        (2,),
+        (3,),
+        padding="VALID",
+        use_bias=False,
+        use_alpha=False,
+        rngs=nnx.Rngs(0),
+    )
+    nnx_canonical = NnxTranspose(
+        1,
+        1,
+        (2,),
+        (3,),
+        padding="VALID",
+        output_padding=0,
+        use_bias=False,
+        use_alpha=False,
+        rngs=nnx.Rngs(0),
+    )
+    assert nnx_legacy(inputs).shape == (1, 9, 1)
+    assert nnx_canonical(inputs).shape == (1, 8, 1)
+
+
+def test_linen_nnx_canonical_same_output_and_gradient_parity_under_jit():
+    inputs = jnp.asarray([[[-0.5], [0.25], [0.75]]], dtype=jnp.float32)
+    kernel = jnp.asarray([[[-0.4]], [[0.6]]], dtype=jnp.float32)
+    cotangent = jnp.linspace(0.2, 1.1, 10, dtype=jnp.float32).reshape(1, 10, 1)
+
+    linen = LinenTranspose1D(
+        features=1,
+        kernel_size=(2,),
+        strides=(3,),
+        padding="SAME",
+        output_padding=1,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    linen_apply = jax.jit(
+        lambda x, w: linen.apply({"params": {"kernel": w}}, x)
+    )
+
+    nnx_layer = NnxTranspose(
+        1,
+        1,
+        (2,),
+        (3,),
+        padding="SAME",
+        output_padding=1,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+        rngs=nnx.Rngs(0),
+    )
+    nnx_layer.kernel[...] = kernel
+    nnx_apply = jax.jit(lambda x: nnx_layer(x))
+
+    linen_output = linen_apply(inputs, kernel)
+    nnx_output = nnx_apply(inputs)
+    linen_input_grad, linen_kernel_grad = jax.grad(
+        lambda x, w: jnp.sum(linen_apply(x, w) * cotangent), argnums=(0, 1)
+    )(inputs, kernel)
+    nnx_input_grad = jax.grad(
+        lambda x: jnp.sum(nnx_apply(x) * cotangent)
+    )(inputs)
+    _, nnx_grads = nnx.value_and_grad(
+        lambda model: jnp.sum(model(inputs) * cotangent)
+    )(nnx_layer)
+
+    assert linen_output.shape == nnx_output.shape == (1, 10, 1)
+    np.testing.assert_allclose(linen_output, nnx_output, rtol=2e-5, atol=2e-6)
+    np.testing.assert_allclose(
+        linen_input_grad, nnx_input_grad, rtol=2e-5, atol=2e-6
+    )
+    np.testing.assert_allclose(
+        linen_kernel_grad, nnx_grads.kernel[...], rtol=2e-5, atol=2e-6
+    )
+
+
+@pytest.mark.parametrize(
+    "linen_cls,torch_cls,input_shape,kernel_shape,strides,dilation,"
+    "output_padding,expected",
+    CASES,
+)
+def test_torch_linen_nnx_canonical_valid_output_and_gradient_parity(
+    linen_cls,
+    torch_cls,
+    input_shape,
+    kernel_shape,
+    strides,
+    dilation,
+    output_padding,
+    expected,
+):
+    rank = len(kernel_shape)
+    input_values = np.linspace(
+        -0.7, 0.9, np.prod(input_shape), dtype=np.float32
+    ).reshape(input_shape)
+    kernel = np.linspace(
+        -0.4, 0.6, np.prod(kernel_shape), dtype=np.float32
+    ).reshape((*kernel_shape, 1, 1))
+
+    linen = linen_cls(
+        features=1,
+        kernel_size=kernel_shape,
+        strides=strides,
+        padding="VALID",
+        kernel_dilation=dilation,
+        output_padding=output_padding,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    variables = linen.init(jax.random.key(0), jnp.asarray(input_values))
+    variables["params"]["kernel"] = jnp.asarray(kernel)
+    linen_apply = jax.jit(lambda x, w: linen.apply({"params": {"kernel": w}}, x))
+
+    nnx_layer = NnxTranspose(
+        1,
+        1,
+        kernel_shape,
+        strides,
+        padding="VALID",
+        kernel_dilation=dilation,
+        output_padding=output_padding,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+        rngs=nnx.Rngs(0),
+    )
+    nnx_layer.kernel[...] = jnp.asarray(kernel)
+
+    torch_layer = torch_cls(
+        1,
+        1,
+        kernel_shape,
+        stride=strides,
+        padding=0,
+        output_padding=output_padding,
+        dilation=dilation,
+        bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    # JAX's ``conv_transpose`` uses the forward-correlation kernel convention;
+    # PyTorch stores the mathematically transposed (spatially reversed) kernel.
+    torch_kernel = np.transpose(
+        np.flip(kernel, axis=tuple(range(rank))),
+        (rank, rank + 1, *range(rank)),
+    ).copy()
+    with torch.no_grad():
+        torch_layer.weight.copy_(torch.from_numpy(torch_kernel))
+
+    linen_x = jnp.asarray(input_values)
+    linen_w = jnp.asarray(kernel)
+    linen_output = linen_apply(linen_x, linen_w)
+    nnx_output = jax.jit(lambda value: nnx_layer(value))(linen_x)
+    torch_x = torch.tensor(_channels_first(input_values), requires_grad=True)
+    torch_output_cf = torch_layer(torch_x)
+    torch_output = _channels_last(torch_output_cf.detach().numpy())
+    assert linen_output.shape == nnx_output.shape == torch_output.shape == expected
+
+    cotangent = np.linspace(
+        0.2, 1.0, np.prod(expected), dtype=np.float32
+    ).reshape(expected)
+    linen_input_grad, linen_kernel_grad = jax.grad(
+        lambda x, w: jnp.sum(linen_apply(x, w) * cotangent), argnums=(0, 1)
+    )(linen_x, linen_w)
+    nnx_input_grad = jax.grad(
+        lambda value: jnp.sum(nnx_layer(value) * cotangent)
+    )(linen_x)
+    _, nnx_grads = nnx.value_and_grad(
+        lambda model: jnp.sum(model(linen_x) * cotangent)
+    )(nnx_layer)
+    (torch_output_cf * torch.tensor(_channels_first(cotangent))).sum().backward()
+
+    np.testing.assert_allclose(
+        np.asarray(linen_output), torch_output, rtol=2e-4, atol=2e-5
+    )
+    np.testing.assert_allclose(
+        np.asarray(nnx_output), torch_output, rtol=2e-4, atol=2e-5
+    )
+    np.testing.assert_allclose(
+        np.asarray(linen_input_grad),
+        _channels_last(torch_x.grad.numpy()),
+        rtol=3e-4,
+        atol=3e-5,
+    )
+    np.testing.assert_allclose(
+        np.asarray(nnx_input_grad),
+        np.asarray(linen_input_grad),
+        rtol=3e-4,
+        atol=3e-5,
+    )
+    np.testing.assert_allclose(
+        np.asarray(nnx_grads.kernel[...]),
+        np.asarray(linen_kernel_grad),
+        rtol=3e-4,
+        atol=3e-5,
+    )
+    np.testing.assert_allclose(
+        np.asarray(linen_kernel_grad),
+        np.flip(
+            np.transpose(
+                torch_layer.weight.grad.numpy(), (*range(2, rank + 2), 0, 1)
+            ),
+            axis=tuple(range(rank)),
+        ),
+        rtol=3e-4,
+        atol=3e-5,
+    )

--- a/tests/integration/test_conv_transpose_shape_contract.py
+++ b/tests/integration/test_conv_transpose_shape_contract.py
@@ -1,24 +1,20 @@
 """Runnable cross-framework tests for canonical ConvTranspose sizing."""
 
-import jax
-import jax.numpy as jnp
 import numpy as np
 import pytest
-import torch
-from flax import nnx
 
-from nmn.linen import (
-    YatConvTranspose1D as LinenTranspose1D,
-    YatConvTranspose2D as LinenTranspose2D,
-    YatConvTranspose3D as LinenTranspose3D,
-)
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+torch = pytest.importorskip("torch")
+nnx = pytest.importorskip("flax.nnx")
+
+from nmn.linen import YatConvTranspose1D as LinenTranspose1D
+from nmn.linen import YatConvTranspose2D as LinenTranspose2D
+from nmn.linen import YatConvTranspose3D as LinenTranspose3D
 from nmn.nnx import YatConvTranspose as NnxTranspose
-from nmn.torch import (
-    YatConvTranspose1D as TorchTranspose1D,
-    YatConvTranspose2D as TorchTranspose2D,
-    YatConvTranspose3D as TorchTranspose3D,
-)
-
+from nmn.torch import YatConvTranspose1D as TorchTranspose1D
+from nmn.torch import YatConvTranspose2D as TorchTranspose2D
+from nmn.torch import YatConvTranspose3D as TorchTranspose3D
 
 CASES = [
     (
@@ -121,9 +117,7 @@ def test_linen_nnx_canonical_same_output_and_gradient_parity_under_jit():
         use_alpha=False,
         epsilon=0.1,
     )
-    linen_apply = jax.jit(
-        lambda x, w: linen.apply({"params": {"kernel": w}}, x)
-    )
+    linen_apply = jax.jit(lambda x, w: linen.apply({"params": {"kernel": w}}, x))
 
     nnx_layer = NnxTranspose(
         1,
@@ -145,18 +139,14 @@ def test_linen_nnx_canonical_same_output_and_gradient_parity_under_jit():
     linen_input_grad, linen_kernel_grad = jax.grad(
         lambda x, w: jnp.sum(linen_apply(x, w) * cotangent), argnums=(0, 1)
     )(inputs, kernel)
-    nnx_input_grad = jax.grad(
-        lambda x: jnp.sum(nnx_apply(x) * cotangent)
-    )(inputs)
-    _, nnx_grads = nnx.value_and_grad(
-        lambda model: jnp.sum(model(inputs) * cotangent)
-    )(nnx_layer)
+    nnx_input_grad = jax.grad(lambda x: jnp.sum(nnx_apply(x) * cotangent))(inputs)
+    _, nnx_grads = nnx.value_and_grad(lambda model: jnp.sum(model(inputs) * cotangent))(
+        nnx_layer
+    )
 
     assert linen_output.shape == nnx_output.shape == (1, 10, 1)
     np.testing.assert_allclose(linen_output, nnx_output, rtol=2e-5, atol=2e-6)
-    np.testing.assert_allclose(
-        linen_input_grad, nnx_input_grad, rtol=2e-5, atol=2e-6
-    )
+    np.testing.assert_allclose(linen_input_grad, nnx_input_grad, rtol=2e-5, atol=2e-6)
     np.testing.assert_allclose(
         linen_kernel_grad, nnx_grads.kernel[...], rtol=2e-5, atol=2e-6
     )
@@ -181,9 +171,9 @@ def test_torch_linen_nnx_canonical_valid_output_and_gradient_parity(
     input_values = np.linspace(
         -0.7, 0.9, np.prod(input_shape), dtype=np.float32
     ).reshape(input_shape)
-    kernel = np.linspace(
-        -0.4, 0.6, np.prod(kernel_shape), dtype=np.float32
-    ).reshape((*kernel_shape, 1, 1))
+    kernel = np.linspace(-0.4, 0.6, np.prod(kernel_shape), dtype=np.float32).reshape(
+        (*kernel_shape, 1, 1)
+    )
 
     linen = linen_cls(
         features=1,
@@ -245,15 +235,15 @@ def test_torch_linen_nnx_canonical_valid_output_and_gradient_parity(
     torch_output = _channels_last(torch_output_cf.detach().numpy())
     assert linen_output.shape == nnx_output.shape == torch_output.shape == expected
 
-    cotangent = np.linspace(
-        0.2, 1.0, np.prod(expected), dtype=np.float32
-    ).reshape(expected)
+    cotangent = np.linspace(0.2, 1.0, np.prod(expected), dtype=np.float32).reshape(
+        expected
+    )
     linen_input_grad, linen_kernel_grad = jax.grad(
         lambda x, w: jnp.sum(linen_apply(x, w) * cotangent), argnums=(0, 1)
     )(linen_x, linen_w)
-    nnx_input_grad = jax.grad(
-        lambda value: jnp.sum(nnx_layer(value) * cotangent)
-    )(linen_x)
+    nnx_input_grad = jax.grad(lambda value: jnp.sum(nnx_layer(value) * cotangent))(
+        linen_x
+    )
     _, nnx_grads = nnx.value_and_grad(
         lambda model: jnp.sum(model(linen_x) * cotangent)
     )(nnx_layer)
@@ -286,9 +276,7 @@ def test_torch_linen_nnx_canonical_valid_output_and_gradient_parity(
     np.testing.assert_allclose(
         np.asarray(linen_kernel_grad),
         np.flip(
-            np.transpose(
-                torch_layer.weight.grad.numpy(), (*range(2, rank + 2), 0, 1)
-            ),
+            np.transpose(torch_layer.weight.grad.numpy(), (*range(2, rank + 2), 0, 1)),
             axis=tuple(range(rank)),
         ),
         rtol=3e-4,

--- a/tests/test_conv_transpose_shapes.py
+++ b/tests/test_conv_transpose_shapes.py
@@ -1,0 +1,75 @@
+"""Framework-independent tests for the ConvTranspose shape contract."""
+
+import pytest
+
+from nmn._conv_transpose import (
+    canonical_same_crop_or_pad,
+    canonical_jax_transpose_padding,
+    canonical_transpose_output_spatial,
+)
+
+
+@pytest.mark.parametrize(
+    "spatial,kernel,strides,padding,dilation,extra,expected",
+    [
+        ((3,), (2,), (3,), "VALID", (1,), (0,), (8,)),
+        ((3,), (2,), (3,), "SAME", (1,), (0,), (9,)),
+        ((3,), (2,), (3,), "SAME", (1,), (1,), (10,)),
+        ((2, 3), (2, 3), (3, 2), "VALID", (1, 1), (0, 0), (5, 7)),
+        (
+            (2, 2, 2),
+            (2, 3, 2),
+            (3, 2, 4),
+            "VALID",
+            (1, 2, 1),
+            (0, 1, 2),
+            (5, 8, 8),
+        ),
+    ],
+)
+def test_canonical_spatial_formula(
+    spatial, kernel, strides, padding, dilation, extra, expected
+):
+    assert (
+        canonical_transpose_output_spatial(
+            spatial, kernel, strides, padding, dilation, extra
+        )
+        == expected
+    )
+
+
+def test_jax_padding_distinguishes_legacy_gap_from_explicit_zero():
+    assert canonical_jax_transpose_padding((2,), (3,), "VALID") == ((1, 1),)
+    assert canonical_jax_transpose_padding((2,), (3,), "SAME", output_padding=1) == (
+        (1, 3),
+    )
+
+
+def test_same_adjustment_uncrops_values_before_it_zero_pads_stride_gaps():
+    assert canonical_same_crop_or_pad(3, 2, output_padding=0) == ((0, 1),)
+    assert canonical_same_crop_or_pad(3, 2, output_padding=1) == ((0, 0),)
+    assert canonical_same_crop_or_pad(2, 3, output_padding=0) == ((0, -1),)
+    assert canonical_same_crop_or_pad(2, 3, output_padding=1) == ((0, -2),)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"strides": 0}, "strides values must be positive"),
+        ({"output_padding": -1}, "output_padding values must be nonnegative"),
+        ({"output_padding": 2}, "smaller than the corresponding stride"),
+        ({"padding": "causal"}, "padding must be"),
+    ],
+)
+def test_contract_rejects_nonportable_configuration(kwargs, match):
+    arguments = dict(
+        input_spatial=(3,),
+        kernel_size=2,
+        strides=2,
+        padding="valid",
+        dilation_rate=1,
+        output_padding=0,
+    )
+    arguments.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        canonical_transpose_output_spatial(**arguments)

--- a/tests/test_conv_transpose_shapes.py
+++ b/tests/test_conv_transpose_shapes.py
@@ -3,8 +3,8 @@
 import pytest
 
 from nmn._conv_transpose import (
-    canonical_same_crop_or_pad,
     canonical_jax_transpose_padding,
+    canonical_same_crop_or_pad,
     canonical_transpose_output_spatial,
 )
 

--- a/tests/test_keras/test_issue_regressions.py
+++ b/tests/test_keras/test_issue_regressions.py
@@ -154,6 +154,141 @@ def input_gradient(layer, value):
 
 
 @pytest.mark.parametrize(
+    "layer_cls,input_shape,kernel,strides,expected",
+    [
+        (YatConvTranspose1D, (1, 3, 1), 2, 3, (1, 8, 1)),
+        (YatConvTranspose2D, (1, 2, 3, 1), (2, 3), (3, 2), (1, 5, 7, 1)),
+        (
+            YatConvTranspose3D,
+            (1, 2, 2, 2, 1),
+            (2, 3, 2),
+            (3, 2, 4),
+            (1, 5, 5, 6, 1),
+        ),
+    ],
+)
+def test_canonical_conv_transpose_valid_shapes_and_config(
+    layer_cls, input_shape, kernel, strides, expected
+):
+    layer = layer_cls(
+        1,
+        kernel,
+        strides=strides,
+        padding="valid",
+        output_shape_mode="nmn",
+        use_bias=False,
+        use_alpha=False,
+    )
+    output = layer(keras.ops.ones(input_shape))
+    assert tuple(output.shape) == expected
+    assert tuple(layer.compute_output_shape(input_shape)) == expected
+    restored = layer_cls.from_config(layer.get_config())
+    assert restored.output_shape_mode == "nmn"
+
+
+def test_canonical_same_output_padding_extends_high_side():
+    layer = YatConvTranspose1D(
+        1,
+        2,
+        strides=3,
+        padding="same",
+        output_padding=1,
+        output_shape_mode="nmn",
+        use_bias=False,
+        use_alpha=False,
+    )
+    output = layer(keras.ops.ones((1, 3, 1)))
+    assert tuple(output.shape) == (1, 10, 1)
+    np.testing.assert_array_equal(to_numpy(output)[:, -1], 0.0)
+
+
+def test_canonical_same_output_padding_uncrops_valid_kernel_contributions():
+    inputs = keras.ops.convert_to_tensor([[[0.5], [1.0], [1.5]]])
+    same = YatConvTranspose1D(
+        1,
+        3,
+        strides=2,
+        padding="same",
+        output_padding=1,
+        output_shape_mode="nmn",
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    valid = YatConvTranspose1D(
+        1,
+        3,
+        strides=2,
+        padding="valid",
+        output_shape_mode="nmn",
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    same(inputs)
+    valid(inputs)
+    kernel = keras.ops.reshape(keras.ops.arange(3, dtype="float32") + 1, (3, 1, 1))
+    same.kernel.assign(kernel)
+    valid.kernel.assign(kernel)
+
+    same_output = same(inputs)
+    valid_output = valid(inputs)
+    assert tuple(same_output.shape) == tuple(valid_output.shape) == (1, 7, 1)
+    np.testing.assert_allclose(to_numpy(same_output), to_numpy(valid_output))
+
+
+def test_conv_transpose_framework_mode_preserves_legacy_stride_gap():
+    inputs = keras.ops.ones((1, 3, 1))
+    legacy = YatConvTranspose1D(
+        1, 2, strides=3, padding="valid", use_bias=False, use_alpha=False
+    )
+    canonical = YatConvTranspose1D(
+        1,
+        2,
+        strides=3,
+        padding="valid",
+        output_shape_mode="nmn",
+        use_bias=False,
+        use_alpha=False,
+    )
+    assert tuple(legacy(inputs).shape) == (1, 9, 1)
+    assert tuple(canonical(inputs).shape) == (1, 8, 1)
+
+
+def test_conv_transpose_rejects_unknown_output_shape_mode():
+    with pytest.raises(ValueError, match="output_shape_mode"):
+        YatConvTranspose1D(1, 2, output_shape_mode="typo")
+
+
+def test_canonical_conv_transpose_jax_input_and_kernel_gradients_are_finite():
+    if BACKEND != "jax":
+        pytest.skip("stateless parameter-gradient probe uses the JAX backend")
+    import jax
+    import jax.numpy as jnp
+
+    layer = YatConvTranspose2D(
+        1,
+        (2, 3),
+        strides=(3, 2),
+        padding="valid",
+        output_shape_mode="nmn",
+        use_bias=False,
+        use_alpha=False,
+    )
+    value = jnp.arange(6, dtype=jnp.float32).reshape((1, 2, 3, 1)) / 5
+    layer(value)
+    trainable = [variable.value for variable in layer.trainable_variables]
+
+    def loss(x, parameters):
+        output, _ = layer.stateless_call(parameters, layer.non_trainable_variables, x)
+        return jnp.sum(output)
+
+    input_grad, parameter_grads = jax.grad(loss, argnums=(0, 1))(value, trainable)
+    assert jnp.isfinite(input_grad).all()
+    assert all(jnp.isfinite(gradient).all() for gradient in parameter_grads)
+
+
+@pytest.mark.parametrize(
     ("layer_cls", "input_shape"),
     [
         (YatConv1D, (2, 7, 4)),

--- a/tests/test_mlx/test_all_layers.py
+++ b/tests/test_mlx/test_all_layers.py
@@ -89,6 +89,55 @@ def _explicit_same_transpose_reference(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "layer_cls,input_shape,kernel,strides,output_padding,expected",
+    [
+        (YatConvTranspose1D, (1, 3, 1), 2, 3, 0, (1, 8, 1)),
+        (
+            YatConvTranspose2D,
+            (1, 2, 3, 1),
+            (2, 3),
+            (3, 2),
+            (0, 0),
+            (1, 5, 7, 1),
+        ),
+        (
+            YatConvTranspose3D,
+            (1, 2, 2, 2, 1),
+            (2, 3, 2),
+            (3, 2, 4),
+            (0, 0, 0),
+            (1, 5, 5, 6, 1),
+        ),
+    ],
+)
+def test_conv_transpose_valid_stride_gap_shapes_and_gradients(
+    layer_cls, input_shape, kernel, strides, output_padding, expected
+):
+    layer = layer_cls(
+        filters=1,
+        kernel_size=kernel,
+        strides=strides,
+        padding="valid",
+        output_padding=output_padding,
+        use_bias=False,
+        use_alpha=False,
+    )
+    inputs = mx.reshape(
+        mx.linspace(-0.7, 0.9, int(np.prod(input_shape))), input_shape
+    )
+    output = layer(inputs)
+    input_grad = mx.grad(lambda value: mx.sum(layer(value)))(inputs)
+    _, parameter_grads = mlx_nn.value_and_grad(
+        layer, lambda model: mx.sum(model(inputs))
+    )(layer)
+    mx.eval(output, input_grad, parameter_grads)
+
+    assert output.shape == expected
+    assert bool(mx.all(mx.isfinite(input_grad)))
+    assert bool(mx.all(mx.isfinite(parameter_grads["kernel"])))
+
+
 def test_conv1d_valid_shape():
     layer = YatConv1D(filters=16, kernel_size=3)
     x = mx.random.normal(shape=(2, 10, 4))

--- a/tests/test_mlx/test_all_layers.py
+++ b/tests/test_mlx/test_all_layers.py
@@ -123,9 +123,7 @@ def test_conv_transpose_valid_stride_gap_shapes_and_gradients(
         use_bias=False,
         use_alpha=False,
     )
-    inputs = mx.reshape(
-        mx.linspace(-0.7, 0.9, int(np.prod(input_shape))), input_shape
-    )
+    inputs = mx.reshape(mx.linspace(-0.7, 0.9, int(np.prod(input_shape))), input_shape)
     output = layer(inputs)
     input_grad = mx.grad(lambda value: mx.sum(layer(value)))(inputs)
     _, parameter_grads = mlx_nn.value_and_grad(

--- a/tests/test_tf/test_yat_conv_transpose.py
+++ b/tests/test_tf/test_yat_conv_transpose.py
@@ -148,3 +148,138 @@ def test_tf_yat_conv_transpose2d_no_bias():
 
     except ImportError:
         pytest.skip("TensorFlow dependencies not available")
+
+
+@pytest.mark.parametrize(
+    "class_name,input_shape,kernel,strides,expected",
+    [
+        ("YatConvTranspose1D", (1, 3, 1), 2, 3, (1, 8, 1)),
+        ("YatConvTranspose2D", (1, 2, 3, 1), (2, 3), (3, 2), (1, 5, 7, 1)),
+        (
+            "YatConvTranspose3D",
+            (1, 2, 2, 2, 1),
+            (2, 3, 2),
+            (3, 2, 4),
+            (1, 5, 5, 6, 1),
+        ),
+    ],
+)
+def test_canonical_valid_stride_gap_output_and_gradients(
+    class_name, input_shape, kernel, strides, expected
+):
+    tf = pytest.importorskip("tensorflow")
+    import nmn.tf as nmn_tf
+
+    layer = getattr(nmn_tf, class_name)(
+        1,
+        kernel,
+        strides=strides,
+        padding="valid",
+        output_padding=0,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    inputs = tf.Variable(
+        tf.reshape(tf.linspace(-0.7, 0.9, np.prod(input_shape)), input_shape)
+    )
+
+    @tf.function
+    def loss_and_output():
+        with tf.GradientTape() as tape:
+            output = layer(inputs)
+            loss = tf.reduce_sum(output)
+        gradients = tape.gradient(loss, (inputs, layer.kernel))
+        return output, gradients
+
+    output, gradients = loss_and_output()
+    assert tuple(output.shape) == expected
+    assert all(gradient is not None for gradient in gradients)
+    assert all(
+        bool(tf.reduce_all(tf.math.is_finite(gradient))) for gradient in gradients
+    )
+
+
+def test_canonical_dilation_and_same_output_padding():
+    tf = pytest.importorskip("tensorflow")
+    from nmn.tf import YatConvTranspose1D
+
+    valid = YatConvTranspose1D(
+        1,
+        3,
+        strides=1,
+        padding="valid",
+        dilation_rate=2,
+        output_padding=0,
+        use_bias=False,
+        use_alpha=False,
+    )
+    same = YatConvTranspose1D(
+        1,
+        2,
+        strides=3,
+        padding="same",
+        output_padding=1,
+        use_bias=False,
+        use_alpha=False,
+    )
+    assert tuple(valid(tf.ones((1, 3, 1))).shape) == (1, 7, 1)
+    assert tuple(same(tf.ones((1, 3, 1))).shape) == (1, 10, 1)
+
+
+def test_canonical_same_output_padding_uncrops_valid_kernel_contributions():
+    tf = pytest.importorskip("tensorflow")
+    from nmn.tf import YatConvTranspose1D
+
+    inputs = tf.constant([[[0.5], [1.0], [1.5]]])
+    same = YatConvTranspose1D(
+        1,
+        3,
+        strides=2,
+        padding="same",
+        output_padding=1,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    valid = YatConvTranspose1D(
+        1,
+        3,
+        strides=2,
+        padding="valid",
+        output_padding=0,
+        use_bias=False,
+        use_alpha=False,
+        epsilon=0.1,
+    )
+    same(inputs)
+    valid(inputs)
+    kernel = tf.reshape(tf.range(1, 4, dtype=tf.float32), (3, 1, 1))
+    same.kernel.assign(kernel)
+    valid.kernel.assign(kernel)
+
+    same_output = same(inputs)
+    valid_output = valid(inputs)
+    assert tuple(same_output.shape) == tuple(valid_output.shape) == (1, 7, 1)
+    tf.debugging.assert_near(same_output, valid_output)
+
+
+def test_implicit_tensorflow_stride_gap_shape_remains_backward_compatible():
+    tf = pytest.importorskip("tensorflow")
+    from nmn.tf import YatConvTranspose1D
+
+    inputs = tf.ones((1, 3, 1))
+    legacy = YatConvTranspose1D(
+        1, 2, strides=3, padding="valid", use_bias=False, use_alpha=False
+    )
+    canonical = YatConvTranspose1D(
+        1,
+        2,
+        strides=3,
+        padding="valid",
+        output_padding=0,
+        use_bias=False,
+        use_alpha=False,
+    )
+    assert tuple(legacy(inputs).shape) == (1, 9, 1)
+    assert tuple(canonical(inputs).shape) == (1, 8, 1)

--- a/tests/test_tf/test_yat_conv_transpose.py
+++ b/tests/test_tf/test_yat_conv_transpose.py
@@ -168,9 +168,18 @@ def test_canonical_valid_stride_gap_output_and_gradients(
     class_name, input_shape, kernel, strides, expected
 ):
     tf = pytest.importorskip("tensorflow")
-    import nmn.tf as nmn_tf
+    from nmn.tf import (
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    )
 
-    layer = getattr(nmn_tf, class_name)(
+    layer_type = {
+        "YatConvTranspose1D": YatConvTranspose1D,
+        "YatConvTranspose2D": YatConvTranspose2D,
+        "YatConvTranspose3D": YatConvTranspose3D,
+    }[class_name]
+    layer = layer_type(
         1,
         kernel,
         strides=strides,

--- a/tests/test_tf/test_yat_conv_transpose.py
+++ b/tests/test_tf/test_yat_conv_transpose.py
@@ -202,6 +202,8 @@ def test_canonical_valid_stride_gap_output_and_gradients(
 
 def test_canonical_dilation_and_same_output_padding():
     tf = pytest.importorskip("tensorflow")
+    if not tf.config.list_physical_devices("GPU"):
+        pytest.skip("TensorFlow CPU Conv2DBackpropInput does not support dilation > 1")
     from nmn.tf import YatConvTranspose1D
 
     valid = YatConvTranspose1D(


### PR DESCRIPTION
Closes #148.\n\nDefines a canonical per-axis SAME/VALID/dilation/stride/output-padding contract, adds backward-compatible opt-in conformance paths for NNX, Linen, Keras, and TensorFlow, documents intentional native compatibility behavior for Torch/MLX, and adds cross-framework 1D/2D/3D output and gradient tests.\n\nValidated with full NNX/Linen suites, Keras JAX/Torch suites, exhaustive helper/runtime shape checks, serialization/config tests, and independent exact-head review.