### PR TITLE
075: Validate DropConnect, dropout, head counts, and scalar configuration consistently

### DIFF
--- a/src/nmn/_validation.py
+++ b/src/nmn/_validation.py
@@ -1,0 +1,92 @@
+"""Import-light validation helpers shared by every NMN backend."""
+
+from __future__ import annotations
+
+import math
+import operator
+from typing import Any, TypeVar, cast
+
+_T = TypeVar("_T")
+
+
+def _has_invalid_rate_dtype(value) -> bool:
+    """Detect non-real scalar arrays without importing their framework."""
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+
+    # NumPy dtypes, and the NumPy-compatible dtypes used by JAX, expose a
+    # one-character kind. Boolean, complex, and textual/object/void values are
+    # not real probability scalars.
+    kind = getattr(dtype, "kind", None)
+    if kind in {"b", "c", "S", "U", "O", "V"}:
+        return True
+
+    # Torch and TensorFlow dtypes do not consistently expose ``kind``, but
+    # provide stable names such as ``torch.bool``, ``bool`` and ``string``.
+    dtype_name = str(getattr(dtype, "name", dtype)).lower()
+    return (
+        "bool" in dtype_name
+        or "complex" in dtype_name
+        or "string" in dtype_name
+        or dtype_name.startswith("str")
+        or "bytes" in dtype_name
+        or "object" in dtype_name
+    )
+
+
+def validate_rate(value: _T, name: str) -> float | _T:
+    """Validate a probability, preserving an abstract scalar tracer if needed."""
+    if isinstance(value, (bool, str, bytes, bytearray)):
+        raise ValueError(
+            f"{name} must be a finite real number in [0, 1), got {value!r}"
+        )
+
+    # Reject vector/container configuration rather than relying on permissive
+    # one-element conversions (for example ``float(np.array([0.5]))``).  A
+    # zero-dimensional framework scalar remains valid.
+    shape = getattr(value, "shape", None)
+    if shape is not None and tuple(shape) != ():
+        raise ValueError(
+            f"{name} must be a finite real number in [0, 1), got {value!r}"
+        )
+    if _has_invalid_rate_dtype(value):
+        raise ValueError(
+            f"{name} must be a finite real number in [0, 1), got {value!r}"
+        )
+    try:
+        rate = float(cast(Any, value))
+    except TypeError:
+        # JAX transformations represent scalar arguments as abstract tracers;
+        # coercing one to float raises ConcretizationTypeError (a TypeError).
+        # Preserve that previously supported traced-scalar path without
+        # importing JAX into this backend-neutral module. Concrete JAX arrays
+        # still take the eager float/range-validation path above.
+        aval = getattr(value, "aval", None)
+        if aval is not None and tuple(getattr(aval, "shape", (None,))) == ():
+            return value
+        raise ValueError(
+            f"{name} must be a finite real number in [0, 1), got {value!r}"
+        ) from None
+    except (ValueError, OverflowError, RuntimeError):
+        raise ValueError(
+            f"{name} must be a finite real number in [0, 1), got {value!r}"
+        ) from None
+    if not math.isfinite(rate) or not 0.0 <= rate < 1.0:
+        raise ValueError(
+            f"{name} must be a finite real number in [0, 1), got {value!r}"
+        )
+    return rate
+
+
+def validate_positive_int(value, name: str) -> int:
+    """Return *value* as a strictly positive integer, rejecting booleans."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    try:
+        integer = operator.index(value)
+    except TypeError:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}") from None
+    if integer <= 0:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return integer

--- a/src/nmn/keras/attention.py
+++ b/src/nmn/keras/attention.py
@@ -15,6 +15,8 @@ from keras.src import initializers, ops
 from keras.src.layers.layer import Layer
 from keras.src.saving.object_registration import register_keras_serializable
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ._yat_core import reduction_safe_upcast
 
 __all__ = [
@@ -63,6 +65,7 @@ def yat_attention_weights(
     Returns:
         Attention weights (batch, num_heads, q_len, kv_len).
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     output_dtype = query.dtype
     query = reduction_safe_upcast(query)
     key = reduction_safe_upcast(key)
@@ -228,12 +231,14 @@ class MultiHeadYatAttention(Layer):
         kernel_initializer: str = "glorot_normal",
         **kwargs,
     ):
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        dropout = validate_rate(dropout, "dropout")
         super().__init__(**kwargs)
 
         if embed_dim % num_heads != 0:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must be divisible by "
-                f"num_heads ({num_heads})."
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
             )
 
         self.embed_dim = embed_dim

--- a/src/nmn/keras/conv.py
+++ b/src/nmn/keras/conv.py
@@ -26,6 +26,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_positive_int, validate_rate
 
 from ._yat_core import reduction_safe_upcast, yat_score
 
@@ -466,7 +467,7 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size if isinstance(kernel_size, (list, tuple)) else (kernel_size,)
         )
@@ -482,13 +483,13 @@ class YatConv1D(_KernelBankSerializationMixin, Layer):
             dilation != 1 for dilation in self.dilation_rate
         ):
             raise ValueError("`strides > 1` is incompatible with `dilation_rate > 1`.")
-        self.groups = groups
+        self.groups = validate_positive_int(groups, "groups")
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
-        self.drop_rate = drop_rate
+        self.drop_rate = validate_rate(drop_rate, "drop_rate")
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
@@ -827,7 +828,7 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -843,13 +844,13 @@ class YatConv2D(_KernelBankSerializationMixin, Layer):
             if isinstance(dilation_rate, (list, tuple))
             else (dilation_rate, dilation_rate)
         )
-        self.groups = groups
+        self.groups = validate_positive_int(groups, "groups")
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
-        self.drop_rate = drop_rate
+        self.drop_rate = validate_rate(drop_rate, "drop_rate")
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
@@ -1144,7 +1145,7 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -1162,13 +1163,13 @@ class YatConv3D(_KernelBankSerializationMixin, Layer):
             if isinstance(dilation_rate, (list, tuple))
             else (dilation_rate, dilation_rate, dilation_rate)
         )
-        self.groups = groups
+        self.groups = validate_positive_int(groups, "groups")
         self.use_alpha = use_alpha
         self.epsilon = validate_epsilon(epsilon)
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
-        self.drop_rate = drop_rate
+        self.drop_rate = validate_rate(drop_rate, "drop_rate")
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
@@ -1457,7 +1458,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size if isinstance(kernel_size, (list, tuple)) else (kernel_size,)
         )
@@ -1481,7 +1482,7 @@ class YatConvTranspose1D(_KernelBankSerializationMixin, Layer):
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
-        self.drop_rate = drop_rate
+        self.drop_rate = validate_rate(drop_rate, "drop_rate")
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
@@ -1743,7 +1744,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -1771,7 +1772,7 @@ class YatConvTranspose2D(_KernelBankSerializationMixin, Layer):
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
-        self.drop_rate = drop_rate
+        self.drop_rate = validate_rate(drop_rate, "drop_rate")
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id
@@ -2033,7 +2034,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         **kwargs,
     ):
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -2063,7 +2064,7 @@ class YatConvTranspose3D(_KernelBankSerializationMixin, Layer):
         self.learnable_epsilon = learnable_epsilon
         self.weight_normalized = weight_normalized
         self.use_dropconnect = use_dropconnect
-        self.drop_rate = drop_rate
+        self.drop_rate = validate_rate(drop_rate, "drop_rate")
         self.tie_kernel_bank = tie_kernel_bank
         self.kernel_bank_size = kernel_bank_size
         self.kernel_bank_id = kernel_bank_id

--- a/src/nmn/keras/embed.py
+++ b/src/nmn/keras/embed.py
@@ -13,6 +13,8 @@ from keras.src import initializers, ops
 from keras.src.layers.layer import Layer
 from keras.src.saving.object_registration import register_keras_serializable
 
+from nmn._validation import validate_positive_int
+
 from ._yat_core import (
     reduction_safe_upcast,
     saturating_downcast,
@@ -55,6 +57,8 @@ class YatEmbed(Layer):
         embedding_initializer="glorot_normal",
         **kwargs,
     ):
+        num_embeddings = validate_positive_int(num_embeddings, "num_embeddings")
+        features = validate_positive_int(features, "features")
         super().__init__(**kwargs)
         self.num_embeddings = num_embeddings
         self.features = features

--- a/src/nmn/keras/nmn.py
+++ b/src/nmn/keras/nmn.py
@@ -13,6 +13,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_positive_int
 
 from ._yat_core import reduction_safe_upcast, saturating_downcast, stable_yat_ratio
 
@@ -109,6 +110,7 @@ class YatNMN(Layer):
         bias_constraint=None,
         **kwargs,
     ):
+        units = validate_positive_int(units, "units")
         super().__init__(activity_regularizer=activity_regularizer, **kwargs)
         self.units = units
         self.epsilon = validate_epsilon(epsilon)

--- a/src/nmn/linen/attention.py
+++ b/src/nmn/linen/attention.py
@@ -17,6 +17,8 @@ from flax.linen.dtypes import promote_dtype
 from flax.linen.module import Module, compact
 from jax import Array
 
+from nmn._validation import validate_positive_int, validate_rate
+
 # Re-export attention functions from NNX (same JAX backend)
 from nmn.nnx.layers.attention._attention_core import (
     validate_attention_normalization,
@@ -210,6 +212,15 @@ class MultiHeadAttention(Module):
     # Appended after every pre-existing field to preserve the positional
     # constructor ABI of Linen dataclass modules.
     normalization: str = "softmax"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        validate_positive_int(self.num_heads, "num_heads")
+        if self.qkv_features is not None:
+            validate_positive_int(self.qkv_features, "qkv_features")
+        if self.out_features is not None:
+            validate_positive_int(self.out_features, "out_features")
+        validate_rate(self.dropout_rate, "dropout_rate")
 
     @compact
     def __call__(

--- a/src/nmn/linen/conv.py
+++ b/src/nmn/linen/conv.py
@@ -17,6 +17,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_positive_int
 
 from ._yat_core import safe_kernel_init, upcast_yat_operands, yat_score
 
@@ -34,8 +35,9 @@ def _validate_feature_groups(
     input_channels: int, output_channels: int, feature_group_count: int
 ) -> None:
     """Validate grouped-convolution channel partitions with clear errors."""
-    if feature_group_count <= 0:
-        raise ValueError("feature_group_count must be a positive integer.")
+    validate_positive_int(input_channels, "input_channels")
+    validate_positive_int(output_channels, "features")
+    validate_positive_int(feature_group_count, "feature_group_count")
     if input_channels % feature_group_count != 0:
         raise ValueError(
             f"Input channels ({input_channels}) must be divisible by "
@@ -54,6 +56,9 @@ class _EpsilonValidatedModule(Module):
     def __post_init__(self) -> None:
         super().__post_init__()
         validate_epsilon(self.epsilon)
+        validate_positive_int(self.features, "features")
+        if hasattr(self, "feature_group_count"):
+            validate_positive_int(self.feature_group_count, "feature_group_count")
 
 
 class YatConv1D(_EpsilonValidatedModule):

--- a/src/nmn/linen/embed.py
+++ b/src/nmn/linen/embed.py
@@ -14,6 +14,8 @@ from flax import linen as nn
 from flax.linen.dtypes import promote_dtype
 from flax.linen.module import Module, compact
 
+from nmn._validation import validate_positive_int
+
 from ._yat_core import reduction_safe_upcast, saturating_downcast
 
 __all__ = ["YatEmbed"]
@@ -56,6 +58,11 @@ class YatEmbed(Module):
     param_dtype: Any = jnp.float32
     embedding_init: Any = default_embed_init
     alpha_init: Any = lambda key, shape, dtype: jnp.ones(shape, dtype)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        validate_positive_int(self.num_embeddings, "num_embeddings")
+        validate_positive_int(self.features, "features")
 
     @compact
     def __call__(self, inputs):

--- a/src/nmn/linen/nmn.py
+++ b/src/nmn/linen/nmn.py
@@ -20,6 +20,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_positive_int
 
 
 def _epsilon_dtype(param_dtype, epsilon):
@@ -127,6 +128,7 @@ class YatNMN(Module):
 
     def __post_init__(self) -> None:
         super().__post_init__()
+        validate_positive_int(self.features, "features")
         validate_epsilon(self.epsilon)
 
     @compact

--- a/src/nmn/mlx/attention.py
+++ b/src/nmn/mlx/attention.py
@@ -21,6 +21,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from nmn._epsilon import validate_epsilon
+from nmn._validation import validate_positive_int, validate_rate
 
 __all__ = [
     "normalize_qk",
@@ -62,6 +63,7 @@ def yat_attention_weights(
     Inputs use the (batch, length, num_heads, head_dim) convention, the
     output mask the (batch, heads, q_len, kv_len) convention.
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     head_dim = query.shape[-1]
     dim_scale = math.sqrt(head_dim)
 
@@ -201,6 +203,9 @@ class MultiHeadYatAttention(nn.Module):
         epsilon: float = 1e-5,
         dtype: mx.Dtype = mx.float32,
     ) -> None:
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        dropout = validate_rate(dropout, "dropout")
         super().__init__()
         if embed_dim % num_heads != 0:
             raise ValueError(

--- a/src/nmn/mlx/conv.py
+++ b/src/nmn/mlx/conv.py
@@ -35,6 +35,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from nmn._epsilon import validate_epsilon
+from nmn._validation import validate_positive_int, validate_rate
 
 from ._epsilon import make_epsilon_parameter
 from ._yat_core import yat_score
@@ -239,10 +240,9 @@ class _YatConvBase(nn.Module):
         if self._ndim == 0:
             raise TypeError("_YatConvBase is not meant to be instantiated directly")
         epsilon = validate_epsilon(epsilon)
-        if groups < 1:
-            raise ValueError(f"groups must be >= 1, got {groups}")
-        if not 0.0 <= drop_rate < 1.0:
-            raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
+        filters = validate_positive_int(filters, "filters")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
 
         self.filters = filters
         self.kernel_size = _as_tuple(kernel_size, self._ndim)
@@ -487,8 +487,8 @@ class _YatConvTransposeBase(nn.Module):
                 "_YatConvTransposeBase is not meant to be instantiated directly"
             )
         epsilon = validate_epsilon(epsilon)
-        if not 0.0 <= drop_rate < 1.0:
-            raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
+        filters = validate_positive_int(filters, "filters")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
 
         self.filters = filters
         self.kernel_size = _as_tuple(kernel_size, self._ndim)

--- a/src/nmn/mlx/embed.py
+++ b/src/nmn/mlx/embed.py
@@ -15,6 +15,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from nmn._epsilon import validate_epsilon
+from nmn._validation import validate_positive_int
 
 from ._precision import reduction_safe_upcast, saturating_downcast
 
@@ -53,6 +54,8 @@ class YatEmbed(nn.Module):
         weight_normalized: bool = False,
         dtype: mx.Dtype = mx.float32,
     ) -> None:
+        num_embeddings = validate_positive_int(num_embeddings, "num_embeddings")
+        features = validate_positive_int(features, "features")
         super().__init__()
         epsilon = validate_epsilon(epsilon)
 

--- a/src/nmn/mlx/goat.py
+++ b/src/nmn/mlx/goat.py
@@ -47,6 +47,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from nmn._epsilon import validate_epsilon
+from nmn._validation import validate_positive_int
 
 from ._epsilon import make_epsilon_parameter
 
@@ -195,6 +196,8 @@ class GoatYatAttention(nn.Module):
         epsilon: float = 1.0,
         dtype: mx.Dtype = mx.float32,
     ):
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
         super().__init__()
         if embed_dim % num_heads != 0:
             raise ValueError(

--- a/src/nmn/mlx/nmn.py
+++ b/src/nmn/mlx/nmn.py
@@ -21,6 +21,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from nmn._epsilon import validate_epsilon
+from nmn._validation import validate_positive_int, validate_rate
 
 from ._epsilon import make_epsilon_parameter
 from ._precision import saturating_downcast
@@ -102,8 +103,8 @@ class YatNMN(nn.Module):
     ) -> None:
         super().__init__()
         epsilon = validate_epsilon(epsilon)
-        if not 0.0 <= drop_rate < 1.0:
-            raise ValueError(f"drop_rate must be in [0, 1), got {drop_rate}")
+        features = validate_positive_int(features, "features")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
 
         # ``freeze_kernel`` is an alias for ``lazy``; either enables lazy mode.
         self.lazy = bool(lazy) or bool(freeze_kernel)

--- a/src/nmn/mlx/rotary.py
+++ b/src/nmn/mlx/rotary.py
@@ -24,6 +24,7 @@ import mlx.nn as nn
 import numpy as np
 
 from nmn._epsilon import validate_epsilon
+from nmn._validation import validate_positive_int, validate_rate
 
 from .attention import yat_attention_weights
 
@@ -222,6 +223,10 @@ class RotaryYatAttention(nn.Module):
         epsilon: float = 1e-5,
         dtype: mx.Dtype = mx.float32,
     ) -> None:
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        max_seq_len = validate_positive_int(max_seq_len, "max_seq_len")
+        dropout = validate_rate(dropout, "dropout")
         super().__init__()
         if embed_dim % num_heads != 0:
             raise ValueError(

--- a/src/nmn/nnx/layers/attention/_attention_core.py
+++ b/src/nmn/nnx/layers/attention/_attention_core.py
@@ -39,6 +39,7 @@ from flax import nnx
 from flax.nnx.module import Module
 from jax import Array, random
 
+from nmn._validation import validate_rate
 from nmn.nnx.layers.squashers import softermax
 
 SUPPORTED_ATTENTION_NORMALIZATIONS = ("softmax", "l1", "softermax")
@@ -103,7 +104,7 @@ def finalize_attention_weights(
         Normalized attention weights of the same shape, cast to ``dtype``.
     """
     validate_attention_normalization(normalization)
