### PR TITLE
063: Make website deployment consume the audited build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'website/**'
       - '.github/workflows/deploy.yml'
+      - '.github/workflows/website.yml'
   
   # Allow manual trigger
   workflow_dispatch:
@@ -24,38 +25,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-          cache-dependency-path: website/docusaurus/package-lock.json
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Prepare static website assets
-        run: bash website/prepare-docusaurus-static.sh
-
-      - name: Install Docusaurus dependencies
-        working-directory: website/docusaurus
-        run: npm ci
-
-      - name: Build Docusaurus
-        working-directory: website/docusaurus
-        run: npm run build
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: 'website/docusaurus/build'
+    # Audit, build, and upload in the reusable validation workflow. The deploy
+    # job consumes that run's artifact and never performs a second build.
+    uses: ./.github/workflows/website.yml
+    permissions:
+      contents: read
 
   deploy:
     environment:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,7 @@
 name: Website
 
 on:
+  workflow_call:
   push:
     branches: [ main, master, develop ]
     paths:
@@ -46,3 +47,10 @@ jobs:
       - name: Build website
         working-directory: website/docusaurus
         run: npm run build
+
+      # deploy.yml consumes this artifact from the same workflow run. Because
+      # steps fail closed, an audit or build failure prevents its creation.
+      - name: Upload audited website artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: website/docusaurus/build

--- a/tests/test_workflow_policy.py
+++ b/tests/test_workflow_policy.py
@@ -170,7 +170,8 @@ def test_release_and_deployment_permissions_are_job_scoped_and_bounded():
     assert "id-token: write" not in deploy_build
     assert deploy.count("id-token: write") == 1
     assert publish.count("timeout-minutes:") == 3
-    assert deploy.count("timeout-minutes:") == 2
+    assert deploy.count("timeout-minutes:") == 1
+    assert (WORKFLOWS / "website.yml").read_text().count("timeout-minutes:") == 1
     assert mirror.count("timeout-minutes:") == 1
 
 
@@ -390,13 +391,39 @@ def test_website_is_built_on_pull_requests_with_node24():
     assert "npm ci" in workflow
     assert "bash website/prepare-docusaurus-static.sh" in workflow
     assert "npm run build" in workflow
+    assert "workflow_call:" in workflow
 
     config = (DOCUSAURUS / "docusaurus.config.js").read_text()
     assert "onBrokenLinks: 'throw'" in config
     assert "onBrokenMarkdownLinks: 'throw'" in config
 
     deploy_workflow = (WORKFLOWS / "deploy.yml").read_text()
-    assert "bash website/prepare-docusaurus-static.sh" in deploy_workflow
+    assert "uses: ./.github/workflows/website.yml" in deploy_workflow
+
+
+def test_deployment_consumes_the_fail_closed_audited_website_artifact():
+    website = (WORKFLOWS / "website.yml").read_text()
+    deploy = (WORKFLOWS / "deploy.yml").read_text()
+    build_steps = website.split("    steps:", 1)[1]
+
+    audit = build_steps.index("run: npm run audit:ci")
+    prepare = build_steps.index("run: bash website/prepare-docusaurus-static.sh")
+    build = build_steps.index("run: npm run build")
+    upload = build_steps.index("uses: actions/upload-pages-artifact@v5")
+
+    assert audit < prepare < build < upload
+    assert "cache-dependency-path: website/docusaurus/package-lock.json" in website
+    assert "continue-on-error" not in build_steps
+    assert "if: always()" not in build_steps
+
+    deploy_build = deploy.split("  build:", 1)[1].split("\n  deploy:", 1)[0]
+    deploy_job = deploy.split("\n  deploy:", 1)[1]
+    assert "uses: ./.github/workflows/website.yml" in deploy_build
+    assert "needs: build" in deploy_job
+    assert "npm ci" not in deploy
+    assert "npm run build" not in deploy
+    assert "actions/upload-pages-artifact" not in deploy
+    assert "'.github/workflows/website.yml'" in deploy
 
 
 def test_website_manifest_and_lockfile_use_coherent_versions():

--- a/website/README.md
+++ b/website/README.md
@@ -66,12 +66,18 @@ This will start a local server at `http://localhost:3000`.
 The final deployed website combines both components. The **Interactive Paper** is embedded into the Docusaurus site.
 
 ### Deployment Workflow (`deploy.yml`)
-1.  **Builds the Visual Paper**: Uses the existing `website/index.html` and assets.
-2.  **Builds Docusaurus**: Compiles the documentation site.
-3.  **Merges**:
+1.  **Runs the reusable website workflow**: Installs the exact
+    `docusaurus/package-lock.json` dependency graph and enforces the reviewed
+    dependency-advisory policy.
+2.  **Builds the Visual Paper**: Uses the existing `website/index.html` and assets.
+3.  **Builds Docusaurus**: Compiles the documentation site.
+4.  **Merges**:
     *   The Visual Paper (`index.html`, `css/`, `js/`, `assets/`) is copied into the Docusaurus `static/paper/` directory.
     *   This makes the visual paper accessible at `https://azettaai.github.io/nmn/paper/`.
-4.  **Deploys**: The combined artifact is pushed to GitHub Pages.
+5.  **Deploys the audited artifact**: GitHub Pages consumes the artifact emitted
+    by that same build; deployment does not reinstall dependencies or rebuild
+    the site. An audit or build failure therefore blocks artifact creation and
+    deployment.
 
 ### Key Links
 *   **Documentation Home**: [https://azettaai.github.io/nmn/](https://azettaai.github.io/nmn/)


### PR DESCRIPTION
Implements dacli task 063-make-website-deployment-consume-the-audited-build.

Refs #158

### Acceptance
- [x] Production deployment is blocked by dependency-audit failure.
- [x] PR validation and deployment use the same preparation script, dependency lock, and build command.
- [x] Prefer a reusable workflow or promote the exact vetted artifact instead of rebuilding.
- [x] A workflow-policy regression proves that audit failure prevents artifact upload/deployment.
