### PR TITLE
064: Run minimum-version compatibility jobs on backend source changes

### DIFF
--- a/.github/workflows/minimum-versions.yml
+++ b/.github/workflows/minimum-versions.yml
@@ -5,6 +5,24 @@ on:
     paths:
       - 'pyproject.toml'
       - '.github/workflows/minimum-versions.yml'
+      - 'scripts/select_minimum_version_jobs.py'
+      - 'src/nmn/*.py'
+      - 'src/nmn/torch/**'
+      - 'src/nmn/tf/**'
+      - 'src/nmn/keras/**'
+      - 'src/nmn/mlx/**'
+      - 'tests/__init__.py'
+      - 'tests/_isolated_backend.py'
+      - 'tests/conftest.py'
+      - 'tests/integration/**'
+      - 'tests/test_torch/**'
+      - 'tests/test_torch_*.py'
+      - 'tests/test_tf/**'
+      - 'tests/test_tf_*.py'
+      - 'tests/test_keras/**'
+      - 'tests/test_keras_*.py'
+      - 'tests/test_mlx/**'
+      - 'tests/test_mlx_*.py'
   schedule:
     - cron: '23 8 * * 1'
   workflow_dispatch:
@@ -13,8 +31,40 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Select affected minimum-version jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      torch: ${{ steps.filter.outputs.torch }}
+      tensorflow: ${{ steps.filter.outputs.tensorflow }}
+      keras: ${{ steps.filter.outputs.keras }}
+      mlx: ${{ steps.filter.outputs.mlx }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - name: Select jobs
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" \
+              | python scripts/select_minimum_version_jobs.py >> "$GITHUB_OUTPUT"
+          else
+            python scripts/select_minimum_version_jobs.py --all >> "$GITHUB_OUTPUT"
+          fi
+
   torch:
     name: PyTorch 1.11 minimum smoke
+    needs: changes
+    if: needs.changes.outputs.torch == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -23,17 +73,21 @@ jobs:
         with:
           python-version: '3.10'
           cache: pip
+      - name: Create clean virtual environment
+        run: python -m venv .venv-minimum
       - name: Install declared lower bound
         run: |
-          pip install numpy pytest
-          pip install -e . --no-deps
-          pip install 'torch==1.11.0+cpu' 'torchvision==0.12.0+cpu' --extra-index-url https://download.pytorch.org/whl/cpu
-          pip check
+          .venv-minimum/bin/python -m pip install numpy pytest
+          .venv-minimum/bin/python -m pip install -e . --no-deps
+          .venv-minimum/bin/python -m pip install 'torch==1.11.0+cpu' 'torchvision==0.12.0+cpu' --extra-index-url https://download.pytorch.org/whl/cpu
+          .venv-minimum/bin/python -m pip check
       - name: Exercise representative public APIs
-        run: pytest tests/test_torch/test_yat_nmn.py tests/test_torch/test_attention.py -q
+        run: .venv-minimum/bin/python -m pytest tests/test_torch/test_yat_nmn.py tests/test_torch/test_attention.py -q
 
   tensorflow:
     name: TensorFlow 2.10 minimum smoke
+    needs: changes
+    if: needs.changes.outputs.tensorflow == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -42,17 +96,21 @@ jobs:
         with:
           python-version: '3.10'
           cache: pip
+      - name: Create clean virtual environment
+        run: python -m venv .venv-minimum
       - name: Install declared lower bound
         run: |
           # TensorFlow 2.10 predates NumPy 2's binary ABI.
-          pip install pytest 'numpy<2' 'tensorflow==2.10.0'
-          pip install -e . --no-deps
-          pip check
+          .venv-minimum/bin/python -m pip install pytest 'numpy<2' 'tensorflow==2.10.0'
+          .venv-minimum/bin/python -m pip install -e . --no-deps
+          .venv-minimum/bin/python -m pip check
       - name: Exercise representative public APIs
-        run: pytest tests/test_tf/test_basic.py tests/test_tf/test_attention.py -q
+        run: .venv-minimum/bin/python -m pytest tests/test_tf/test_basic.py tests/test_tf/test_attention.py -q
 
   keras:
     name: Keras 3.0 minimum smoke
+    needs: changes
+    if: needs.changes.outputs.keras == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -63,17 +121,21 @@ jobs:
         with:
           python-version: '3.10'
           cache: pip
+      - name: Create clean virtual environment
+        run: python -m venv .venv-minimum
       - name: Install declared lower bound
         run: |
-          pip install numpy pytest 'keras==3.0.0'
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install -e . --no-deps
-          pip check
+          .venv-minimum/bin/python -m pip install numpy pytest 'keras==3.0.0'
+          .venv-minimum/bin/python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          .venv-minimum/bin/python -m pip install -e . --no-deps
+          .venv-minimum/bin/python -m pip check
       - name: Exercise representative public APIs
-        run: pytest tests/test_keras/test_basic.py tests/test_keras/test_attention.py -q
+        run: .venv-minimum/bin/python -m pytest tests/test_keras/test_basic.py tests/test_keras/test_attention.py -q
 
   mlx:
     name: MLX 0.18.1 minimum smoke
+    needs: changes
+    if: needs.changes.outputs.mlx == 'true'
     runs-on: macos-15
     timeout-minutes: 15
     steps:
@@ -82,10 +144,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: pip
+      - name: Create clean virtual environment
+        run: python -m venv .venv-minimum
       - name: Install declared lower bound
         run: |
-          pip install numpy pytest 'mlx==0.18.1'
-          pip install -e . --no-deps
-          pip check
+          .venv-minimum/bin/python -m pip install numpy pytest 'mlx==0.18.1'
+          .venv-minimum/bin/python -m pip install -e . --no-deps
+          .venv-minimum/bin/python -m pip check
       - name: Exercise representative public APIs on Apple Silicon
-        run: pytest tests/test_mlx/test_basic.py tests/test_mlx/test_attention.py -q
+        run: .venv-minimum/bin/python -m pytest tests/test_mlx/test_basic.py tests/test_mlx/test_attention.py -q

--- a/scripts/select_minimum_version_jobs.py
+++ b/scripts/select_minimum_version_jobs.py
@@ -1,0 +1,77 @@
+"""Select minimum-version CI jobs from pull-request file changes.
+
+The selector is deliberately standard-library-only so the workflow can run it
+before installing NMN or any optional machine-learning framework.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+
+JOBS = ("torch", "tensorflow", "keras", "mlx")
+
+_BACKEND_PREFIXES = {
+    "torch": ("src/nmn/torch/", "tests/test_torch/", "tests/test_torch_"),
+    "tensorflow": ("src/nmn/tf/", "tests/test_tf/", "tests/test_tf_"),
+    "keras": ("src/nmn/keras/", "tests/test_keras/", "tests/test_keras_"),
+    "mlx": ("src/nmn/mlx/", "tests/test_mlx/", "tests/test_mlx_"),
+}
+
+# Changes to dependency declarations, this policy, shared package modules, or
+# cross-framework test support can invalidate every backend's lower bound.
+_ALL_JOB_FILES = {
+    ".github/workflows/minimum-versions.yml",
+    "pyproject.toml",
+    "scripts/select_minimum_version_jobs.py",
+    "tests/__init__.py",
+    "tests/_isolated_backend.py",
+    "tests/conftest.py",
+}
+_ALL_JOB_PREFIXES = ("src/nmn/_", "tests/integration/")
+
+
+def select_jobs(paths: Iterable[str]) -> set[str]:
+    """Return the minimum-version jobs affected by repository-relative *paths*."""
+
+    selected: set[str] = set()
+    for raw_path in paths:
+        path = raw_path.removeprefix("./")
+        if path in _ALL_JOB_FILES or path.startswith(_ALL_JOB_PREFIXES):
+            return set(JOBS)
+        for job, prefixes in _BACKEND_PREFIXES.items():
+            if path.startswith(prefixes):
+                selected.add(job)
+    return selected
+
+
+def _changed_paths_from_stdin() -> list[str]:
+    data = sys.stdin.buffer.read()
+    if not data:
+        return []
+    return [
+        item.decode("utf-8", errors="surrogateescape")
+        for item in data.rstrip(b"\0").split(b"\0")
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write GitHub Actions boolean outputs for every minimum-version job."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="select every job (used by schedules and manual dispatches)",
+    )
+    args = parser.parse_args(argv)
+
+    selected = set(JOBS) if args.all else select_jobs(_changed_paths_from_stdin())
+    for job in JOBS:
+        print(f"{job}={'true' if job in selected else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by the workflow
+    raise SystemExit(main())

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -1,5 +1,6 @@
 """Regression tests for CI/CD workflow policy."""
 
+import importlib.util
 import json
 import re
 from pathlib import Path
@@ -16,6 +17,15 @@ DOCUSAURUS = WORKFLOWS.parents[1] / "website" / "docusaurus"
 ROOT = WORKFLOWS.parents[1]
 CHECKOUT_REF = re.compile(r"actions/checkout@([^\s'\"#]+)")
 ACTION_REF = re.compile(r"uses:\s+([^\s@]+)@([^\s#]+)")
+
+
+def _load_minimum_version_selector():
+    path = ROOT / "scripts" / "select_minimum_version_jobs.py"
+    spec = importlib.util.spec_from_file_location("minimum_version_selector", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_publish_uploads_only_version_tags():
@@ -175,8 +185,60 @@ def test_minimum_backend_policy_is_scheduled_and_matches_metadata():
     assert "tensorflow==2.10.0" in workflow and "tensorflow>=2.10.0" in extras["tf"]
     assert "keras==3.0.0" in workflow and "keras>=3.0.0" in extras["keras"]
     assert "mlx==0.18.1" in workflow and "mlx>=0.18.1" in extras["mlx"]
+    assert workflow.count("python -m venv .venv-minimum") == 4
+    assert workflow.count(".venv-minimum/bin/python -m pip check") == 4
+    assert workflow.count(".venv-minimum/bin/python -m pytest") == 4
     assert "native TPU Mosaic and CUDA" in docs
     assert "real Apple Silicon GPU" in docs
+
+
+def test_minimum_backend_workflow_triggers_on_affected_sources_and_tests():
+    workflow = (WORKFLOWS / "minimum-versions.yml").read_text()
+    trigger = workflow.split("permissions:", 1)[0]
+
+    expected_paths = {
+        "src/nmn/torch/**",
+        "src/nmn/tf/**",
+        "src/nmn/keras/**",
+        "src/nmn/mlx/**",
+        "tests/test_torch/**",
+        "tests/test_torch_*.py",
+        "tests/test_tf/**",
+        "tests/test_tf_*.py",
+        "tests/test_keras/**",
+        "tests/test_keras_*.py",
+        "tests/test_mlx/**",
+        "tests/test_mlx_*.py",
+    }
+    assert all(f"- '{path}'" in trigger for path in expected_paths)
+    assert "docs/**" not in trigger
+    assert "README.md" not in trigger
+    assert "needs: changes" in workflow
+    assert workflow.count("if: needs.changes.outputs.") == 4
+    assert "python scripts/select_minimum_version_jobs.py" in workflow
+
+
+def test_minimum_backend_selector_is_precise_and_fail_closed_for_shared_code():
+    selector = _load_minimum_version_selector()
+
+    for job, source, test in (
+        ("torch", "src/nmn/torch/layers/linear.py", "tests/test_torch/test_basic.py"),
+        ("tensorflow", "src/nmn/tf/conv.py", "tests/test_tf/test_basic.py"),
+        ("keras", "src/nmn/keras/nmn.py", "tests/test_keras/test_basic.py"),
+        ("mlx", "src/nmn/mlx/attention.py", "tests/test_mlx/test_basic.py"),
+    ):
+        assert selector.select_jobs([source]) == {job}
+        assert selector.select_jobs([test]) == {job}
+
+    assert selector.select_jobs(["tests/test_mlx_goat_source.py"]) == {"mlx"}
+
+    assert selector.select_jobs(["docs/guides/pytorch.md"]) == set()
+    assert selector.select_jobs(["README.md"]) == set()
+    assert selector.select_jobs(["src/nmn/_epsilon.py"]) == set(selector.JOBS)
+    assert selector.select_jobs(["tests/integration/test_cross_framework.py"]) == set(
+        selector.JOBS
+    )
+    assert selector.select_jobs(["pyproject.toml"]) == set(selector.JOBS)
 
 
 def test_jax_ci_covers_minimum_and_latest_dependency_sets():


### PR DESCRIPTION
Implements dacli task 064-run-minimum-version-compatibility-jobs-on-backend-source-changes.

Refs #157

### Acceptance
- [x] Changes under each backend source tree trigger that backend's minimum-version smoke job.
- [x] Relevant backend tests also trigger the corresponding job.
- [x] Documentation-only changes do not start unnecessary framework installs.
- [x] Path filtering is covered by a workflow-policy test.
- [x] The declared Python/framework minimums are tested from a clean environment.