-
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     if alpha is not None:
         attn_weights = attn_weights * alpha
 

--- a/src/nmn/nnx/layers/attention/multi_head.py
+++ b/src/nmn/nnx/layers/attention/multi_head.py
@@ -34,6 +34,8 @@ from flax.typing import (
 )
 from jax import Array, lax
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from .._numerics import fp32_if_low_precision, inverse_softplus
 from .masks import combine_masks
 from .yat_attention import yat_attention
@@ -74,8 +76,7 @@ def _validate_decode_mask(mask: Array | None, expected_shape: tuple[int, ...]) -
         broadcast_shape = jnp.broadcast_shapes(tuple(mask.shape), expected_shape)
     except ValueError as exc:
         raise ValueError(
-            f"Decode mask shape {mask.shape} is not broadcastable to "
-            f"{expected_shape}."
+            f"Decode mask shape {mask.shape} is not broadcastable to {expected_shape}."
         ) from exc
     if broadcast_shape != expected_shape:
         raise ValueError(
@@ -263,6 +264,14 @@ class MultiHeadAttention(Module):
             use_softermax: Whether to use softermax instead of softmax.
             power: Power parameter for softermax.
         """
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        in_features = validate_positive_int(in_features, "in_features")
+        if qkv_features is not None:
+            qkv_features = validate_positive_int(qkv_features, "qkv_features")
+        if out_features is not None:
+            out_features = validate_positive_int(out_features, "out_features")
+        dropout_rate = validate_rate(dropout_rate, "dropout_rate")
+        dropconnect_rate = validate_rate(dropconnect_rate, "dropconnect_rate")
         self.num_heads = num_heads
         self.in_features = in_features
         self.qkv_features = qkv_features if qkv_features is not None else in_features
@@ -299,11 +308,6 @@ class MultiHeadAttention(Module):
         self.power = power
         self.use_dropconnect = use_dropconnect
         self.dropconnect_rate = dropconnect_rate
-        if not 0.0 <= dropconnect_rate < 1.0:
-            raise ValueError(
-                "dropconnect_rate must be in the half-open interval [0, 1), "
-                f"got {dropconnect_rate}"
-            )
         self.dropconnect_rng = (
             rngs.dropout.fork() if use_dropconnect else nnx.data(None)
         )

--- a/src/nmn/nnx/layers/attention/rotary_yat.py
+++ b/src/nmn/nnx/layers/attention/rotary_yat.py
@@ -47,6 +47,7 @@ from flax.typing import (
 from jax import Array, random
 
 from nmn._attention_shape import validate_attention_inputs
+from nmn._validation import validate_positive_int, validate_rate
 from nmn.nnx.layers.squashers import softermax
 
 from .._numerics import fp32_if_low_precision, inverse_softplus
@@ -361,6 +362,7 @@ def rotary_yat_performer_attention(
     - Multi-Scale FAVOR+ features for YAT kernel approximation
     - O(n) linear complexity attention
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
 
@@ -510,7 +512,10 @@ class RotaryYatAttention(Module):
             rngs: Random number generators.
         """
         validate_attention_normalization(normalization)
-
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        max_seq_len = validate_positive_int(max_seq_len, "max_seq_len")
+        dropout_rate = validate_rate(dropout_rate, "dropout_rate")
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.head_dim = embed_dim // num_heads
@@ -571,8 +576,7 @@ class RotaryYatAttention(Module):
 
         if embed_dim % num_heads != 0:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must be divisible by "
-                f"num_heads ({num_heads})."
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
             )
 
         if self.head_dim % 2 != 0:

--- a/src/nmn/nnx/layers/attention/yat_attention.py
+++ b/src/nmn/nnx/layers/attention/yat_attention.py
@@ -40,6 +40,7 @@ from flax.typing import Dtype, PrecisionLike
 from jax import Array, random
 
 from nmn._attention_shape import validate_attention_inputs
+from nmn._validation import validate_rate
 from nmn.nnx.layers._numerics import fp32_if_low_precision
 from nmn.nnx.layers.squashers import softermax
 
@@ -102,6 +103,7 @@ def yat_attention_weights(
     Returns:
         Attention weights of shape [..., num_heads, q_length, kv_length]
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     query, key = promote_dtype((query, key), dtype=dtype)
     dtype = query.dtype
 
@@ -326,6 +328,7 @@ def yat_attention_normalized(
     Returns:
         Output of shape [..., q_length, num_heads, v_dim].
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
 
@@ -495,6 +498,7 @@ def yat_performer_attention(
     Returns:
         Output of shape [..., q_length, num_heads, v_dim].
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     query, key, value = promote_dtype((query, key, value), dtype=dtype)
     dtype = query.dtype
 

--- a/src/nmn/nnx/layers/conv/yat_conv.py
+++ b/src/nmn/nnx/layers/conv/yat_conv.py
@@ -33,6 +33,7 @@ from flax.typing import (
 from jax import lax
 
 from nmn._kernel_bank import initializer_signature
+from nmn._validation import validate_positive_int, validate_rate
 
 from ...kernel_bank import KernelBank, _BankParam
 from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
@@ -163,12 +164,12 @@ class YatConv(Module):
         kernel_bank: tp.Optional[KernelBank] = None,
         rngs: rnglib.Rngs,
     ):
-        if not 0.0 <= drop_rate < 1.0:
-            raise ValueError(
-                f"drop_rate must be in the half-open interval [0, 1), got {drop_rate}"
-            )
-        if feature_group_count <= 0:
-            raise ValueError("feature_group_count must be positive")
+        in_features = validate_positive_int(in_features, "in_features")
+        out_features = validate_positive_int(out_features, "out_features")
+        feature_group_count = validate_positive_int(
+            feature_group_count, "feature_group_count"
+        )
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         if in_features % feature_group_count != 0:
             raise ValueError("in_features must be a multiple of feature_group_count")
         if out_features % feature_group_count != 0:

--- a/src/nmn/nnx/layers/conv/yat_conv_transpose.py
+++ b/src/nmn/nnx/layers/conv/yat_conv_transpose.py
@@ -28,6 +28,7 @@ from flax.typing import (
 from jax import lax
 
 from nmn._conv_transpose import canonical_jax_transpose_padding
+from nmn._validation import validate_positive_int, validate_rate
 
 from .._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 from .utils import (
@@ -139,11 +140,9 @@ class YatConvTranspose(Module):
         drop_rate: float = 0.0,
         rngs: rnglib.Rngs,
     ):
-        if not 0.0 <= drop_rate < 1.0:
-            raise ValueError(
-                "drop_rate must be in the half-open interval [0, 1), "
-                f"got {drop_rate}"
-            )
+        in_features = validate_positive_int(in_features, "in_features")
+        out_features = validate_positive_int(out_features, "out_features")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size,)
         else:

--- a/src/nmn/nnx/layers/embed.py
+++ b/src/nmn/nnx/layers/embed.py
@@ -14,6 +14,8 @@ from flax.typing import (
     PromoteDtypeFn,
 )
 
+from nmn._validation import validate_positive_int
+
 from ._numerics import finite_cast, fp32_if_low_precision, inverse_softplus
 
 Array = jax.Array
@@ -106,6 +108,8 @@ class Embed(Module):
         alpha_init: Initializer = default_alpha_init,
         rngs: rnglib.Rngs,
     ):
+        num_embeddings = validate_positive_int(num_embeddings, "num_embeddings")
+        features = validate_positive_int(features, "features")
         self.embedding = nnx.Param(
             embedding_init(rngs.params(), (num_embeddings, features), param_dtype)
         )

--- a/src/nmn/nnx/layers/nmn.py
+++ b/src/nmn/nnx/layers/nmn.py
@@ -22,6 +22,7 @@ from flax.typing import (
 from jax import lax
 
 from nmn._kernel_bank import initializer_signature
+from nmn._validation import validate_positive_int, validate_rate
 
 from ..kernel_bank import KernelBank, _BankParam
 from ._numerics import fp32_if_low_precision, inverse_softplus
@@ -181,10 +182,9 @@ class YatNMN(Module):
         rngs: rnglib.Rngs,
     ):
 
-        if not 0.0 <= drop_rate < 1.0:
-            raise ValueError(
-                f"drop_rate must be in the half-open interval [0, 1), got {drop_rate}"
-            )
+        in_features = validate_positive_int(in_features, "in_features")
+        out_features = validate_positive_int(out_features, "out_features")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
 
         # ── Lazy mode (issue #37): freeze ONLY the kernel ───────────────────────
         # `freeze_kernel` is an alias for `lazy`. When enabled, the kernel is stored

--- a/src/nmn/tf/attention.py
+++ b/src/nmn/tf/attention.py
@@ -13,6 +13,8 @@ from typing import Optional, Tuple, Union
 
 import tensorflow as tf
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ._precision import reduction_safe_upcast
 from .saved_model import ExportPath, export_attention
 
@@ -69,6 +71,7 @@ def yat_attention_weights(
     Returns:
         Attention weights (batch, num_heads, q_len, kv_len).
     """
+    dropout_rate = validate_rate(dropout_rate, "dropout_rate")
     output_dtype = query.dtype
     if output_dtype in (tf.float16, tf.bfloat16):
         query = reduction_safe_upcast(query)
@@ -257,12 +260,14 @@ class MultiHeadYatAttention(tf.Module):
         dtype: tf.DType = tf.float32,
         name: Optional[str] = None,
     ):
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        dropout = validate_rate(dropout, "dropout")
         super().__init__(name=name)
 
         if embed_dim % num_heads != 0:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must be divisible by "
-                f"num_heads ({num_heads})."
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
             )
 
         self.embed_dim = embed_dim

--- a/src/nmn/tf/conv.py
+++ b/src/nmn/tf/conv.py
@@ -14,6 +14,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_positive_int
 
 from ._precision import reduction_safe_upcast
 from ._yat_core import yat_score
@@ -28,8 +29,8 @@ def _epsilon_variable_dtype(layer):
 
 def _validate_groups(filters: int, groups: int) -> None:
     """Validate the statically known grouped-convolution configuration."""
-    if groups <= 0:
-        raise ValueError(f"groups must be a positive integer, got {groups}")
+    validate_positive_int(filters, "filters")
+    validate_positive_int(groups, "groups")
     if filters % groups != 0:
         raise ValueError(f"Filters ({filters}) must be divisible by groups ({groups})")
 
@@ -146,7 +147,7 @@ class YatConv1D(SingleInputSavedModelMixin, tf.Module):
         name: Optional[str] = None,
     ):
         super().__init__(name=name)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = kernel_size
         self.strides = strides
         self.padding = padding.upper()
@@ -343,7 +344,7 @@ class YatConv2D(SingleInputSavedModelMixin, tf.Module):
         name: Optional[str] = None,
     ):
         super().__init__(name=name)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -553,7 +554,7 @@ class YatConv3D(SingleInputSavedModelMixin, tf.Module):
         name: Optional[str] = None,
     ):
         super().__init__(name=name)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -764,7 +765,7 @@ class YatConvTranspose1D(SingleInputSavedModelMixin, tf.Module):
         output_padding: Optional[int] = None,
     ):
         super().__init__(name=name)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = kernel_size
         self.strides = strides
         self.padding = padding.upper()
@@ -1003,7 +1004,7 @@ class YatConvTranspose2D(SingleInputSavedModelMixin, tf.Module):
         output_padding: Optional[Union[int, Tuple[int, int]]] = None,
     ):
         super().__init__(name=name)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))
@@ -1268,7 +1269,7 @@ class YatConvTranspose3D(SingleInputSavedModelMixin, tf.Module):
         output_padding: Optional[Union[int, Tuple[int, int, int]]] = None,
     ):
         super().__init__(name=name)
-        self.filters = filters
+        self.filters = validate_positive_int(filters, "filters")
         self.kernel_size = (
             kernel_size
             if isinstance(kernel_size, (list, tuple))

--- a/src/nmn/tf/embed.py
+++ b/src/nmn/tf/embed.py
@@ -11,6 +11,8 @@ from typing import Optional, Union
 
 import tensorflow as tf
 
+from nmn._validation import validate_positive_int
+
 from ._precision import reduction_safe_upcast, saturating_downcast
 from .saved_model import ExportPath, export_embedding
 
@@ -50,6 +52,8 @@ class YatEmbed(tf.Module):
         dtype: tf.DType = tf.float32,
         name: Optional[str] = None,
     ):
+        num_embeddings = validate_positive_int(num_embeddings, "num_embeddings")
+        features = validate_positive_int(features, "features")
         super().__init__(name=name)
         self.num_embeddings = num_embeddings
         self.features = features

--- a/src/nmn/tf/nmn.py
+++ b/src/nmn/tf/nmn.py
@@ -11,6 +11,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_positive_int
 
 from ._precision import reduction_safe_upcast, saturating_downcast
 from .saved_model import SingleInputSavedModelMixin
@@ -99,6 +100,7 @@ class YatNMN(SingleInputSavedModelMixin, tf.Module):
         freeze_kernel: bool = False,
         name: Optional[str] = None,
     ):
+        features = validate_positive_int(features, "features")
         super().__init__(name=name)
         self.features = features
         self.dtype = dtype

--- a/src/nmn/torch/attention/multi_head.py
+++ b/src/nmn/torch/attention/multi_head.py
@@ -22,6 +22,8 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from .yat_attention import yat_attention
 
 __all__ = ["MultiHeadYatAttention"]
@@ -88,12 +90,14 @@ class MultiHeadYatAttention(nn.Module):
         dtype=None,
         param_dtype=None,
     ):
+        embed_dim = validate_positive_int(embed_dim, "embed_dim")
+        num_heads = validate_positive_int(num_heads, "num_heads")
+        dropout = validate_rate(dropout, "dropout")
         super().__init__()
 
         if embed_dim % num_heads != 0:
             raise ValueError(
-                f"embed_dim ({embed_dim}) must be divisible by "
-                f"num_heads ({num_heads})."
+                f"embed_dim ({embed_dim}) must be divisible by num_heads ({num_heads})."
             )
 
         self.embed_dim = embed_dim

--- a/src/nmn/torch/attention/yat_attention.py
+++ b/src/nmn/torch/attention/yat_attention.py
@@ -28,6 +28,7 @@ import torch.nn.functional as F
 from torch import Tensor
 
 from nmn._attention_shape import validate_attention_inputs
+from nmn._validation import validate_rate
 
 from .._precision import saturating_upcast
 
@@ -88,6 +89,7 @@ def yat_attention_weights(
         Attention weights of shape (batch, num_heads, q_len, kv_len)
     """
     validate_attention_inputs(query, key, exact_rank=4)
+    dropout_p = validate_rate(dropout_p, "dropout_p")
     output_dtype = query.dtype
     if output_dtype in (torch.float16, torch.bfloat16):
         # dot^2 and the expanded squared distance both overflow/cancel readily

--- a/src/nmn/torch/embed.py
+++ b/src/nmn/torch/embed.py
@@ -14,6 +14,8 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int
+
 from ._precision import saturating_downcast, saturating_upcast
 
 __all__ = ["YatEmbed"]
@@ -64,6 +66,8 @@ class YatEmbed(nn.Module):
         device=None,
         dtype=None,
     ):
+        num_embeddings = validate_positive_int(num_embeddings, "num_embeddings")
+        features = validate_positive_int(features, "features")
         super().__init__()
         self.num_embeddings = num_embeddings
         self.features = features

--- a/src/nmn/torch/layers/_yat_conv_core.py
+++ b/src/nmn/torch/layers/_yat_conv_core.py
@@ -28,6 +28,7 @@ from nmn._epsilon import (
     validate_epsilon,
     validate_epsilon_for_dtype,
 )
+from nmn._validation import validate_rate
 
 from .._precision import saturating_downcast, saturating_upcast
 
@@ -135,7 +136,7 @@ def setup_yat_attrs(
         )
     else:
         layer.register_parameter("epsilon_param", None)
-    layer.drop_rate = drop_rate
+    layer.drop_rate = validate_rate(drop_rate, "drop_rate")
 
     # Alpha. Priority: constant_alpha > use_alpha.
     layer._constant_alpha_value = None

--- a/src/nmn/torch/layers/yat_conv1d.py
+++ b/src/nmn/torch/layers/yat_conv1d.py
@@ -12,6 +12,8 @@ from torch.nn import functional as F
 from torch.nn.common_types import _size_1_t
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ..kernel_bank import KernelBank
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
@@ -85,6 +87,10 @@ class YatConv1D(Conv1d):
         param_dtype=None,
         kernel_bank: Optional[KernelBank] = None,
     ) -> None:
+        in_channels = validate_positive_int(in_channels, "in_channels")
+        out_channels = validate_positive_int(out_channels, "out_channels")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         # param_dtype controls parameter storage; dtype controls computation
         storage_dtype = param_dtype if param_dtype is not None else dtype
 

--- a/src/nmn/torch/layers/yat_conv2d.py
+++ b/src/nmn/torch/layers/yat_conv2d.py
@@ -12,6 +12,8 @@ from torch.nn import functional as F
 from torch.nn.common_types import _size_2_t
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ..kernel_bank import KernelBank
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
@@ -85,6 +87,10 @@ class YatConv2D(Conv2d):
         param_dtype=None,
         kernel_bank: Optional[KernelBank] = None,
     ) -> None:
+        in_channels = validate_positive_int(in_channels, "in_channels")
+        out_channels = validate_positive_int(out_channels, "out_channels")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
         # Validate groups upfront so errors surface at construction time

--- a/src/nmn/torch/layers/yat_conv3d.py
+++ b/src/nmn/torch/layers/yat_conv3d.py
@@ -12,6 +12,8 @@ from torch.nn import functional as F
 from torch.nn.common_types import _size_3_t
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ..kernel_bank import KernelBank
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
@@ -83,6 +85,10 @@ class YatConv3D(Conv3d):
         param_dtype=None,
         kernel_bank: Optional[KernelBank] = None,
     ) -> None:
+        in_channels = validate_positive_int(in_channels, "in_channels")
+        out_channels = validate_positive_int(out_channels, "out_channels")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
         # Handle shared kernel bank

--- a/src/nmn/torch/layers/yat_conv_transpose1d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose1d.py
@@ -11,6 +11,8 @@ from torch.nn.common_types import _size_1_t
 from torch.nn.modules.utils import _single
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
     setup_yat_attrs,
@@ -62,6 +64,10 @@ class YatConvTranspose1D(ConvTranspose1d):
         dtype=None,
         param_dtype=None,
     ) -> None:
+        in_channels = validate_positive_int(in_channels, "in_channels")
+        out_channels = validate_positive_int(out_channels, "out_channels")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
         # If constant_bias or scalar_bias is set, don't allocate a per-channel

--- a/src/nmn/torch/layers/yat_conv_transpose2d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose2d.py
@@ -11,6 +11,8 @@ from torch.nn.common_types import _size_2_t
 from torch.nn.modules.utils import _pair
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
     setup_yat_attrs,
@@ -62,6 +64,10 @@ class YatConvTranspose2D(ConvTranspose2d):
         dtype=None,
         param_dtype=None,
     ) -> None:
+        in_channels = validate_positive_int(in_channels, "in_channels")
+        out_channels = validate_positive_int(out_channels, "out_channels")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
         # If constant_bias or scalar_bias is set, don't allocate a per-channel

--- a/src/nmn/torch/layers/yat_conv_transpose3d.py
+++ b/src/nmn/torch/layers/yat_conv_transpose3d.py
@@ -11,6 +11,8 @@ from torch.nn.common_types import _size_3_t
 from torch.nn.modules.utils import _triple
 from torch.nn.parameter import Parameter
 
+from nmn._validation import validate_positive_int, validate_rate
+
 from ._yat_conv_core import (
     apply_preserving_epsilon_dtype,
     setup_yat_attrs,
@@ -62,6 +64,10 @@ class YatConvTranspose3D(ConvTranspose3d):
         dtype=None,
         param_dtype=None,
     ) -> None:
+        in_channels = validate_positive_int(in_channels, "in_channels")
+        out_channels = validate_positive_int(out_channels, "out_channels")
+        groups = validate_positive_int(groups, "groups")
+        drop_rate = validate_rate(drop_rate, "drop_rate")
         storage_dtype = param_dtype if param_dtype is not None else dtype
 
         # If constant_bias or scalar_bias is set, don't allocate a per-channel

--- a/src/nmn/torch/nmn/yat_nmn.py
+++ b/src/nmn/torch/nmn/yat_nmn.py
@@ -17,6 +17,7 @@ from nmn._epsilon import (
     validate_epsilon_for_dtype,
 )
 from nmn._kernel_bank import initializer_signature
+from nmn._validation import validate_positive_int
 
 from .._precision import saturating_downcast, saturating_upcast
 from ..kernel_bank import KernelBank
@@ -119,6 +120,8 @@ class YatNMN(nn.Module):
         device=None,
         kernel_bank: Optional[KernelBank] = None,
     ):
+        in_features = validate_positive_int(in_features, "in_features")
+        out_features = validate_positive_int(out_features, "out_features")
         super().__init__()
 
         # Store attributes

--- a/tests/test_keras/test_validation.py
+++ b/tests/test_keras/test_validation.py
@@ -1,0 +1,46 @@
+"""Keras constructor and functional validation matrix."""
+
+import math
+
+import pytest
+
+from nmn.keras import (
+    MultiHeadYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+from nmn.keras.attention import yat_attention_weights
+
+CONVS = [
+    (YatConv1D, 3),
+    (YatConv2D, (3, 3)),
+    (YatConv3D, (3, 3, 3)),
+    (YatConvTranspose1D, 3),
+    (YatConvTranspose2D, (3, 3)),
+    (YatConvTranspose3D, (3, 3, 3)),
+]
+
+
+@pytest.mark.parametrize(("layer", "kernel_size"), CONVS)
+@pytest.mark.parametrize("rate", [math.nan, math.inf, -0.1, 1.0, 2.0])
+def test_all_conv_families_reject_invalid_dropconnect(layer, kernel_size, rate):
+    with pytest.raises(ValueError, match="drop_rate must be a finite real number"):
+        layer(2, kernel_size, drop_rate=rate)
+
+
+def test_attention_validates_before_build():
+    with pytest.raises(ValueError, match="num_heads must be a positive integer"):
+        MultiHeadYatAttention(8, 0)
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(8, 2, dropout=math.nan)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        yat_attention_weights(None, None, dropout_rate=1.0)
+
+
+def test_rate_boundaries_remain_supported():
+    YatConv1D(1, 1, drop_rate=0.0)
+    MultiHeadYatAttention(2, 1, dropout=0.999999)

--- a/tests/test_linen/test_validation.py
+++ b/tests/test_linen/test_validation.py
@@ -1,0 +1,58 @@
+"""Flax Linen constructor and functional validation matrix."""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from nmn.linen import (
+    MultiHeadAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+from nmn.linen.attention import yat_attention_weights
+
+
+@pytest.mark.parametrize(
+    "layer",
+    [
+        YatConv1D,
+        YatConv2D,
+        YatConv3D,
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    ],
+)
+def test_all_conv_families_reject_invalid_feature_counts(layer):
+    with pytest.raises(ValueError, match="features must be a positive integer"):
+        layer(features=0, kernel_size=(3,))
+
+
+def test_attention_validates_static_configuration():
+    with pytest.raises(ValueError, match="num_heads must be a positive integer"):
+        MultiHeadAttention(num_heads=0)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        MultiHeadAttention(num_heads=1, dropout_rate=math.nan)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        yat_attention_weights(None, None, dropout_rate=1.0)
+
+
+def test_rate_boundaries_remain_supported():
+    MultiHeadAttention(num_heads=1, dropout_rate=0.0)
+    MultiHeadAttention(num_heads=1, dropout_rate=0.999999)
+
+
+def test_wrapper_dropout_rate_remains_a_valid_traced_scalar():
+    q = jnp.ones((1, 1, 1, 1))
+
+    @jax.jit
+    def apply(rate):
+        return yat_attention_weights(q, q, dropout_rate=rate, deterministic=True)
+
+    assert apply(jnp.array(0.0)).shape == (1, 1, 1, 1)

--- a/tests/test_mlx/test_validation.py
+++ b/tests/test_mlx/test_validation.py
@@ -1,0 +1,62 @@
+"""MLX constructor and functional validation matrix."""
+
+import math
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+from nmn.mlx import (
+    MultiHeadYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+from nmn.mlx.attention import yat_attention_weights
+
+CONVS = [
+    (YatConv1D, 1),
+    (YatConv2D, (1, 1)),
+    (YatConv3D, (1, 1, 1)),
+    (YatConvTranspose1D, 1),
+    (YatConvTranspose2D, (1, 1)),
+    (YatConvTranspose3D, (1, 1, 1)),
+]
+
+
+@pytest.mark.parametrize(("layer", "kernel_size"), CONVS)
+@pytest.mark.parametrize("rate", [math.nan, math.inf, -0.1, 1.0, 2.0])
+def test_all_conv_families_reject_invalid_dropconnect(layer, kernel_size, rate):
+    with pytest.raises(ValueError, match="drop_rate must be a finite real number"):
+        layer(2, kernel_size, drop_rate=rate)
+
+
+def test_attention_validates_before_allocation():
+    with pytest.raises(ValueError, match="num_heads must be a positive integer"):
+        MultiHeadYatAttention(8, 0)
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(8, 2, dropout=math.nan)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        yat_attention_weights(None, None, dropout_rate=1.0)
+
+
+def test_rate_boundaries_remain_supported():
+    YatConv1D(1, 1, drop_rate=0.0)
+    MultiHeadYatAttention(2, 1, dropout=0.999999)
+
+
+def test_boolean_array_is_not_accepted_as_a_rate():
+    import mlx.core as mx
+
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(2, 1, dropout=mx.array(False))
+
+
+def test_complex_array_is_not_accepted_as_a_rate():
+    import mlx.core as mx
+
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(2, 1, dropout=mx.array(0.5 + 1j))

--- a/tests/test_nnx/test_validation.py
+++ b/tests/test_nnx/test_validation.py
@@ -1,0 +1,76 @@
+"""Flax NNX constructor and functional validation matrix."""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from nmn.nnx import MultiHeadAttention, YatConv, YatConvTranspose
+from nmn.nnx.layers.attention.yat_attention import yat_attention_weights
+
+
+@pytest.mark.parametrize("kernel_size", [3, (3, 3), (3, 3, 3)])
+@pytest.mark.parametrize("layer", [YatConv, YatConvTranspose])
+@pytest.mark.parametrize("rate", [math.nan, math.inf, -0.1, 1.0, 2.0])
+def test_all_conv_dimensions_reject_invalid_dropconnect(layer, kernel_size, rate):
+    with pytest.raises(ValueError, match="drop_rate must be a finite real number"):
+        layer(2, 2, kernel_size, drop_rate=rate, rngs=nnx.Rngs(0))
+
+
+def test_attention_validates_before_rng_consumption():
+    rngs = nnx.Rngs(0)
+    with pytest.raises(ValueError, match="num_heads must be a positive integer"):
+        MultiHeadAttention(0, 8, rngs=rngs)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        MultiHeadAttention(2, 8, dropout_rate=math.nan, rngs=rngs)
+    q = jnp.zeros((1, 1, 1, 1))
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        yat_attention_weights(q, q, dropout_rate=1.0)
+
+
+def test_rate_boundaries_remain_supported():
+    YatConv(1, 1, 1, drop_rate=0.0, rngs=nnx.Rngs(0))
+    MultiHeadAttention(1, 1, dropout_rate=0.999999, rngs=nnx.Rngs(0))
+
+
+def test_functional_dropout_rate_remains_a_valid_traced_scalar():
+    q = jnp.ones((1, 1, 1, 1))
+
+    @jax.jit
+    def apply(rate):
+        return yat_attention_weights(q, q, dropout_rate=rate, deterministic=True)
+
+    assert apply(jnp.array(0.0)).shape == (1, 1, 1, 1)
+
+
+@pytest.mark.parametrize("rate", [jnp.array(1.0), jnp.array([0.5]), jnp.array(False)])
+def test_jax_rates_still_validate_eagerly(rate):
+    q = jnp.ones((1, 1, 1, 1))
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        yat_attention_weights(q, q, dropout_rate=rate, deterministic=True)
+
+
+def test_boolean_tracer_is_not_accepted_as_a_rate():
+    q = jnp.ones((1, 1, 1, 1))
+
+    @jax.jit
+    def apply(rate):
+        return yat_attention_weights(q, q, dropout_rate=rate, deterministic=True)
+
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        apply(jnp.array(False))
+
+
+@pytest.mark.parametrize("rate", [jnp.array(0.5 + 0j), jnp.array(0.5 + 1j)])
+def test_complex_rates_are_rejected_eagerly_and_when_traced(rate):
+    q = jnp.ones((1, 1, 1, 1))
+
+    def apply(value):
+        return yat_attention_weights(q, q, dropout_rate=value, deterministic=True)
+
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        apply(rate)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        jax.jit(apply)(rate)

--- a/tests/test_tf/test_validation.py
+++ b/tests/test_tf/test_validation.py
@@ -1,0 +1,56 @@
+"""TensorFlow constructor and functional validation matrix."""
+
+import math
+
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from nmn.tf import (
+    MultiHeadYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+from nmn.tf.attention import yat_attention_weights
+
+
+@pytest.mark.parametrize(
+    "layer",
+    [
+        YatConv1D,
+        YatConv2D,
+        YatConv3D,
+        YatConvTranspose1D,
+        YatConvTranspose2D,
+        YatConvTranspose3D,
+    ],
+)
+def test_all_conv_families_reject_invalid_feature_counts(layer):
+    with pytest.raises(ValueError, match="filters must be a positive integer"):
+        layer(filters=0, kernel_size=1)
+
+
+def test_attention_validates_before_allocation():
+    with pytest.raises(ValueError, match="num_heads must be a positive integer"):
+        MultiHeadYatAttention(8, 0)
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(8, 2, dropout=math.nan)
+    with pytest.raises(ValueError, match="dropout_rate must be a finite real number"):
+        yat_attention_weights(None, None, dropout_rate=1.0)
+
+
+def test_rate_boundaries_remain_supported():
+    MultiHeadYatAttention(2, 1, dropout=0.0)
+    MultiHeadYatAttention(2, 1, dropout=0.999999)
+
+
+@pytest.mark.parametrize(
+    "rate", [tf.constant(False), tf.constant("0.5"), tf.constant(0.5 + 0j)]
+)
+def test_non_real_tensors_are_not_accepted_as_rates(rate):
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(2, 1, dropout=rate)

--- a/tests/test_torch/test_validation.py
+++ b/tests/test_torch/test_validation.py
@@ -1,0 +1,72 @@
+"""PyTorch constructor and functional validation matrix."""
+
+import math
+
+import pytest
+import torch
+
+from nmn.torch import (
+    MultiHeadYatAttention,
+    YatConv1D,
+    YatConv2D,
+    YatConv3D,
+    YatConvTranspose1D,
+    YatConvTranspose2D,
+    YatConvTranspose3D,
+)
+from nmn.torch.attention import yat_attention_weights
+
+CONVS = [
+    (YatConv1D, 3),
+    (YatConv2D, (3, 3)),
+    (YatConv3D, (3, 3, 3)),
+    (YatConvTranspose1D, 3),
+    (YatConvTranspose2D, (3, 3)),
+    (YatConvTranspose3D, (3, 3, 3)),
+]
+INVALID_RATES = [math.nan, math.inf, -0.1, 1.0, 2.0]
+
+
+@pytest.mark.parametrize(("layer", "kernel_size"), CONVS)
+@pytest.mark.parametrize("rate", INVALID_RATES)
+def test_all_conv_families_reject_invalid_dropconnect(layer, kernel_size, rate):
+    with pytest.raises(ValueError, match="drop_rate must be a finite real number"):
+        layer(2, 2, kernel_size, drop_rate=rate)
+
+
+@pytest.mark.parametrize("rate", INVALID_RATES)
+def test_attention_rejects_invalid_dropout(rate):
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(8, 2, dropout=rate)
+    q = torch.zeros(1, 1, 1, 1)
+    with pytest.raises(ValueError, match="dropout_p must be a finite real number"):
+        yat_attention_weights(q, q, dropout_p=rate)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"embed_dim": 0, "num_heads": 1},
+        {"embed_dim": 8, "num_heads": 0},
+        {"embed_dim": 8, "num_heads": -2},
+    ],
+)
+def test_attention_dimensions_fail_before_modulo(kwargs):
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        MultiHeadYatAttention(**kwargs)
+
+
+def test_rate_boundaries_remain_supported():
+    YatConv1D(1, 1, 1, drop_rate=0.0)
+    MultiHeadYatAttention(2, 1, dropout=0.999999)
+
+
+def test_boolean_tensor_is_not_accepted_as_a_rate():
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(2, 1, dropout=torch.tensor(False))
+
+
+@pytest.mark.parametrize("rate", [torch.tensor(0.5 + 0j), torch.tensor(0.5 + 1j)])
+def test_complex_tensors_are_not_accepted_as_rates(rate):
+    with pytest.raises(ValueError, match="dropout must be a finite real number"):
+        MultiHeadYatAttention(2, 1, dropout=rate)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,49 @@
+"""Framework-independent scalar validation contract."""
+
+import math
+
+import numpy as np
+import pytest
+
+from nmn._validation import validate_positive_int, validate_rate
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        math.nan,
+        math.inf,
+        -math.inf,
+        -0.1,
+        1.0,
+        2.0,
+        True,
+        False,
+        "0.5",
+        b"0.5",
+        [0.5],
+        (0.5,),
+        np.array([0.5]),
+        np.array(False),
+        np.array("0.5"),
+        np.array(b"0.5"),
+        np.complex64(0.5 + 1j),
+        np.array(0.5 + 0j),
+    ],
+)
+def test_invalid_rates_have_one_diagnostic(value):
+    with pytest.raises(
+        ValueError, match=r"rate must be a finite real number in \[0, 1\)"
+    ):
+        validate_rate(value, "rate")
+
+
+@pytest.mark.parametrize("value", [0.0, 0.5, 0.999999, np.array(0.5)])
+def test_valid_rates_are_preserved(value):
+    assert validate_rate(value, "rate") == float(value)
+
+
+@pytest.mark.parametrize("value", [0, -1, 1.0, True, "1"])
+def test_positive_integer_contract(value):
+    with pytest.raises(ValueError, match="count must be a positive integer"):
+        validate_positive_int(value, "count")


### PR DESCRIPTION
Implements dacli task 075-validate-dropconnect-dropout-head-counts-and-scalar-configuration-consistently.

Refs #146

### Acceptance
- [x] All rate parameters reject NaN, infinity, negative values, 1, and values above 1 before allocation or RNG consumption.
- [x] Zero and values strictly below 1 remain supported.
- [x] `num_heads`, embedding dimensions, groups, and feature counts require positive integers before arithmetic.
- [x] All six convolution/transpose families and attention modules/functions have a cross-backend validation matrix with consistent `ValueError` diagnostics.
